### PR TITLE
Added IT87XX Fan Controller Main Control Register ON/OFF mod (part 2)

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -231,10 +231,11 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
             if (value.HasValue)
             {
                 SaveDefaultFanPwmControl(index);
-
+                bool valid;
+                WriteByte(FAN_MAIN_CTRL_REG, (byte)(_fanMainControlValue[index] | ReadByte(FAN_MAIN_CTRL_REG, out valid))); // Bitwise opperand to get control of the fan.
                 if (_hasNewerAutoPwm)
                 {
-                    byte ctrlValue = ReadByte(FAN_PWM_CTRL_REG[index], out bool valid);
+                    byte ctrlValue = ReadByte(FAN_PWM_CTRL_REG[index], out valid);
 
                     if (valid)
                     {


### PR DESCRIPTION
Following my PR [#230 ](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/pull/230) , forgot to add the WriteByte sentence in the SetControl subroutine.
This line of code changes the value of the register 0x13, the whole reason of the initial pull request.