### PR TITLE
Added support for Nuvoton NCT6798D

### DIFF
--- a/Hardware/LPC/Chip.cs
+++ b/Hardware/LPC/Chip.cs
@@ -50,6 +50,7 @@ namespace OpenHardwareMonitor.Hardware.LPC {
     NCT6793D = 0xD121,
     NCT6795D = 0xD352,
     NCT6796D = 0xD423,
+    NCT6798D = 0xD42B,
 
     W83627DHG = 0xA020,
     W83627DHGP = 0xB070,
@@ -105,6 +106,7 @@ namespace OpenHardwareMonitor.Hardware.LPC {
         case Chip.NCT6793D: return "Nuvoton NCT6793D";
         case Chip.NCT6795D: return "Nuvoton NCT6795D";
         case Chip.NCT6796D: return "Nuvoton NCT6796D";
+        case Chip.NCT6798D: return "Nuvoton NCT6798D";
 
         case Chip.W83627DHG: return "Winbond W83627DHG";
         case Chip.W83627DHGP: return "Winbond W83627DHG-P";

--- a/Hardware/LPC/LMSensors.cs
+++ b/Hardware/LPC/LMSensors.cs
@@ -83,6 +83,8 @@ namespace OpenHardwareMonitor.Hardware.LPC {
               lmChips.Add(new LMChip(Chip.NCT6795D, path)); break;
             case "nct6796":
               lmChips.Add(new LMChip(Chip.NCT6796D, path)); break;
+            case "nct6798":
+              lmChips.Add(new LMChip(Chip.NCT6798D, path)); break;
 
             case "w83627ehf":
               lmChips.Add(new LMChip(Chip.W83627EHF, path)); break;

--- a/Hardware/LPC/LPCIO.cs
+++ b/Hardware/LPC/LPCIO.cs
@@ -243,6 +243,10 @@ namespace OpenHardwareMonitor.Hardware.LPC {
               chip = Chip.NCT6796D;
               logicalDeviceNumber = WINBOND_NUVOTON_HARDWARE_MONITOR_LDN;
               break;
+            case 0x2B:
+              chip = Chip.NCT6798D;
+              logicalDeviceNumber = WINBOND_NUVOTON_HARDWARE_MONITOR_LDN;
+              break;
           } break;
       }
       if (chip == Chip.Unknown) {
@@ -262,7 +266,7 @@ namespace OpenHardwareMonitor.Hardware.LPC {
         ushort vendorID = port.ReadWord(FINTEK_VENDOR_ID_REGISTER);
                 
         // disable the hardware monitor i/o space lock on NCT679*D chips
-        if (address == verify && (chip == Chip.NCT6791D || chip == Chip.NCT6796D || chip == Chip.NCT6793D || chip == Chip.NCT6795D)) {
+        if (address == verify && (chip == Chip.NCT6791D || chip == Chip.NCT6796D || chip == Chip.NCT6793D || chip == Chip.NCT6795D || chip == Chip.NCT6798D)) {
           port.NuvotonDisableIOSpaceLock();
         }
 
@@ -315,7 +319,8 @@ namespace OpenHardwareMonitor.Hardware.LPC {
           case Chip.NCT6792D:
           case Chip.NCT6793D:
           case Chip.NCT6795D:
-          case Chip.NCT6796D:          
+          case Chip.NCT6796D:
+          case Chip.NCT6798D:
             superIOs.Add(new NCT677X(chip, revision, address, port));
             break;
           case Chip.F71858:

--- a/Hardware/LPC/NCT677X.cs
+++ b/Hardware/LPC/NCT677X.cs
@@ -276,6 +276,7 @@ namespace OpenHardwareMonitor.Hardware.LPC {
         case Chip.NCT6793D:
         case Chip.NCT6795D:
         case Chip.NCT6796D:
+        case Chip.NCT6798D:
           if (chip == Chip.NCT6779D) {
             fans = new float?[5];
             controls = new float?[5];
@@ -418,7 +419,7 @@ namespace OpenHardwareMonitor.Hardware.LPC {
     public float?[] Controls { get { return controls; } }
 
     private void DisableIOSpaceLock() {
-      if (chip != Chip.NCT6791D && chip != Chip.NCT6796D && chip != Chip.NCT6793D && chip != Chip.NCT6795D)
+      if (chip != Chip.NCT6791D && chip != Chip.NCT6796D && chip != Chip.NCT6793D && chip != Chip.NCT6795D && chip != Chip.NCT6798D)
         return;
 
       // the lock is disabled already if the vendor ID can be read

--- a/Hardware/Mainboard/SuperIOHardware.cs
+++ b/Hardware/Mainboard/SuperIOHardware.cs
@@ -272,6 +272,7 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
         case Chip.NCT6793D:
         case Chip.NCT6795D:
         case Chip.NCT6796D:
+        case Chip.NCT6798D:
           GetNuvotonConfigurationD(superIO, manufacturer, model, v, t, f, c);
           break;
         default:


### PR DESCRIPTION
Tested on ASUS MAXIMUS XI HERO:

Sensors

|
+- ASUS ROG MAXIMUS XI HERO (/mainboard)
|  |
|  +- Nuvoton NCT6798D (/lpc/nct6798d)
|  |  +- CPU VCore      :    0.904    0.704    1.032 (/lpc/nct6798d/voltage/0)
|  |  +- Voltage #2     :        1    0.992        1 (/lpc/nct6798d/voltage/1)
|  |  +- AVCC           :     3.36     3.36     3.36 (/lpc/nct6798d/voltage/2)
|  |  +- 3VCC           :    3.296    3.296    3.312 (/lpc/nct6798d/voltage/3)
|  |  +- Voltage #5     :    1.728    1.728    1.728 (/lpc/nct6798d/voltage/4)
|  |  +- Voltage #6     :    0.208    0.208    0.208 (/lpc/nct6798d/voltage/5)
|  |  +- 3VSB           :     3.36    3.344     3.36 (/lpc/nct6798d/voltage/7)
|  |  +- VBAT           :    3.168    3.168    3.168 (/lpc/nct6798d/voltage/8)
|  |  +- VTT            :    0.528    0.528    0.528 (/lpc/nct6798d/voltage/9)
|  |  +- Voltage #11    :    0.536    0.536    0.536 (/lpc/nct6798d/voltage/10)
|  |  +- Voltage #12    :    0.568    0.568    0.568 (/lpc/nct6798d/voltage/11)
|  |  +- Voltage #13    :    1.064    1.056    1.064 (/lpc/nct6798d/voltage/12)
|  |  +- Voltage #14    :    0.608    0.608    0.608 (/lpc/nct6798d/voltage/13)
|  |  +- Voltage #15    :      0.6      0.6      0.6 (/lpc/nct6798d/voltage/14)
|  |  +- Temperature #1 :     30.5       30     30.5 (/lpc/nct6798d/temperature/1)
|  |  +- Temperature #2 :       26       26       26 (/lpc/nct6798d/temperature/2)
|  |  +- Temperature #4 :       21       21       22 (/lpc/nct6798d/temperature/4)
|  |  +- Temperature #5 :       18       18       18 (/lpc/nct6798d/temperature/5)
|  |  +- Temperature #6 :       49       49       50 (/lpc/nct6798d/temperature/6)
|  |  +- Fan #1         :      479      479      662 (/lpc/nct6798d/fan/0)
|  |  +- Fan #2         :      263      263      362 (/lpc/nct6798d/fan/1)
|  |  +- Fan #3         :      500      500      661 (/lpc/nct6798d/fan/2)
|  |  +- Fan #4         :      493      493      638 (/lpc/nct6798d/fan/3)
|  |  +- Fan Control #1 :  28.6275  25.8824  35.6863 (/lpc/nct6798d/control/0)
|  |  +- Fan Control #2 :  28.6275  25.8824  35.6863 (/lpc/nct6798d/control/1)
|  |  +- Fan Control #3 :  28.6275  25.8824  35.6863 (/lpc/nct6798d/control/2)
|  |  +- Fan Control #4 :  28.6275  25.8824  35.6863 (/lpc/nct6798d/control/3)
|  |  +- Fan Control #5 :       60       60   65.098 (/lpc/nct6798d/control/4)
|  |  +- Fan Control #6 :      100      100      100 (/lpc/nct6798d/control/5)