### PR TITLE
Added support for Nuvoton NCT6797D

### DIFF
--- a/Hardware/LPC/Chip.cs
+++ b/Hardware/LPC/Chip.cs
@@ -50,6 +50,7 @@ namespace OpenHardwareMonitor.Hardware.LPC {
     NCT6793D = 0xD121,
     NCT6795D = 0xD352,
     NCT6796D = 0xD423,
+    NCT6797D = 0xD451,
     NCT6798D = 0xD42B,
 
     W83627DHG = 0xA020,
@@ -106,6 +107,7 @@ namespace OpenHardwareMonitor.Hardware.LPC {
         case Chip.NCT6793D: return "Nuvoton NCT6793D";
         case Chip.NCT6795D: return "Nuvoton NCT6795D";
         case Chip.NCT6796D: return "Nuvoton NCT6796D";
+        case Chip.NCT6797D: return "Nuvoton NCT6797D";
         case Chip.NCT6798D: return "Nuvoton NCT6798D";
 
         case Chip.W83627DHG: return "Winbond W83627DHG";

--- a/Hardware/LPC/LMSensors.cs
+++ b/Hardware/LPC/LMSensors.cs
@@ -83,6 +83,8 @@ namespace OpenHardwareMonitor.Hardware.LPC {
               lmChips.Add(new LMChip(Chip.NCT6795D, path)); break;
             case "nct6796":
               lmChips.Add(new LMChip(Chip.NCT6796D, path)); break;
+            case "nct6797":
+              lmChips.Add(new LMChip(Chip.NCT6797D, path)); break;
             case "nct6798":
               lmChips.Add(new LMChip(Chip.NCT6798D, path)); break;
 

--- a/Hardware/LPC/LPCIO.cs
+++ b/Hardware/LPC/LPCIO.cs
@@ -243,6 +243,10 @@ namespace OpenHardwareMonitor.Hardware.LPC {
               chip = Chip.NCT6796D;
               logicalDeviceNumber = WINBOND_NUVOTON_HARDWARE_MONITOR_LDN;
               break;
+            case 0x51:
+              chip = Chip.NCT6797D;
+              logicalDeviceNumber = WINBOND_NUVOTON_HARDWARE_MONITOR_LDN;
+              break;
             case 0x2B:
               chip = Chip.NCT6798D;
               logicalDeviceNumber = WINBOND_NUVOTON_HARDWARE_MONITOR_LDN;
@@ -266,7 +270,7 @@ namespace OpenHardwareMonitor.Hardware.LPC {
         ushort vendorID = port.ReadWord(FINTEK_VENDOR_ID_REGISTER);
                 
         // disable the hardware monitor i/o space lock on NCT679*D chips
-        if (address == verify && (chip == Chip.NCT6791D || chip == Chip.NCT6796D || chip == Chip.NCT6793D || chip == Chip.NCT6795D || chip == Chip.NCT6798D)) {
+        if (address == verify && (chip == Chip.NCT6791D || chip == Chip.NCT6796D || chip == Chip.NCT6793D || chip == Chip.NCT6795D || chip == Chip.NCT6798D || chip == Chip.NCT6797D)) {
           port.NuvotonDisableIOSpaceLock();
         }
 
@@ -320,6 +324,7 @@ namespace OpenHardwareMonitor.Hardware.LPC {
           case Chip.NCT6793D:
           case Chip.NCT6795D:
           case Chip.NCT6796D:
+          case Chip.NCT6797D:
           case Chip.NCT6798D:
             superIOs.Add(new NCT677X(chip, revision, address, port));
             break;

--- a/Hardware/LPC/NCT677X.cs
+++ b/Hardware/LPC/NCT677X.cs
@@ -276,6 +276,7 @@ namespace OpenHardwareMonitor.Hardware.LPC {
         case Chip.NCT6793D:
         case Chip.NCT6795D:
         case Chip.NCT6796D:
+        case Chip.NCT6797D:
         case Chip.NCT6798D:
           if (chip == Chip.NCT6779D) {
             fans = new float?[5];
@@ -419,7 +420,7 @@ namespace OpenHardwareMonitor.Hardware.LPC {
     public float?[] Controls { get { return controls; } }
 
     private void DisableIOSpaceLock() {
-      if (chip != Chip.NCT6791D && chip != Chip.NCT6796D && chip != Chip.NCT6793D && chip != Chip.NCT6795D && chip != Chip.NCT6798D)
+      if (chip != Chip.NCT6791D && chip != Chip.NCT6796D && chip != Chip.NCT6793D && chip != Chip.NCT6795D && chip != Chip.NCT6798D && chip != Chip.NCT6797D)
         return;
 
       // the lock is disabled already if the vendor ID can be read

--- a/Hardware/Mainboard/SuperIOHardware.cs
+++ b/Hardware/Mainboard/SuperIOHardware.cs
@@ -272,6 +272,7 @@ namespace OpenHardwareMonitor.Hardware.Mainboard {
         case Chip.NCT6793D:
         case Chip.NCT6795D:
         case Chip.NCT6796D:
+        case Chip.NCT6797D:
         case Chip.NCT6798D:
           GetNuvotonConfigurationD(superIO, manufacturer, model, v, t, f, c);
           break;


### PR DESCRIPTION
This will add hardware sensors for following MSI mainboards:

- B360-A PRO (MS-7B22)
- B360M PRO-VDH (MS-7B24)
- B450 TOMAHAWK (MS-7C02)
- H310M PRO-D (MS-7B33)
- MAG Z390 TOMAHAWK (MS-7B18)
- MEG Z390 ACE (MS-7B12)
- MPG Z390 GAMING PRO CARBON (MS-7B17)
- Z390-A PRO (MS-7B98)

and possibly much more.

Tested with Z390-A PRO and B450 TOMAHAWK.