### PR TITLE
Cleanup warnings

### DIFF
--- a/External/Aga.Controls/Aga.Controls.csproj
+++ b/External/Aga.Controls/Aga.Controls.csproj
@@ -55,7 +55,7 @@
     <CodeAnalysisRules>
     </CodeAnalysisRules>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CodeAnalysisRuleSet>Migrated rules for Aga.Controls.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/External/Aga.Controls/Properties/AssemblyInfo.cs
+++ b/External/Aga.Controls/Properties/AssemblyInfo.cs
@@ -6,7 +6,6 @@ using System.Security.Permissions;
 
 [assembly: ComVisible(false)]
 [assembly: CLSCompliant(false)]
-[assembly: SecurityPermission(SecurityAction.RequestMinimum, Execution = true)]
 
 [assembly: AssemblyTitle("Aga.Controls")]
 [assembly: AssemblyCopyright("Copyright © Andrey Gliznetsov 2006 - 2009")]

--- a/Hardware/HDD/SmartNames.cs
+++ b/Hardware/HDD/SmartNames.cs
@@ -163,10 +163,6 @@ namespace OpenHardwareMonitor.Hardware.HDD {
       get { return "Load/Unload Retry Count"; }
     }
 
-    public static string MediaWearoutIndicator {
-      get { return "Media Wearout Indicator"; }
-    }
-
     public static string MultiZoneErrorRate {
       get { return "Multi-Zone Error Rate"; }
     }

--- a/OpenHardwareMonitorLib.csproj
+++ b/OpenHardwareMonitorLib.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
@@ -14,11 +14,15 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Authors>Libre Hardware Monitor contributors, Michael Möller</Authors>
     <PackageId>LibreHardwareMonitorLib</PackageId>
-    <PackageLicenseUrl>https://github.com/LibreHardwareMonitor/LibreHardwareMonitor</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/LibreHardwareMonitor/LibreHardwareMonitor</PackageProjectUrl>
     <PackageTags>libre open hardware monitor monitoring system logging cpu gpu</PackageTags>
     <RepositoryUrl>https://github.com/LibreHardwareMonitor/LibreHardwareMonitor</RepositoryUrl>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="LICENSE" Pack="true" Visible="false" PackagePath=""/>
+  </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />

--- a/Properties/AssemblyLibInfo.cs
+++ b/Properties/AssemblyLibInfo.cs
@@ -23,6 +23,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 
 [assembly: ComVisible(false)]
-[assembly: CLSCompliant(true)]
 
 


### PR DESCRIPTION
* Fixes CS3001/CS3003/CS3005 warnings caused by OpenHardwareMonitorLib project being marked as CLSCompliant
* Fixes NU5125 by using `PackageLicenseFile` and inlcuding the LICENSE file into the package, but this could also be fixed with `PackageLicenseExpression`
* Fixes CS0618, SecurityAction.RequestMinimum is obsolete in .Net 4.0
* Fixes `CodeAnalysisRuleSet` in Debug configuration pointing to missing rule set

Cleans almost all of the warnings, the only one left is NU1701 - we are using hidlibrary that targets .net 4.6.1 when we also target .netstandard2.0, which might not be fully compatible. 

TBH the whole hidlibrary dependency should be removed since it is only used for one device: AquastreamXT. Or maybe we should split all HID/USB stuff to a different project.