### PR TITLE
Fix Network Hardware populating when disabled.

### DIFF
--- a/Hardware/Computer.cs
+++ b/Hardware/Computer.cs
@@ -401,15 +401,18 @@ namespace OpenHardwareMonitor.Hardware {
     }
 
     public void Traverse(IVisitor visitor) {
-      foreach (IGroup group in groups)
+      foreach (IGroup group in groups) {
         foreach (IHardware hardware in group.Hardware) 
           hardware.Accept(visitor);
-          int newNiccount = NetworkInterface.GetAllNetworkInterfaces().Length;
-          if (nicCount != newNiccount) {
-            nicCount = newNiccount;
-            NICEnabled = false;
-            NICEnabled = true;
-          }
+      }
+      if(NICEnabled) {
+        int newNiccount = NetworkInterface.GetAllNetworkInterfaces().Length;
+        if (nicCount != newNiccount) {
+          nicCount = newNiccount;
+          NICEnabled = false;
+          NICEnabled = true;
+        }
+      }
     }
 
     private class Settings : ISettings {


### PR DESCRIPTION
Added a check to make sure Network hardware is enabled before toggling `NICEnabled` in Traverse function.

Also fixed deceptive indentation, where code was indented and aligned with `foreach` loops but wasn't actually part of the code block since there are no brackets.

closes #62 