### PR TITLE
Activate 0 RPM fan sensors

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -124,7 +124,6 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                 {
                     Sensor sensor = new Sensor(fan.Name, fan.Index, SensorType.Fan, this, settings);
                     _fans.Add(sensor);
-                    ActivateSensor(sensor);
                 }
             }
         }
@@ -2128,7 +2127,11 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
             foreach (Sensor sensor in _fans)
             {
                 float? value = _readFan(sensor.Index);
-                sensor.Value = value;
+                if (value.HasValue)
+                {
+                    sensor.Value = value;
+                    ActivateSensor(sensor);
+                }
             }
 
             foreach (Sensor sensor in _controls)

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -124,6 +124,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                 {
                     Sensor sensor = new Sensor(fan.Name, fan.Index, SensorType.Fan, this, settings);
                     _fans.Add(sensor);
+                    ActivateSensor(sensor);
                 }
             }
         }
@@ -2127,12 +2128,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
             foreach (Sensor sensor in _fans)
             {
                 float? value = _readFan(sensor.Index);
-                if (value.HasValue)
-                {
-                    sensor.Value = value;
-                    if (value.Value > 0)
-                        ActivateSensor(sensor);
-                }
+                sensor.Value = value;
             }
 
             foreach (Sensor sensor in _controls)


### PR DESCRIPTION
The fans are no longer lazy-activated with a non-zero value, so every control gets its matching activated fan, even if the fan is 0 rpm. 