### PR TITLE
Add SMBIOS BIOS Date + Size

### DIFF
--- a/Hardware/SMBIOS.cs
+++ b/Hardware/SMBIOS.cs
@@ -63,7 +63,8 @@ namespace OpenHardwareMonitor.Hardware {
 
         string biosVendor = ReadSysFS("/sys/class/dmi/id/bios_vendor");
         string biosVersion = ReadSysFS("/sys/class/dmi/id/bios_version");
-        this.biosInformation = new BIOSInformation(biosVendor, biosVersion);
+        string biosDate = ReadSysFS("/sys/class/dmi/id/bios_date");
+        this.biosInformation = new BIOSInformation(biosVendor, biosVersion, biosDate);
 
         this.memoryDevices = new MemoryDevice[0];
       } else {              
@@ -161,6 +162,16 @@ namespace OpenHardwareMonitor.Hardware {
       if (BIOS != null) {
         r.Append("BIOS Vendor: "); r.AppendLine(BIOS.Vendor);
         r.Append("BIOS Version: "); r.AppendLine(BIOS.Version);
+        if (BIOS.Date != null) {
+            r.Append("BIOS Date: "); r.AppendLine(BIOS.Date.Value.ToShortDateString());
+        }
+        if (BIOS.SizeInKB != null) { 
+            r.Append("BIOS Size: ");
+            if (BIOS.SizeInKB > 1024)
+              r.AppendLine(BIOS.SizeInKB.Value / 1024 + " MB");
+            else
+              r.AppendLine(BIOS.SizeInKB.Value + " KB");
+        }
         r.AppendLine();
       }
 
@@ -304,12 +315,16 @@ namespace OpenHardwareMonitor.Hardware {
 
       private readonly string vendor;
       private readonly string version;
+      private readonly DateTime? date;
+      private readonly long? sizeInKB;
       
-      public BIOSInformation(string vendor, string version) 
+      public BIOSInformation(string vendor, string version, string date = null, int? sizeInKB = null) 
         : base (0x00, 0, null, null) 
       {
         this.vendor = vendor;
         this.version = version;
+        this.date = ParseBIOSDate(date);
+        this.sizeInKB = sizeInKB;
       }
       
       public BIOSInformation(byte type, ushort handle, byte[] data,
@@ -318,7 +333,26 @@ namespace OpenHardwareMonitor.Hardware {
       {
         this.vendor = GetString(0x04);
         this.version = GetString(0x05);
+        this.date = ParseBIOSDate(GetString(0x08));
+        this.sizeInKB = 64 * (GetByte(0x09) + 1);
       }
+
+      private static DateTime? ParseBIOSDate(string biosDate)
+      {
+        var parts = (biosDate ?? "").Split('/');
+        if (parts.Length == 3 &&
+            int.TryParse(parts[0], out int month) &&
+            int.TryParse(parts[1], out int day) &&
+            int.TryParse(parts[2], out int year)) { 
+            return new DateTime(year < 100 ? 1900 + year : year, month, day);
+        }
+
+        return null;
+      }
+      
+      public DateTime? Date { get { return date; } }
+
+      public long? SizeInKB { get { return sizeInKB; } }
 
       public string Vendor { get { return vendor; } }
 


### PR DESCRIPTION
Adds support for detecting the BIOS release date (Windows + Linux) and the BIOS size (Windows only, no dmi fs entry for size) as well as adding them to the report.