### PR TITLE
Fix NIC refresh logic when disabled

### DIFF
--- a/Hardware/Computer.cs
+++ b/Hardware/Computer.cs
@@ -401,15 +401,18 @@ namespace OpenHardwareMonitor.Hardware {
     }
 
     public void Traverse(IVisitor visitor) {
+      if (nicEnabled) {
+        int newNiccount = NetworkInterface.GetAllNetworkInterfaces().Length;
+        if (nicCount != newNiccount) {
+          nicCount = newNiccount;
+          NICEnabled = false;
+          NICEnabled = true;
+        }
+      }
+
       foreach (IGroup group in groups)
         foreach (IHardware hardware in group.Hardware) 
           hardware.Accept(visitor);
-          int newNiccount = NetworkInterface.GetAllNetworkInterfaces().Length;
-          if (nicCount != newNiccount) {
-            nicCount = newNiccount;
-            NICEnabled = false;
-            NICEnabled = true;
-          }
     }
 
     private class Settings : ISettings {


### PR DESCRIPTION
When nic was disabled, it was ignored as whenever the `Computer` was traversed it would become enabled. This PR fixes this logic (so if disabled, it will stay disabled). It also formats the code segment as the indentation was misleading (it made it seem like the NIC was enabled and disabled inside the loop)

Tested both scenarios (enable / disabled NIC) successfully.

Aside: enabling NIC sensor collection has caused somewhere around a 5x slowdown in time it takes to refresh values. I'll see if I can't dig deeper and see if there are low hanging fruit.

EDIT: Fixed the perf issues, I'll submit another PR once this one is merged.