### PR TITLE
Add SMBIOS Mainboard serial number to report

### DIFF
--- a/Hardware/SMBIOS.cs
+++ b/Hardware/SMBIOS.cs
@@ -181,6 +181,8 @@ namespace OpenHardwareMonitor.Hardware {
         r.AppendLine(Board.ProductName);
         r.Append("Mainboard Version: ");
         r.AppendLine(Board.Version);
+        r.Append("Mainboard Serial: ");
+        r.AppendLine(Board.SerialNumber);
         r.AppendLine();
       }
 


### PR DESCRIPTION
Mainboard serial number was missing from report for some reason.

After:

```
Mainboard Manufacturer: ASRock
Mainboard Name: Z170 Professional Gaming i7
Mainboard Version: 
Mainboard Serial: M80-610031xxxxx
```