### PR TITLE
Add support for ITE IT8792E and Gigabyte X470 Aorus Gaming 7 Wifi

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -248,6 +248,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     return Model.B450A_PRO;
                 case var _ when name.Equals("B350 GAMING PLUS (MS-7A34)", StringComparison.OrdinalIgnoreCase):
                     return Model.B350_Gaming_Plus;
+                case var _ when name.Equals("X470 AORUS GAMING 7 WIFI-CF", StringComparison.OrdinalIgnoreCase):
+                    return Model.X470_AORUS_GAMING_7_WIFI;
                 case var _ when name.Equals("Base Board Product Name", StringComparison.OrdinalIgnoreCase):
                 case var _ when name.Equals("To be filled by O.E.M.", StringComparison.OrdinalIgnoreCase):
                     return Model.Unknown;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
@@ -40,6 +40,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
         IT8728F = 0x8728,
         IT8771E = 0x8771,
         IT8772E = 0x8772,
+        IT8792E = 0x8733,
 
         NCT6771F = 0xB470,
         NCT6776F = 0xC330,
@@ -97,6 +98,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                 case Chip.IT8728F: return "ITE IT8728F";
                 case Chip.IT8771E: return "ITE IT8771E";
                 case Chip.IT8772E: return "ITE IT8772E";
+                case Chip.IT8792E: return "ITE IT8792E";
 
                 case Chip.NCT610X: return "Nuvoton NCT610X";
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -80,6 +80,14 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                 _fansDisabled = new bool[5];
                 Controls = new float?[3];
             }
+            else if (chip == Chip.IT8792E)
+            {
+                Voltages = new float?[8];
+                Temperatures = new float?[3];
+                Fans = new float?[3];
+                _fansDisabled = new bool[3];
+                Controls = new float?[3];
+            }
             else
             {
                 Voltages = new float?[9];
@@ -124,7 +132,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                 _has16BitFanCounter = true;
             }
 
-            if (chip == Chip.IT8620E)
+            if (chip == Chip.IT8620E || chip == Chip.IT8792E)
             {
                 _hasNewerAutoPwm = true;
             }

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -98,7 +98,9 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                 chip == Chip.IT8771E ||
                 chip == Chip.IT8772E ||
                 chip == Chip.IT8686E ||
-                chip == Chip.IT8688E)
+                chip == Chip.IT8688E ||
+                chip == Chip.IT8792E
+                )
             {
                 _voltageGain = 0.012f;
             }

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LPCIO.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LPCIO.cs
@@ -495,7 +495,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
         private bool DetectIT87(LpcPort port)
         {
             // IT87XX can enter only on port 0x2E
-            if (port.RegisterPort != 0x2E)
+            // IT8792 using 0x4E
+            if (port.RegisterPort != 0x2E && port.RegisterPort != 0x4E)
                 return false;
 
 
@@ -549,6 +550,9 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                     break;
                 case 0x8772:
                     chip = Chip.IT8772E;
+                    break;
+                case 0x8733:
+                    chip = Chip.IT8792E;
                     break;
                 default:
                     chip = Chip.Unknown;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LPcPort.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LPcPort.cs
@@ -68,7 +68,15 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
             Ring0.WriteIoPort(RegisterPort, 0x87);
             Ring0.WriteIoPort(RegisterPort, 0x01);
             Ring0.WriteIoPort(RegisterPort, 0x55);
-            Ring0.WriteIoPort(RegisterPort, 0x55);
+            if (RegisterPort == 0x4E)
+            {
+                Ring0.WriteIoPort(RegisterPort, 0xAA);
+            }
+            else
+            {
+                Ring0.WriteIoPort(RegisterPort, 0x55);
+            }
+            
         }
 
         public void IT87Exit()

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LPcPort.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LPcPort.cs
@@ -75,8 +75,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
             else
             {
                 Ring0.WriteIoPort(RegisterPort, 0x55);
-            }
-            
+            }            
         }
 
         public void IT87Exit()

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -113,6 +113,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
         Z68AP_D3,
         Z68X_UD3H_B3,
         Z68X_UD7_B3,
+        X470_AORUS_GAMING_7_WIFI,
 
         // Shuttle
         FH67,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -800,6 +800,50 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                                 c.Add(new Ctrl("Fan Control #" + (i + 1), i));
 
                             break;
