### PR TITLE
Tray Icons default to white color

### DIFF
--- a/GUI/SensorNotifyIcon.cs
+++ b/GUI/SensorNotifyIcon.cs
@@ -42,7 +42,7 @@ namespace OpenHardwareMonitor.GUI {
       this.sensor = sensor;
       this.notifyIcon = new NotifyIconAdv();
 
-      Color defaultColor = Color.Black;
+      Color defaultColor = Color.White;
       if (sensor.SensorType == SensorType.Load ||
           sensor.SensorType == SensorType.Control ||
           sensor.SensorType == SensorType.Level) 


### PR DESCRIPTION
As mentioned in #11, white makes more sense as the default color since the default color of modern Windows OS is black / dark