### PR TITLE
CPU idle C-States (Intel & AMD 10-16) / CPU & Northbridge voltages (AMD 10-16) / Fixes for AMD 10-16 temperatures

### DIFF
--- a/Hardware/CPU/AMD10CPU.cs
+++ b/Hardware/CPU/AMD10CPU.cs
@@ -186,7 +186,7 @@ namespace OpenHardwareMonitor.Hardware.CPU {
 
         if(dev == 0x43851002)
           cStatesIoOffset = (byte)((rev & 0xFF) < 0x40 ? 0xB3 : 0x9C);
-        else if(dev == 0x780B1022)
+        else if(dev == 0x780B1022 || dev == 0x790B1022)
           cStatesIoOffset = (byte)0x9C;
       }
       if(cStatesIoOffset != 0) {

--- a/Hardware/CPU/AMD10CPU.cs
+++ b/Hardware/CPU/AMD10CPU.cs
@@ -21,7 +21,7 @@ namespace OpenHardwareMonitor.Hardware.CPU {
   internal sealed class AMD10CPU : AMDCPU {
 
     private readonly Sensor coreTemperature;
-    private readonly Sensor[] coreClocks;    
+    private readonly Sensor[] coreClocks;
     private readonly Sensor busClock;
     private readonly Sensor[] cStatesResidency;
     private readonly Sensor coreVoltage;
@@ -443,8 +443,6 @@ namespace OpenHardwareMonitor.Hardware.CPU {
         }
       }
     }
-
-    private static float NewMethod(uint vid70) => vid70 < 0b1111_1000 ? 1.5500f - 0.00625f * vid70 : 0;
 
     public override void Close() {      
       if (temperatureStream != null) {


### PR DESCRIPTION
I've added support for CPU idle C-States residency counters (both AMD [except Ryzen] / Intel). 
It hope it works ok, I used the official OEM docs... I can only test it for a half dozen of PCs.
I tried to use the same code style whenever possible, let me know if you need changes.
Thanks for reviving OHM!