### PR TITLE
IT8620E fan control fix and add Gigabyte H81M-HD3

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -218,6 +218,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     return Model.H67A_UD3H_B3;
                 case var _ when name.Equals("H67A-USB3-B3", StringComparison.OrdinalIgnoreCase):
                     return Model.H67A_USB3_B3;
+                case var _ when name.Equals("H81M-HD3", StringComparison.OrdinalIgnoreCase):
+                    return Model.H81M_HD3;
                 case var _ when name.Equals("P35-DS3", StringComparison.OrdinalIgnoreCase):
                     return Model.P35_DS3;
                 case var _ when name.Equals("P35-DS3L", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -73,6 +73,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                          chip == Chip.IT8665E ||
                          chip == Chip.IT8686E ||
                          chip == Chip.IT8688E ||
+                         chip == Chip.IT8620E ||
                          chip == Chip.IT879XE;
 
             switch (chip)

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -89,6 +89,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
         H61M_USB3_B3_REV_2_0,
         H67A_UD3H_B3,
         H67A_USB3_B3,
+        H81M_HD3,
         MA770T_UD3,
         MA770T_UD3P,
         MA785GM_US2H,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -228,6 +228,11 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     break;
                 }
                 case Chip.IT8620E:
+                {
+                    GetIteConfigurationsB(superIO, manufacturer, model, v, t, f, c);
+                        
+                    break;
+                }
                 case Chip.IT8628E:
                 case Chip.IT8655E:
                 case Chip.IT8665E:
@@ -1067,6 +1072,26 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             f.Add(new Fan("Power Fan", 2));
                             f.Add(new Fan("System Fan #2", 3));
 
+                            break;
+                        }
+                        case Model.H81M_HD3: //IT8620E
+                        {
+                            v.Add(new Voltage("VCore", 0));
+                            v.Add(new Voltage("Voltage #2", 1, true));
+                            v.Add(new Voltage("Voltage #3", 2, true));
+                            v.Add(new Voltage("Voltage #4", 3, true));
+                            v.Add(new Voltage("iGPU", 4));
+                            v.Add(new Voltage("CPU VRIN", 5));
+                            v.Add(new Voltage("DIMM", 6));
+                            v.Add(new Voltage("3VSB", 7, 10, 10, 0));
+                            v.Add(new Voltage("VBat", 8, 10, 10));
+                            t.Add(new Temperature("CPU", 2));
+                            t.Add(new Temperature("SYS", 0));
+                            f.Add(new Fan("CPU Fan", 0));
+                            f.Add(new Fan("SYS Fan", 1));
+                            c.Add(new Ctrl("CPU Fan Control", 0));
+                            c.Add(new Ctrl("SYS Fan Control", 1));
+                            
                             break;
                         }
                         case Model.AX370_Gaming_K7: // IT8686E

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1076,7 +1076,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                         }
                         case Model.H81M_HD3: //IT8620E
                         {
-                            v.Add(new Voltage("VCore", 0));
+                            v.Add(new Voltage("Vcore", 0));
                             v.Add(new Voltage("Voltage #2", 1, true));
                             v.Add(new Voltage("Voltage #3", 2, true));
                             v.Add(new Voltage("Voltage #4", 3, true));
@@ -1086,11 +1086,11 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             v.Add(new Voltage("3VSB", 7, 10, 10, 0));
                             v.Add(new Voltage("VBat", 8, 10, 10));
                             t.Add(new Temperature("CPU", 2));
-                            t.Add(new Temperature("SYS", 0));
+                            t.Add(new Temperature("System", 0));
                             f.Add(new Fan("CPU Fan", 0));
-                            f.Add(new Fan("SYS Fan", 1));
-                            c.Add(new Ctrl("CPU Fan Control", 0));
-                            c.Add(new Ctrl("SYS Fan Control", 1));
+                            f.Add(new Fan("System Fan", 1));
+                            c.Add(new Ctrl("CPU Fan", 0));
+                            c.Add(new Ctrl("System Fan", 1));
                             
                             break;
                         }


### PR DESCRIPTION


I couldn't control my fans on IT8620E anymore (I guess commit 5976a5a7c63e6f71402b2c28d8ac3b45cf5db75c broke it). It is fixed for me by adding the chip to _hasExtReg.

I also added my mainboard Gigabyte H81M-HD3.

![Libre_Hardware_Monitor_2020-06-09_15-19-50](https://user-images.githubusercontent.com/6840978/84152291-b77b8b00-aa64-11ea-8dda-be47eebf83c9.png)