### PR TITLE
Fix generic Windows NVMe drive detection

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Storage/NVMeWindows.cs
+++ b/LibreHardwareMonitorLib/Hardware/Storage/NVMeWindows.cs
@@ -28,6 +28,7 @@ namespace LibreHardwareMonitor.Hardware.Storage
             Kernel32.STORAGE_QUERY_BUFFER nptwb = Kernel32.CreateStruct<Kernel32.STORAGE_QUERY_BUFFER>();
             nptwb.ProtocolSpecific.ProtocolType = Kernel32.STORAGE_PROTOCOL_TYPE.ProtocolTypeNvme;
             nptwb.ProtocolSpecific.DataType = (uint)Kernel32.STORAGE_PROTOCOL_NVME_DATA_TYPE.NVMeDataTypeIdentify;
+            nptwb.ProtocolSpecific.ProtocolDataRequestValue = (uint)Kernel32.STORAGE_PROTOCOL_NVME_PROTOCOL_DATA_REQUEST_VALUE.NVMeIdentifyCnsController;
             nptwb.ProtocolSpecific.ProtocolDataOffset = (uint)Marshal.SizeOf<Kernel32.STORAGE_PROTOCOL_SPECIFIC_DATA>();
             nptwb.ProtocolSpecific.ProtocolDataLength = (uint)nptwb.Buffer.Length;
             nptwb.PropertyId = Kernel32.STORAGE_PROPERTY_ID.StorageAdapterProtocolSpecificProperty;
@@ -103,6 +104,7 @@ namespace LibreHardwareMonitor.Hardware.Storage
             Kernel32.STORAGE_QUERY_BUFFER nptwb = Kernel32.CreateStruct<Kernel32.STORAGE_QUERY_BUFFER>();
             nptwb.ProtocolSpecific.ProtocolType = Kernel32.STORAGE_PROTOCOL_TYPE.ProtocolTypeNvme;
             nptwb.ProtocolSpecific.DataType = (uint)Kernel32.STORAGE_PROTOCOL_NVME_DATA_TYPE.NVMeDataTypeIdentify;
+            nptwb.ProtocolSpecific.ProtocolDataRequestValue = (uint)Kernel32.STORAGE_PROTOCOL_NVME_PROTOCOL_DATA_REQUEST_VALUE.NVMeIdentifyCnsController;
             nptwb.ProtocolSpecific.ProtocolDataOffset = (uint)Marshal.SizeOf<Kernel32.STORAGE_PROTOCOL_SPECIFIC_DATA>();
             nptwb.ProtocolSpecific.ProtocolDataLength = (uint)nptwb.Buffer.Length;
             nptwb.PropertyId = Kernel32.STORAGE_PROPERTY_ID.StorageAdapterProtocolSpecificProperty;

--- a/LibreHardwareMonitorLib/Interop/Kernel32.cs
+++ b/LibreHardwareMonitorLib/Interop/Kernel32.cs
@@ -433,6 +433,13 @@ namespace LibreHardwareMonitor.Interop
             NVMeDataTypeFeature
         }
 
+        internal enum STORAGE_PROTOCOL_NVME_PROTOCOL_DATA_REQUEST_VALUE
+        {
+            NVMeIdentifyCnsSpecificNamespace = 0,
+            NVMeIdentifyCnsController = 1,
+            NVMeIdentifyCnsActiveNamespaces = 2
+        }
+
         internal enum STORAGE_PROTOCOL_TYPE
         {
             ProtocolTypeUnknown = 0x00,


### PR DESCRIPTION
This was missing a key piece of data to work according to https://docs.microsoft.com/en-us/windows/win32/fileio/working-with-nvme-devices

Without this patch the ioctl calls fail in my system (using a 2TB HP EX950 PCIe 3.0 x4 drive) here https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/master/LibreHardwareMonitorLib/Hardware/Storage/NVMeWindows.cs#L114 and here https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/master/LibreHardwareMonitorLib/Hardware/Storage/NVMeWindows.cs#L39 