### PR TITLE
Add support for Intel Goldmont, Goldmont Plus, Cannon Lake, Ice Lake, Tiger Lake and Tremont microarchitectures

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Cpu/IntelCpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/IntelCpu.cs
@@ -143,24 +143,46 @@ namespace LibreHardwareMonitor.Hardware.CPU
                             _microArchitecture = MicroArchitecture.Skylake;
                             tjMax = GetTjMaxFromMsr();
                             break;
-                        case 0x4C:
+                        case 0x4C: // Intel Airmont (Cherry Trail, Braswell)
                             _microArchitecture = MicroArchitecture.Airmont;
                             tjMax = GetTjMaxFromMsr();
                             break;
-                        case 0x8E:
-                        case 0x9E: // Intel Core i5, i7 7xxxx (14nm)
+                        case 0x8E: // Intel Core i5, i7 7xxxx (14nm) (Kaby Lake) and 8xxxx (14nm++) (Coffee Lake)
+                        case 0x9E: 
                             _microArchitecture = MicroArchitecture.KabyLake;
                             tjMax = GetTjMaxFromMsr();
                             break;
-                        case 0x5C: // Intel ApolloLake
-                            _microArchitecture = MicroArchitecture.ApolloLake;
+                        case 0x5C: // Goldmont (Apollo Lake)
+                        case 0x5F: // (Denverton)
+                            _microArchitecture = MicroArchitecture.Goldmont;
                             tjMax = GetTjMaxFromMsr();
                             break;
-                        case 0xAE: // Intel Core i5, i7 8xxxx (14nm++)
-                            _microArchitecture = MicroArchitecture.CoffeeLake;
+                        case 0x7A: // Goldmont plus (Gemini Lake)
+                            _microArchitecture = MicroArchitecture.GoldmontPlus;
                             tjMax = GetTjMaxFromMsr();
                             break;
-                        default:
+                        case 0x66: // Intel Core i3 8xxx (10nm) (Cannon Lake)
+                            _microArchitecture = MicroArchitecture.CannonLake;
+                            tjMax = GetTjMaxFromMsr();
+                            break;
+                        case 0x7D: // Intel Core i3, i5, i7 10xxx (10nm) (Ice Lake)
+                        case 0x7E:
+                        case 0x6A: // Ice Lake server
+                        case 0x6C:
+                                _microArchitecture = MicroArchitecture.IceLake;
+                            tjMax = GetTjMaxFromMsr();
+                            break;
+                        case 0x86: // Tremont (10nm) (Elkhart Lake, Skyhawk Lake)
+                            _microArchitecture = MicroArchitecture.Tremont;
+                            tjMax = GetTjMaxFromMsr();
+                            break;
+                            case 0x8C: // Tiger Lake (10nm)
+                        case 0x8D:
+                            _microArchitecture = MicroArchitecture.TigerLake;
+                            tjMax = GetTjMaxFromMsr();
+                            break;
+
+                            default:
                             _microArchitecture = MicroArchitecture.Unknown;
                             tjMax = Floats(100);
                             break;
@@ -217,10 +239,14 @@ namespace LibreHardwareMonitor.Hardware.CPU
                 case MicroArchitecture.Silvermont:
                 case MicroArchitecture.Skylake:
                 case MicroArchitecture.Airmont:
-                case MicroArchitecture.ApolloLake:
+                case MicroArchitecture.Goldmont:
                 case MicroArchitecture.KabyLake:
-                case MicroArchitecture.CoffeeLake:
-                {
+                case MicroArchitecture.GoldmontPlus:
+                case MicroArchitecture.CannonLake:
+                case MicroArchitecture.IceLake:
+                case MicroArchitecture.TigerLake:
+                case MicroArchitecture.Tremont:
+                    {
                     if (Ring0.ReadMsr(MSR_PLATFORM_INFO, out uint eax, out uint _))
                     {
                         _timeStampCounterMultiplier = (eax >> 8) & 0xff;
@@ -324,8 +350,13 @@ namespace LibreHardwareMonitor.Hardware.CPU
                 _microArchitecture == MicroArchitecture.Skylake ||
                 _microArchitecture == MicroArchitecture.Silvermont ||
                 _microArchitecture == MicroArchitecture.Airmont ||
+                _microArchitecture == MicroArchitecture.Goldmont ||
                 _microArchitecture == MicroArchitecture.KabyLake ||
-                _microArchitecture == MicroArchitecture.ApolloLake)
+                _microArchitecture == MicroArchitecture.GoldmontPlus ||
+                _microArchitecture == MicroArchitecture.CannonLake ||
+                _microArchitecture == MicroArchitecture.IceLake ||
+                _microArchitecture == MicroArchitecture.TigerLake ||
+                _microArchitecture == MicroArchitecture.Tremont)
             {
                 _powerSensors = new Sensor[_energyStatusMsrs.Length];
                 _lastEnergyTime = new DateTime[_energyStatusMsrs.Length];
@@ -490,31 +521,35 @@ namespace LibreHardwareMonitor.Hardware.CPU
                             {
                                 uint multiplier = eax & 0xff;
                                 _coreClocks[i].Value = (float)(multiplier * newBusClock);
-                            }
-
                                 break;
+                            }                                
+
                             case MicroArchitecture.SandyBridge:
                             case MicroArchitecture.IvyBridge:
                             case MicroArchitecture.Haswell:
                             case MicroArchitecture.Broadwell:
                             case MicroArchitecture.Silvermont:
+                            case MicroArchitecture.Airmont:
                             case MicroArchitecture.Skylake:
-                            case MicroArchitecture.ApolloLake:
+                            case MicroArchitecture.Goldmont:
                             case MicroArchitecture.KabyLake:
-                            case MicroArchitecture.CoffeeLake:
+                            case MicroArchitecture.GoldmontPlus:
+                            case MicroArchitecture.CannonLake:
+                            case MicroArchitecture.IceLake:
+                            case MicroArchitecture.TigerLake:
+                            case MicroArchitecture.Tremont:
                             {
                                 uint multiplier = (eax >> 8) & 0xff;
                                 _coreClocks[i].Value = (float)(multiplier * newBusClock);
-                            }
-
                                 break;
+                            }
+                                
                             default:
                             {
                                 double multiplier = ((eax >> 8) & 0x1f) + 0.5 * ((eax >> 14) & 1);
                                 _coreClocks[i].Value = (float)(multiplier * newBusClock);
-                            }
-
                                 break;
