### PR TITLE
Add SMBIOS Baseboard wakeup type

### DIFF
--- a/Hardware/SMBIOS.cs
+++ b/Hardware/SMBIOS.cs
@@ -171,6 +171,8 @@ namespace OpenHardwareMonitor.Hardware {
         r.AppendLine(System.ProductName);
         r.Append("System Version: ");
         r.AppendLine(System.Version);
+        r.Append("System Wakeup: ");
+        r.AppendLine(System.WakeUp.ToString());
         r.AppendLine();
       }
 
@@ -332,9 +334,10 @@ namespace OpenHardwareMonitor.Hardware {
       private readonly string version;
       private readonly string serialNumber;
       private readonly string family;
+      private readonly SystemWakeUp wakeUp;
 
       public SystemInformation(string manufacturerName, string productName, 
-        string version, string serialNumber, string family) 
+        string version, string serialNumber, string family, byte wakeUp = 2) 
         : base (0x01, 0, null, null) 
       {
         this.manufacturerName = manufacturerName;
@@ -342,6 +345,7 @@ namespace OpenHardwareMonitor.Hardware {
         this.version = version;
         this.serialNumber = serialNumber;
         this.family = family;
+        this.wakeUp = (SystemWakeUp)wakeUp;
       }
 
       public SystemInformation(byte type, ushort handle, byte[] data,
@@ -353,6 +357,7 @@ namespace OpenHardwareMonitor.Hardware {
         this.version = GetString(0x06);
         this.serialNumber = GetString(0x07);
         this.family = GetString(0x1A);
+        this.wakeUp = (SystemWakeUp)GetByte(0x18);
       }
 
       public string ManufacturerName { get { return manufacturerName; } }
@@ -365,6 +370,20 @@ namespace OpenHardwareMonitor.Hardware {
 
       public string Family { get { return family; } }
 
+      public SystemWakeUp WakeUp { get { return wakeUp; } }
+    }
+
+    public enum SystemWakeUp
+    {
+        Reserved,
+        Other,
+        Unknown,
+        APMTimer,
+        ModemRing,
+        LANRemote,
+        PowerSwitch,
+        PCIPME,
+        ACPowerRestored
     }
 
     public class BaseBoardInformation : Structure {
@@ -401,7 +420,6 @@ namespace OpenHardwareMonitor.Hardware {
       public string Version { get { return version; } }
 
       public string SerialNumber { get { return serialNumber; } }
-
     }
 
     public class ProcessorInformation : Structure {

--- a/Hardware/SMBIOS.cs
+++ b/Hardware/SMBIOS.cs
@@ -337,7 +337,7 @@ namespace OpenHardwareMonitor.Hardware {
       private readonly SystemWakeUp wakeUp;
 
       public SystemInformation(string manufacturerName, string productName, 
-        string version, string serialNumber, string family, byte wakeUp = (byte)SystemWakeUp.Unknown) 
+        string version, string serialNumber, string family, SystemWakeUp wakeUp = SystemWakeUp.Unknown) 
         : base (0x01, 0, null, null) 
       {
         this.manufacturerName = manufacturerName;
@@ -345,7 +345,7 @@ namespace OpenHardwareMonitor.Hardware {
         this.version = version;
         this.serialNumber = serialNumber;
         this.family = family;
-        this.wakeUp = (SystemWakeUp)wakeUp;
+        this.wakeUp = wakeUp;
       }
 
       public SystemInformation(byte type, ushort handle, byte[] data,
@@ -410,7 +410,7 @@ namespace OpenHardwareMonitor.Hardware {
         this.manufacturerName = GetString(0x04).Trim();
         this.productName = GetString(0x05).Trim();
         this.version = GetString(0x06).Trim();
-        this.serialNumber = GetString(0x07).Trim();               
+        this.serialNumber = GetString(0x07).Trim();
       }
       
       public string ManufacturerName { get { return manufacturerName; } }

--- a/Hardware/SMBIOS.cs
+++ b/Hardware/SMBIOS.cs
@@ -337,7 +337,7 @@ namespace OpenHardwareMonitor.Hardware {
       private readonly SystemWakeUp wakeUp;
 
       public SystemInformation(string manufacturerName, string productName, 
-        string version, string serialNumber, string family, byte wakeUp = 2) 
+        string version, string serialNumber, string family, byte wakeUp = (byte)SystemWakeUp.Unknown) 
         : base (0x01, 0, null, null) 
       {
         this.manufacturerName = manufacturerName;


### PR DESCRIPTION
Adds support for the reason why the machine is powered on to the SMBIOS Baseboard class.