+                        case Model.X470_AORUS_GAMING_7_WIFI: //ITE IT8686E & IT8792
+                            switch(superIO.Chip)
+                            {
+                                case Chip.IT8686E:
+                                    v.Add(new Voltage("Vcore", 0, 0, 1));
+                                    v.Add(new Voltage("+3.3V", 1, 6.5F, 10));
+                                    v.Add(new Voltage("+12V", 2, 5, 1));
+                                    v.Add(new Voltage("+5V", 3, 1.5F, 1));
+                                    v.Add(new Voltage("SOC Vcore", 4, 0, 1));
+                                    v.Add(new Voltage("VDDP", 5, 0, 1));
+                                    v.Add(new Voltage("DIMM AB", 6, 0, 1));
+                                    v.Add(new Voltage("3VSB", 7, 10, 10));
+                                    v.Add(new Voltage("VBat", 8, 10, 10));
+                                    v.Add(new Voltage("AVCC3", 9, 54, 10));
+
+                                    t.Add(new Temperature("System 1", 0));
+                                    t.Add(new Temperature("Chipset", 1));
+                                    t.Add(new Temperature("CPU", 2));
+                                    t.Add(new Temperature("PCIE_X16", 3));
+                                    t.Add(new Temperature("VRM", 4));
+                                    break;
+                                case Chip.IT8792E:
+                                    v.Add(new Voltage("VIN0", 0, 0, 1));
+                                    v.Add(new Voltage("DDR VTT", 1, 0, 1));
+                                    v.Add(new Voltage("Chipset Core", 2, 0, 1));
+                                    v.Add(new Voltage("VIN3", 3, 0, 1));
+                                    v.Add(new Voltage("CPU VDD18", 4, 0, 1));
+                                    v.Add(new Voltage("Chipset Core +2.5V", 5, 0, 1));
+                                    v.Add(new Voltage("3VSB", 6, 0, 10));
+                                    v.Add(new Voltage("VBAT", 7, 10, 10));
+
+                                    t.Add(new Temperature("PCIE_X8", 0));
+                                    t.Add(new Temperature("System 2", 2));
+                                    break;
+                            }
+
+
+                            for (int i = 0; i < superIO.Fans.Length; i++)
+                                f.Add(new Fan("Fan #" + (i + 1), i));
+
+                            for (int i = 0; i < superIO.Controls.Length; i++)
+                                c.Add(new Ctrl("Fan Control #" + (i + 1), i));
+
+                            break;
                         default:
                             v.Add(new Voltage("Vcore", 0));
                             v.Add(new Voltage("DIMM", 1, true));

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -801,7 +801,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
 
                             break;
                         case Model.X470_AORUS_GAMING_7_WIFI: //ITE IT8686E & IT8792
-                            switch(superIO.Chip)
+                            switch (superIO.Chip)
                             {
                                 case Chip.IT8686E:
                                     v.Add(new Voltage("Vcore", 0, 0, 1));
@@ -835,7 +835,6 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                                     t.Add(new Temperature("System 2", 2));
                                     break;
                             }
-
 
                             for (int i = 0; i < superIO.Fans.Length; i++)
                                 f.Add(new Fan("Fan #" + (i + 1), i));

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -211,6 +211,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                 case Chip.IT8726F:
                 case Chip.IT8665E:
                 case Chip.IT8686E:
+                case Chip.IT8792E:
                     GetIteConfigurationsA(superIO, manufacturer, model, v, t, f, c, ref readFan, ref postUpdate, ref mutex);
                     break;
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -827,9 +827,9 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                                     v.Add(new Voltage("Chipset Core", 2, 0, 1));
                                     v.Add(new Voltage("VIN3", 3, 0, 1));
                                     v.Add(new Voltage("CPU VDD18", 4, 0, 1));
-                                    v.Add(new Voltage("Chipset Core +2.5V", 5, 0, 1));
-                                    v.Add(new Voltage("3VSB", 6, 0, 10));
-                                    v.Add(new Voltage("VBAT", 7, 10, 10));
+                                    v.Add(new Voltage("Chipset Core +2.5V", 5, 0.5F, 1));
+                                    v.Add(new Voltage("3VSB", 6, 1, 10));
+                                    v.Add(new Voltage("VBat", 7, 0.7F, 1));
 
                                     t.Add(new Temperature("PCIE_X8", 0));
                                     t.Add(new Temperature("System 2", 2));


### PR DESCRIPTION
This WIP/Draft PR adds support for IT8792E chip and Gigabyte X470 Aorus Gaming 7 Wifi mother board.
Current state is working, but some values slightly offset.
Any advice, idea is welcome to make it better. :)

![gb-x470-it87932e](https://user-images.githubusercontent.com/422679/67167247-eccd4e80-f397-11e9-8c95-6db6f32a71eb.png)
