### PR TITLE
Feature: Persist collapsed tree nodes

### DIFF
--- a/LibreHardwareMonitor/LibreHardwareMonitor.csproj
+++ b/LibreHardwareMonitor/LibreHardwareMonitor.csproj
@@ -87,6 +87,7 @@
     <Compile Include="..\LibreHardwareMonitorLib\Properties\AssemblyVersion.cs">
       <Link>Properties\AssemblyVersion.cs</Link>
     </Compile>
+    <Compile Include="UI\IExpandPersistNode.cs" />
     <Compile Include="UI\ScaledPlotModel.cs" />
     <Compile Include="UI\GadgetWindow.cs" />
     <Compile Include="UI\Gadget.cs" />

--- a/LibreHardwareMonitor/UI/IExpandPersistNode.cs
+++ b/LibreHardwareMonitor/UI/IExpandPersistNode.cs
@@ -1,0 +1,7 @@
+﻿namespace LibreHardwareMonitor.UI
+{
+    public interface IExpandPersistNode
+    {
+        bool Expanded { get; set; }
+    }
+}

--- a/LibreHardwareMonitor/UI/TypeNode.cs
+++ b/LibreHardwareMonitor/UI/TypeNode.cs
@@ -5,14 +5,21 @@
 // All Rights Reserved.
 
 using LibreHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Utilities;
 
 namespace LibreHardwareMonitor.UI
 {
-    public sealed class TypeNode : Node
+    public sealed class TypeNode : Node, IExpandPersistNode
     {
-        public TypeNode(SensorType sensorType)
+        private readonly PersistentSettings _settings;
+        private readonly string _expandedIdentifier;
+        private bool _expanded;
+
+        public TypeNode(SensorType sensorType, Identifier parentId, PersistentSettings settings)
         {
             SensorType = sensorType;
+            _expandedIdentifier = new Identifier(parentId, SensorType.ToString(), ".expanded").ToString();
+            _settings = settings;
 
             switch (sensorType)
             {
@@ -76,6 +83,7 @@ namespace LibreHardwareMonitor.UI
 
             NodeAdded += TypeNode_NodeAdded;
             NodeRemoved += TypeNode_NodeRemoved;
+            _expanded = settings.GetValue(_expandedIdentifier, true);
         }
 
         private void TypeNode_NodeRemoved(Node node)
@@ -104,5 +112,15 @@ namespace LibreHardwareMonitor.UI
         }
 
         public SensorType SensorType { get; }
+
+        public bool Expanded
+        {
+            get => _expanded;
+            set
+            {
+                _expanded = value;
+                _settings.SetValue(_expandedIdentifier, _expanded);
+            }
+        }
     }
 }


### PR DESCRIPTION
By default, the whole tree is expanded on startup. I personally monitor a handful of sensors and I find it cumbersome to close ~80% of them to only look at the ones I'm interested in.

This feature remembers collapsed nodes.