### PR TITLE
Expose NVMe factor SMART attributes

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Storage/NVMeGeneric.cs
+++ b/LibreHardwareMonitorLib/Hardware/Storage/NVMeGeneric.cs
@@ -53,8 +53,12 @@ namespace LibreHardwareMonitor.Hardware.Storage
                 AddSensor("Percentage Used", 3, false, SensorType.Level, health => health.PercentageUsed);
                 AddSensor("Data Read", 4, false, SensorType.Data, health => UnitsToData(health.DataUnitRead));
                 AddSensor("Data Written", 5, false, SensorType.Data, health => UnitsToData(health.DataUnitWritten));
+                AddSensor("Error Info Log Entry Count", 6, false, SensorType.Factor, health => health.ErrorInfoLogEntryCount);
+                AddSensor("Media Errors", 7, false, SensorType.Factor, health => health.MediaErrors);
+                AddSensor("Power Cycles", 8, false, SensorType.Factor, health => health.PowerCycle);
+                AddSensor("Unsafe Shutdowns", 9, false, SensorType.Factor, health => health.UnsafeShutdowns);
 
-                int sensorIdx = 6;
+                int sensorIdx = 10;
                 for (int i = 0; i < log.TemperatureSensors.Length; i++)
                 {
                     int idx = i;


### PR DESCRIPTION
There are a few properties from the `NVMeHealthInfo` that haven't been
exposed as sensors. This commit adds a subset of these absent properties
(only factors). I think these properties should be exposed as I believe
others will find the number of errors / power cycles informative. I've
attached a screenshot of the new sensors.

![image](https://user-images.githubusercontent.com/2106129/75200802-51c0f880-572c-11ea-8144-71dfac18bdb2.png)

