### PR TITLE
Performance improvements when NIC Enabled

### DIFF
--- a/Hardware/Computer.cs
+++ b/Hardware/Computer.cs
@@ -401,17 +401,8 @@ namespace OpenHardwareMonitor.Hardware {
     }
 
     public void Traverse(IVisitor visitor) {
-      if (nicEnabled) {
-        int newNiccount = NetworkInterface.GetAllNetworkInterfaces().Length;
-        if (nicCount != newNiccount) {
-          nicCount = newNiccount;
-          NICEnabled = false;
-          NICEnabled = true;
-        }
-      }
-
       foreach (IGroup group in groups)
-        foreach (IHardware hardware in group.Hardware) 
+        foreach (IHardware hardware in group.Hardware)
           hardware.Accept(visitor);
     }
 

--- a/Hardware/Nic/Nic.cs
+++ b/Hardware/Nic/Nic.cs
@@ -9,7 +9,6 @@
 */
 
 using System;
-using System.Diagnostics;
 using System.Globalization;
 using System.Net.NetworkInformation;
 
@@ -17,60 +16,38 @@ namespace OpenHardwareMonitor.Hardware.Nic
 {
     internal class Nic : Hardware
     {
-        private ISettings settings;
         private Sensor dataUploaded;
         private Sensor dataDownloaded;
         private Sensor uploadSpeed;
         private Sensor downloadSpeed;
         private Sensor networkUtilization;
-        private NetworkInterface networkInterface;
-        private int nicIndex;
         private DateTime latesTime;
-        private DateTime presentBootTime;
 
         private long bytesUploaded;
         private long bytesDownloaded;
-        private bool shouldTotalFlowUpdate = true;
 
-        public Nic(string name, ISettings Settings, int index, NicGroup nicGroup)
-          : base(name, new Identifier("NIC",index.ToString(CultureInfo.InvariantCulture)), Settings)
+        public Nic(NetworkInterface networkInterface, ISettings settings, int index)
+          : base(networkInterface.Name, new Identifier("NIC",index.ToString(CultureInfo.InvariantCulture)), settings)
         {
-            settings = Settings;
-            nicIndex = index;
-            networkInterface = nicGroup.NetworkInterfaces[index];
-            presentBootTime = DateTime.Now.AddMilliseconds(-(double)Environment.TickCount);
-            dataUploaded = new Sensor("Data Uploaded", 2, SensorType.Data, this,
-              settings);
+            NetworkInterface = networkInterface;
+            dataUploaded = new Sensor("Data Uploaded", 2, SensorType.Data, this, settings);
             ActivateSensor(dataUploaded);
-            dataDownloaded = new Sensor("Data Downloaded", 3, SensorType.Data, this,
-              settings);
+            dataDownloaded = new Sensor("Data Downloaded", 3, SensorType.Data, this, settings);
             ActivateSensor(dataDownloaded);
-            uploadSpeed = new Sensor("Upload Speed", 7, SensorType.Throughput, this,
-              settings);
+            uploadSpeed = new Sensor("Upload Speed", 7, SensorType.Throughput, this,  settings);
             ActivateSensor(uploadSpeed);
-            downloadSpeed = new Sensor("Download Speed", 8, SensorType.Throughput, this,
-              settings);
+            downloadSpeed = new Sensor("Download Speed", 8, SensorType.Throughput, this, settings);
             ActivateSensor(downloadSpeed);
-            networkUtilization = new Sensor("Network Utilization", 1, SensorType.Load, this,
-              settings);
+            networkUtilization = new Sensor("Network Utilization", 1, SensorType.Load, this,  settings);
             ActivateSensor(networkUtilization);
             bytesUploaded = NetworkInterface.GetIPStatistics().BytesSent;
             bytesDownloaded = NetworkInterface.GetIPStatistics().BytesReceived;
             latesTime = DateTime.Now;
         }
 
-        public override HardwareType HardwareType
-        {
-            get
-            {
-                return HardwareType.NIC;
-            }
-        }
+        public override HardwareType HardwareType => HardwareType.NIC;
 
-        internal NetworkInterface NetworkInterface
-        {
-            get { return networkInterface; }
-        }
+        internal NetworkInterface NetworkInterface { get; }
 
         public override void Update()
         {

--- a/Hardware/Nic/Nic.cs
+++ b/Hardware/Nic/Nic.cs
@@ -25,11 +25,12 @@ namespace OpenHardwareMonitor.Hardware.Nic
 
         private long bytesUploaded;
         private long bytesDownloaded;
+        private readonly NetworkInterface networkInterface;
 
         public Nic(NetworkInterface networkInterface, ISettings settings, int index)
           : base(networkInterface.Name, new Identifier("NIC",index.ToString(CultureInfo.InvariantCulture)), settings)
         {
-            NetworkInterface = networkInterface;
+            this.networkInterface = networkInterface;
             dataUploaded = new Sensor("Data Uploaded", 2, SensorType.Data, this, settings);
             ActivateSensor(dataUploaded);
             dataDownloaded = new Sensor("Data Downloaded", 3, SensorType.Data, this, settings);
@@ -45,9 +46,21 @@ namespace OpenHardwareMonitor.Hardware.Nic
             latesTime = DateTime.Now;
         }
 
-        public override HardwareType HardwareType => HardwareType.NIC;
+        public override HardwareType HardwareType
+        {
+            get
+            {
+                return HardwareType.NIC;
+            }
+        }
 
-        internal NetworkInterface NetworkInterface { get; }
+        internal NetworkInterface NetworkInterface
+        {
+            get
+            {
+                return networkInterface;
+            }
+        }
 
         public override void Update()
         {
@@ -59,7 +72,7 @@ namespace OpenHardwareMonitor.Hardware.Nic
             long dBytesDownloaded = interfaceStats.BytesReceived - bytesDownloaded;
             uploadSpeed.Value = (float)dBytesUploaded / dt;
             downloadSpeed.Value = (float)dBytesDownloaded / dt;
-            networkUtilization.Value = Clamp((float)Math.Max(dBytesUploaded, dBytesDownloaded) * 800 / NetworkInterface.Speed / dt, 0,100);
+            networkUtilization.Value = Clamp((float)Math.Max(dBytesUploaded, dBytesDownloaded) * 800 / NetworkInterface.Speed / dt, 0, 100);
             bytesUploaded = interfaceStats.BytesSent;
             bytesDownloaded = interfaceStats.BytesReceived;
             dataUploaded.Value = ((float)bytesUploaded / 1073741824);

--- a/Hardware/Nic/NicGroup.cs
+++ b/Hardware/Nic/NicGroup.cs
@@ -18,6 +18,7 @@ namespace OpenHardwareMonitor.Hardware.Nic
 
             ScanNics(settings);
             NetworkChange.NetworkAddressChanged += NetworkChange_NetworkAddressChanged; 
+            NetworkChange.NetworkAvailabilityChanged += NetworkChange_NetworkAddressChanged;
         }
 
         private void ScanNics(ISettings settings)

--- a/Hardware/Nic/NicGroup.cs
+++ b/Hardware/Nic/NicGroup.cs
@@ -13,9 +13,6 @@ namespace OpenHardwareMonitor.Hardware.Nic
         public NicGroup(ISettings settings)
         {
             _settings = settings;
-            if (Software.OperatingSystem.IsLinux)
-                return;
-
             ScanNics(settings);
             NetworkChange.NetworkAddressChanged += NetworkChange_NetworkAddressChanged; 
             NetworkChange.NetworkAvailabilityChanged += NetworkChange_NetworkAddressChanged;
@@ -70,13 +67,20 @@ namespace OpenHardwareMonitor.Hardware.Nic
             return report.ToString();
         }
 
-        public IEnumerable<IHardware> Hardware => _hardware;
+        public IEnumerable<IHardware> Hardware
+        {
+            get
+            {
+                return _hardware;
+            }
+        }
 
         public NetworkInterface[] NetworkInterfaces { get; set; }
 
         public void Close()
         {
             NetworkChange.NetworkAddressChanged -= NetworkChange_NetworkAddressChanged;
+            NetworkChange.NetworkAvailabilityChanged -= NetworkChange_NetworkAddressChanged;
             foreach (var nic in _hardware)
                 nic.Close();
         }

--- a/Hardware/Nic/NicGroup.cs
+++ b/Hardware/Nic/NicGroup.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Net.NetworkInformation;
 using System.Text;
 
@@ -7,28 +7,43 @@ namespace OpenHardwareMonitor.Hardware.Nic
 {
     internal class NicGroup : IGroup
     {
-
-        private List<Hardware> hardware = new List<Hardware>();
-        private NetworkInterface[] _networkInterfaces;
+        private readonly ISettings _settings;
+        private List<Nic> _hardware = new List<Nic>();
 
         public NicGroup(ISettings settings)
         {
-            int p = (int)Environment.OSVersion.Platform;
-            if ((p == 4) || (p == 128))
-            {
-                hardware = new List<Hardware>();
+            _settings = settings;
+            if (Software.OperatingSystem.IsLinux)
                 return;
-            }
-            _networkInterfaces = NetworkInterface.GetAllNetworkInterfaces();
-            for (int i = 0; i < _networkInterfaces.Length; i++)
+
+            ScanNics(settings);
+            NetworkChange.NetworkAddressChanged += NetworkChange_NetworkAddressChanged; 
+        }
+
+        private void ScanNics(ISettings settings)
+        {
+            NetworkInterfaces = NetworkInterface.GetAllNetworkInterfaces();
+            _hardware = NetworkInterfaces.Where(DesiredNetworkType)
+                .Select((x, i) => new Nic(x, settings, i))
+                .ToList();
+        }
+
+        private void NetworkChange_NetworkAddressChanged(object sender, System.EventArgs e)
+        {
+            ScanNics(_settings);
+        }
+
+        private static bool DesiredNetworkType(NetworkInterface nic)
+        {
+            switch (nic.NetworkInterfaceType)
             {
-                if (_networkInterfaces[i].NetworkInterfaceType != NetworkInterfaceType.Unknown && _networkInterfaces[i].NetworkInterfaceType != NetworkInterfaceType.Loopback && _networkInterfaces[i].NetworkInterfaceType != NetworkInterfaceType.Tunnel)
-                {
-                    hardware.Add(new Nic(_networkInterfaces[i].Name, settings, i, this));
-                }
-                
+                case NetworkInterfaceType.Loopback:
+                case NetworkInterfaceType.Tunnel:
+                case NetworkInterfaceType.Unknown:
+                    return false;
+                default:
+                    return true;
             }
-                
         }
 
         public string GetReport()
@@ -38,7 +53,7 @@ namespace OpenHardwareMonitor.Hardware.Nic
 
             var report = new StringBuilder();
 
-            foreach (Nic hw in hardware)
+            foreach (Nic hw in _hardware)
             {
                 report.AppendLine(hw.NetworkInterface.Description);
                 report.AppendLine(hw.NetworkInterface.OperationalStatus.ToString());
@@ -54,21 +69,14 @@ namespace OpenHardwareMonitor.Hardware.Nic
             return report.ToString();
         }
 
-    public IEnumerable<IHardware> Hardware => hardware;
-    public NetworkInterface[] NetworkInterfaces
-        {
-            get
-            {
-                return _networkInterfaces;
-            }
-            set
-            {
-                _networkInterfaces = value;
-            }
-        }
+        public IEnumerable<IHardware> Hardware => _hardware;
+
+        public NetworkInterface[] NetworkInterfaces { get; set; }
+
         public void Close()
         {
-            foreach (Hardware nic in hardware)
+            NetworkChange.NetworkAddressChanged -= NetworkChange_NetworkAddressChanged;
+            foreach (var nic in _hardware)
                 nic.Close();
         }
     }


### PR DESCRIPTION
Gathering all the network interfaces can be expensive:

```
NetworkInterface.GetAllNetworkInterfaces()
```

That expression can take around 100ms on my machine. Thus calling it every
interval can lead to some noticeable delays. The fix is to hook into an
event that is only called when an interface changes, and then we'd refresh
the internal list.

The NetworkChange.NetworkAddressChanged event caters to our needs.

Switching to this event eliminated the performance degradation (except on
startup and when an interface changes -- but we have to pay the price
somewhere).

Also the logic for detecting a change in interfaces was flawed as one
could create and destroy a virtual NIC in the interval number of seconds
and the previous logic wouldn't detect a change (as the total number of
interfaces wouldn't change).