+                            }
                         }
                     }
                     else
@@ -572,8 +607,12 @@ namespace LibreHardwareMonitor.Hardware.CPU
             Skylake,
             Airmont,
             KabyLake,
-            ApolloLake,
-            CoffeeLake
+            Goldmont,
+            GoldmontPlus,
+            CannonLake,
+            IceLake,
+            TigerLake,
+            Tremont
         }
 
         // ReSharper disable InconsistentNaming

--- a/LibreHardwareMonitorLib/Hardware/Cpu/IntelCpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/IntelCpu.cs
@@ -56,7 +56,6 @@ namespace LibreHardwareMonitor.Hardware.CPU
                                             tjMax = Floats(85 + 10);
                                             break;
                                     }
-
                                     break;
                                 case 0x0B: // G0
                                     tjMax = Floats(90 + 10);
@@ -68,7 +67,6 @@ namespace LibreHardwareMonitor.Hardware.CPU
                                     tjMax = Floats(85 + 10);
                                     break;
                             }
-
                             break;
                         case 0x17: // Intel Core 2 (45nm)
                             _microArchitecture = MicroArchitecture.Core;
@@ -88,7 +86,6 @@ namespace LibreHardwareMonitor.Hardware.CPU
                                     tjMax = Floats(90);
                                     break;
                             }
-
                             break;
                         case 0x1A: // Intel Core i7 LGA1366 (45nm)
                         case 0x1E: // Intel Core i5, i7 LGA1156 (45nm)
@@ -169,27 +166,25 @@ namespace LibreHardwareMonitor.Hardware.CPU
                         case 0x7E:
                         case 0x6A: // Ice Lake server
                         case 0x6C:
-                                _microArchitecture = MicroArchitecture.IceLake;
+                            _microArchitecture = MicroArchitecture.IceLake;
                             tjMax = GetTjMaxFromMsr();
                             break;
                         case 0x86: // Tremont (10nm) (Elkhart Lake, Skyhawk Lake)
                             _microArchitecture = MicroArchitecture.Tremont;
                             tjMax = GetTjMaxFromMsr();
                             break;
-                            case 0x8C: // Tiger Lake (10nm)
+                        case 0x8C: // Tiger Lake (10nm)
                         case 0x8D:
                             _microArchitecture = MicroArchitecture.TigerLake;
                             tjMax = GetTjMaxFromMsr();
                             break;
-
-                            default:
+                        default:
                             _microArchitecture = MicroArchitecture.Unknown;
                             tjMax = Floats(100);
                             break;
                     }
                 }
-
-                    break;
+                break;
                 case 0x0F:
                 {
                     switch (_model)
@@ -209,14 +204,12 @@ namespace LibreHardwareMonitor.Hardware.CPU
                             break;
                     }
                 }
-
-                    break;
+                break;
                 default:
                     _microArchitecture = MicroArchitecture.Unknown;
                     tjMax = Floats(100);
-                    break;
+                break;
             }
-
             // set timeStampCounterMultiplier
             switch (_microArchitecture)
             {
@@ -229,8 +222,7 @@ namespace LibreHardwareMonitor.Hardware.CPU
                         _timeStampCounterMultiplier = ((edx >> 8) & 0x1f) + 0.5 * ((edx >> 14) & 1);
                     }
                 }
-
-                    break;
+                break;
                 case MicroArchitecture.Nehalem:
                 case MicroArchitecture.SandyBridge:
                 case MicroArchitecture.IvyBridge:
@@ -246,14 +238,13 @@ namespace LibreHardwareMonitor.Hardware.CPU
                 case MicroArchitecture.IceLake:
                 case MicroArchitecture.TigerLake:
                 case MicroArchitecture.Tremont:
-                    {
+                {
                     if (Ring0.ReadMsr(MSR_PLATFORM_INFO, out uint eax, out uint _))
                     {
                         _timeStampCounterMultiplier = (eax >> 8) & 0xff;
                     }
                 }
-
-                    break;
+                break;
                 default:
                     _timeStampCounterMultiplier = 0;
                     break;


### PR DESCRIPTION
This PR adds support for Intel Goldmont, Goldmont Plus, Cannon Lake, Ice Lake, Tiger Lake and Tremont microarchitectures.

It also removes Apollo Lake and Coffee Lake from the microarchitectures enum because:
- Apollo Lake is not the name of a microarchitecture, but the name of a core. The actual name of the microarchitecture it belongs to is Goldmont
- Coffee Lake shares it's (extended) model ID with Kaby Lake, therefore the Coffee Lake enum member is not required. The previous model ID for Coffee Lake was wrong (looked like a mix-up of model ID and stepping)

This PR is based on information from:
- [WikiChip](https://en.wikichip.org/wiki/intel/cpuid)
- the [Linux kernel](https://github.com/torvalds/linux/blob/master/arch/x86/include/asm/intel-family.h)

