### PR TITLE
Scale TreeViewAdv elements based on DPI

### DIFF
--- a/External/Aga.Controls/Tree/NodeControls/NodeCheckBox.cs
+++ b/External/Aga.Controls/Tree/NodeControls/NodeCheckBox.cs
@@ -46,7 +46,9 @@ namespace Aga.Controls.Tree.NodeControls
 
 		public override Size MeasureSize(TreeNodeAdv node, DrawContext context)
 		{
-			return new Size(ImageSize, ImageSize);
+			int scaledX = node.Tree.GetScaledSize(ImageSize, false);
+			int scaledY = node.Tree.GetScaledSize(ImageSize);
+			return new Size(scaledX, scaledY);
 		}
 
 		public override void Draw(TreeNodeAdv node, DrawContext context)
@@ -56,13 +58,15 @@ namespace Aga.Controls.Tree.NodeControls
 			if (Application.RenderWithVisualStyles)
 			{
 				VisualStyleRenderer renderer;
+				int scaledX = node.Tree.GetScaledSize(ImageSize, false);
+				int scaledY = node.Tree.GetScaledSize(ImageSize);
 				if (state == CheckState.Indeterminate)
 					renderer = new VisualStyleRenderer(VisualStyleElement.Button.CheckBox.MixedNormal);
 				else if (state == CheckState.Checked)
 					renderer = new VisualStyleRenderer(VisualStyleElement.Button.CheckBox.CheckedNormal);
 				else
 					renderer = new VisualStyleRenderer(VisualStyleElement.Button.CheckBox.UncheckedNormal);
-				renderer.DrawBackground(context.Graphics, new Rectangle(bounds.X, bounds.Y, ImageSize, ImageSize));
+				renderer.DrawBackground(context.Graphics, new Rectangle(bounds.X, bounds.Y, scaledX, scaledY));
 			}
 			else
 			{

--- a/External/Aga.Controls/Tree/NodeControls/NodeIcon.cs
+++ b/External/Aga.Controls/Tree/NodeControls/NodeIcon.cs
@@ -19,9 +19,15 @@ namespace Aga.Controls.Tree.NodeControls
 		{
 			Image image = GetIcon(node);
 			if (image != null)
-				return image.Size;
+			{
+				int scaledX = node.Tree.GetScaledSize(image.Size.Width, false);
+				int scaledY = node.Tree.GetScaledSize(image.Size.Height);
+				return new Size(scaledX, scaledY); ;
+			}
 			else
+			{
 				return Size.Empty;
+			}
 		}
 
 

--- a/External/Aga.Controls/Tree/NodeControls/NodePlusMinus.cs
+++ b/External/Aga.Controls/Tree/NodeControls/NodePlusMinus.cs
@@ -46,7 +46,9 @@ namespace Aga.Controls.Tree.NodeControls
 
 		public override Size MeasureSize(TreeNodeAdv node, DrawContext context)
 		{
-			return new Size(Width, Width);
+			int scaledX = node.Tree.GetScaledSize(Width, false);
+			int scaledY = node.Tree.GetScaledSize(Width);
+			return new Size(scaledX, scaledY);
 		}
 
 		public override void Draw(TreeNodeAdv node, DrawContext context)
@@ -54,7 +56,9 @@ namespace Aga.Controls.Tree.NodeControls
 			if (node.CanExpand)
 			{
 				Rectangle r = context.Bounds;
-				int dy = (int)Math.Round((float)(r.Height - ImageSize) / 2);
+				int scaledX = node.Tree.GetScaledSize(ImageSize, false);
+				int scaledY = node.Tree.GetScaledSize(ImageSize);
+				int dy = (int)Math.Round((float)(r.Height - scaledY) / 2);
 				if (Application.RenderWithVisualStyles)
 				{
 					VisualStyleRenderer renderer;
@@ -62,7 +66,7 @@ namespace Aga.Controls.Tree.NodeControls
 						renderer = OpenedRenderer;
 					else
 						renderer = ClosedRenderer;
-					renderer.DrawBackground(context.Graphics, new Rectangle(r.X, r.Y + dy, ImageSize, ImageSize));
+					renderer.DrawBackground(context.Graphics, new Rectangle(r.X, r.Y + dy, scaledX, scaledY));
 				}
 				else
 				{

--- a/External/Aga.Controls/Tree/TreeViewAdv.Draw.cs
+++ b/External/Aga.Controls/Tree/TreeViewAdv.Draw.cs
@@ -259,8 +259,9 @@ namespace Aga.Controls.Tree
 			while (curNode != _root && curNode != null)
 			{
 				int level = curNode.Level;
-				int x = (level - 1) * _indent + NodePlusMinus.ImageSize / 2 + LeftMargin;
-				int width = NodePlusMinus.Width - NodePlusMinus.ImageSize / 2;
+				int scaledIndent = node.Tree.GetScaledSize(_indent, false);
+				int x = (level - 1) * scaledIndent + NodePlusMinus.ImageSize / 2 + LeftMargin;
+				int width = node.Tree.GetScaledSize(NodePlusMinus.Width - NodePlusMinus.ImageSize / 2, false);
 				int y = rowRect.Y;
 				int y2 = y + rowRect.Height;
 


### PR DESCRIPTION
TreeViewAdv assumed a standard 96 DPI display. This commit fixes some
problems on high DPI displays, including some problems mentioned in
OHM issue 830.

- column header height
- checkboxes
- icons
- indentation

Tested on a 96 DPI display and on a 240 DPI display.