### PR TITLE
Fix 64bit detection, broken since 66e69c4c25ef2554b3ed44378dc5fc465ab…

### DIFF
--- a/Software/OperatingSystem.cs
+++ b/Software/OperatingSystem.cs
@@ -2,38 +2,36 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
-namespace OpenHardwareMonitor.Software
-{
-    public static class OperatingSystem
-    {
-        static OperatingSystem()
-        {
-            // The operating system doesn't change during execution so let's query it just one time.
-            var platform = Environment.OSVersion.Platform;
-            IsLinux = platform == PlatformID.Unix || platform == PlatformID.MacOSX;
+namespace OpenHardwareMonitor.Software {
+  public static class OperatingSystem {
+    static OperatingSystem() {
+      // The operating system doesn't change during execution so let's query it just one time.
+      var platform = Environment.OSVersion.Platform;
+      IsLinux = platform == PlatformID.Unix || platform == PlatformID.MacOSX;
 
 
-            if (IntPtr.Size == 8)
-                Is64Bit = true;
-
-            try
-            {
-                var result = IsWow64Process(Process.GetCurrentProcess().Handle, out bool wow64Process);
-
-                Is64Bit = result && wow64Process;
-            }
-            catch (EntryPointNotFoundException)
-            {
-                Is64Bit = false;
-            }
+      if (IntPtr.Size == 8) {
+        Is64Bit = true;
+      } else if (!IsLinux) {
+        try {
+          var result = IsWow64Process(Process.GetCurrentProcess().Handle, out bool wow64Process);
+          // If we are still here, this is a 64bit windows; 32bit windows does
+          // not provide IsWow64Process.
+          Is64Bit = true;
         }
-
-        public static bool Is64Bit { get; }
-
-        public static bool IsLinux { get; }
-
-        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool IsWow64Process(IntPtr hProcess, out bool wow64Process);
+        catch (EntryPointNotFoundException) {
+          // IsWow64Process is not present on 32 bit:
+          Is64Bit = false;
+        }
+      }
     }
+
+    public static bool Is64Bit { get; }
+
+    public static bool IsLinux { get; }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsWow64Process(IntPtr hProcess, out bool wow64Process);
+  }
 }


### PR DESCRIPTION
…47781.

This commit restores the previous logic of accepting an 8-byte intptr as evidence
enough for 64bit. It also accepts presence of IsWow64Process as evidence of 64bit.
On 64bit, this may return true or false depending on the process. On 32bit this entry
point is not available and an exception will be raised.