### PR TITLE
Fix AccessViolationException when closing and reopening a NvidiaGpu instance

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Gpu/NvidiaGpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Gpu/NvidiaGpu.cs
@@ -107,7 +107,7 @@ namespace LibreHardwareMonitor.Hardware.Gpu
                 _control.Control = _fanControl;
             }
 
-            if (NvidiaML.IsAvailable)
+            if (NvidiaML.IsAvailable || NvidiaML.Initialize())
             {
                 if (hasPciBusId)
                     _nvmlDevice = NvidiaML.NvmlDeviceGetHandleByPciBusId($" 0000:{busId:X2}:00.0") ?? NvidiaML.NvmlDeviceGetHandleByIndex(_adapterIndex);


### PR DESCRIPTION
I found an issue that shows up when you Close() a Nvidia GPU and then reopen it.
On close the NvidiaML DLL will be unloaded, but it will never be reloaded again which results in AccessViolationExceptions when you try to call any NvidiaML function.

This PR fixes that bug.