### PR TITLE
Removal of ValueTuple reference.

### DIFF
--- a/OpenHardwareMonitorLib.csproj
+++ b/OpenHardwareMonitorLib.csproj
@@ -136,6 +136,5 @@
   <ItemGroup>
     <PackageReference Include="hidlibrary" Version="3.2.46" />
     <PackageReference Include="System.Management" Version="4.5.0-preview1-25914-04" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
It turned out that usage of ValueTuple can be avoided by using GroupBy instead of separate list of  ValueTuple to track uniqueness by SensorType and SensorChannel.

Also, IMHO the whole for-each loop looks better as series of LINQ queries.