### PR TITLE
Bugfix - abandoned ISABus mutex deadlock

### DIFF
--- a/Hardware/Ring0.cs
+++ b/Hardware/Ring0.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -257,7 +257,7 @@ namespace OpenHardwareMonitor.Hardware {
         return true;
       try {
         return isaBusMutex.WaitOne(millisecondsTimeout, false);
-      } catch (AbandonedMutexException) { return false; } 
+      } catch (AbandonedMutexException) { return true; }
         catch (InvalidOperationException) { return false; }
     }
 


### PR DESCRIPTION
Mutexes might get abandoned, e.g. if the program is killed ungracefully while the mutex was held open.
-> Even if it was abandoned, we still got the lock, so operations can be continued.
(without this change, users can resolve the situation only by rebooting)