### PR TITLE
Fix 'PInvokeStackImbalance' in NVAPI.cs

### DIFF
--- a/Hardware/Nvidia/NVAPI.cs
+++ b/Hardware/Nvidia/NVAPI.cs
@@ -236,48 +236,83 @@ namespace OpenHardwareMonitor.Hardware.Nvidia {
     public static readonly uint GPU_COOLER_LEVELS_VER = (uint)
       Marshal.SizeOf(typeof(NvGPUCoolerLevels)) | 0x10000;
 
-    private delegate IntPtr nvapi_QueryInterfaceDelegate(uint id);
-    private delegate NvStatus NvAPI_InitializeDelegate();
-    private delegate NvStatus NvAPI_GPU_GetFullNameDelegate(
-      NvPhysicalGpuHandle gpuHandle, StringBuilder name);
+     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+     private delegate IntPtr nvapi_QueryInterfaceDelegate(uint id);
 
-    public delegate NvStatus NvAPI_GPU_GetThermalSettingsDelegate(
-      NvPhysicalGpuHandle gpuHandle, int sensorIndex,
-      ref NvGPUThermalSettings nvGPUThermalSettings);
-    public delegate NvStatus NvAPI_EnumNvidiaDisplayHandleDelegate(int thisEnum,
-      ref NvDisplayHandle displayHandle);
-    public delegate NvStatus NvAPI_GetPhysicalGPUsFromDisplayDelegate(
-      NvDisplayHandle displayHandle, [Out] NvPhysicalGpuHandle[] gpuHandles,
-      out uint gpuCount);
-    public delegate NvStatus NvAPI_EnumPhysicalGPUsDelegate(
-      [Out] NvPhysicalGpuHandle[] gpuHandles, out int gpuCount);
-    public delegate NvStatus NvAPI_GPU_GetTachReadingDelegate(
-      NvPhysicalGpuHandle gpuHandle, out int value);
-    public delegate NvStatus NvAPI_GPU_GetAllClocksDelegate(
-      NvPhysicalGpuHandle gpuHandle, ref NvClocks nvClocks);
-    public delegate NvStatus NvAPI_GPU_GetPStatesDelegate(
-      NvPhysicalGpuHandle gpuHandle, ref NvPStates nvPStates);
-    public delegate NvStatus NvAPI_GPU_GetUsagesDelegate(
-      NvPhysicalGpuHandle gpuHandle, ref NvUsages nvUsages);
-    public delegate NvStatus NvAPI_GPU_GetCoolerSettingsDelegate(
-      NvPhysicalGpuHandle gpuHandle, int coolerIndex,
-      ref NvGPUCoolerSettings nvGPUCoolerSettings);
-    public delegate NvStatus NvAPI_GPU_SetCoolerLevelsDelegate(
-      NvPhysicalGpuHandle gpuHandle, int coolerIndex,
-      ref NvGPUCoolerLevels NvGPUCoolerLevels);
-    public delegate NvStatus NvAPI_GPU_GetMemoryInfoDelegate(
-      NvDisplayHandle displayHandle, ref NvMemoryInfo nvMemoryInfo);
-    public delegate NvStatus NvAPI_GetDisplayDriverVersionDelegate(
-      NvDisplayHandle displayHandle, [In, Out] ref NvDisplayDriverVersion
-      nvDisplayDriverVersion);
-    public delegate NvStatus NvAPI_GetInterfaceVersionStringDelegate(
-      StringBuilder version);
-    public delegate NvStatus NvAPI_GPU_GetPCIIdentifiersDelegate(
-      NvPhysicalGpuHandle gpuHandle, out uint deviceId, out uint subSystemId, 
-      out uint revisionId, out uint extDeviceId);
+     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+     private delegate NvStatus NvAPI_InitializeDelegate();
 
-    private static readonly bool available;
-    [DllImport(@"nvapi.dll", EntryPoint = @"nvapi_QueryInterface", CallingConvention = CallingConvention.Cdecl, PreserveSig = true)]    private static extern IntPtr NvAPI32_QueryInterface(uint interfaceId);    [DllImport(@"nvapi64.dll", EntryPoint = @"nvapi_QueryInterface", CallingConvention = CallingConvention.Cdecl, PreserveSig = true)]    private static extern IntPtr NvAPI64_QueryInterface(uint interfaceId);
+     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+     private delegate NvStatus NvAPI_GPU_GetFullNameDelegate(
+       NvPhysicalGpuHandle gpuHandle, StringBuilder name);
+
+     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+     public delegate NvStatus NvAPI_GPU_GetThermalSettingsDelegate(
+       NvPhysicalGpuHandle gpuHandle, int sensorIndex,
+       ref NvGPUThermalSettings nvGPUThermalSettings);
+
+     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+     public delegate NvStatus NvAPI_EnumNvidiaDisplayHandleDelegate(int thisEnum,
+       ref NvDisplayHandle displayHandle);
+
+     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+     public delegate NvStatus NvAPI_GetPhysicalGPUsFromDisplayDelegate(
+       NvDisplayHandle displayHandle, [Out] NvPhysicalGpuHandle[] gpuHandles,
+       out uint gpuCount);
+
+     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+     public delegate NvStatus NvAPI_EnumPhysicalGPUsDelegate(
+       [Out] NvPhysicalGpuHandle[] gpuHandles, out int gpuCount);
+
+     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+     public delegate NvStatus NvAPI_GPU_GetTachReadingDelegate(
+       NvPhysicalGpuHandle gpuHandle, out int value);
+
+     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+     public delegate NvStatus NvAPI_GPU_GetAllClocksDelegate(
+       NvPhysicalGpuHandle gpuHandle, ref NvClocks nvClocks);
+
+     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+     public delegate NvStatus NvAPI_GPU_GetPStatesDelegate(
+       NvPhysicalGpuHandle gpuHandle, ref NvPStates nvPStates);
+
+     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+     public delegate NvStatus NvAPI_GPU_GetUsagesDelegate(
+       NvPhysicalGpuHandle gpuHandle, ref NvUsages nvUsages);
+
+     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+     public delegate NvStatus NvAPI_GPU_GetCoolerSettingsDelegate(
+       NvPhysicalGpuHandle gpuHandle, int coolerIndex,
+       ref NvGPUCoolerSettings nvGPUCoolerSettings);
+
+     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+     public delegate NvStatus NvAPI_GPU_SetCoolerLevelsDelegate(
+       NvPhysicalGpuHandle gpuHandle, int coolerIndex,
+       ref NvGPUCoolerLevels NvGPUCoolerLevels);
+
+     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+     public delegate NvStatus NvAPI_GPU_GetMemoryInfoDelegate(
+       NvDisplayHandle displayHandle, ref NvMemoryInfo nvMemoryInfo);
+
+     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+     public delegate NvStatus NvAPI_GetDisplayDriverVersionDelegate(
+       NvDisplayHandle displayHandle, [In, Out] ref NvDisplayDriverVersion
+       nvDisplayDriverVersion);
+
+     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+     public delegate NvStatus NvAPI_GetInterfaceVersionStringDelegate(
+       StringBuilder version);
+
+     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+     public delegate NvStatus NvAPI_GPU_GetPCIIdentifiersDelegate(
+       NvPhysicalGpuHandle gpuHandle, out uint deviceId, out uint subSystemId,
+       out uint revisionId, out uint extDeviceId);
+
+        private static readonly bool available;
+    [DllImport(@"nvapi.dll", EntryPoint = @"nvapi_QueryInterface", CallingConvention = CallingConvention.Cdecl, PreserveSig = true)]
+    private static extern IntPtr NvAPI32_QueryInterface(uint interfaceId);
+    [DllImport(@"nvapi64.dll", EntryPoint = @"nvapi_QueryInterface", CallingConvention = CallingConvention.Cdecl, PreserveSig = true)]
+    private static extern IntPtr NvAPI64_QueryInterface(uint interfaceId);
     private static readonly NvAPI_InitializeDelegate NvAPI_Initialize;
     private static readonly NvAPI_GPU_GetFullNameDelegate
       _NvAPI_GPU_GetFullName;


### PR DESCRIPTION
My problem: [Here](https://stackoverflow.com/questions/54962553/how-to-use-libre-hardware-monitor-library-to-read-gpu-sensors) with my question and my answer :innocent:  
Other people with the same problem: [Here](https://stackoverflow.com/questions/39202455/calling-unmanaged-code-from-c-sharp/39203588)