### PR TITLE
Add extra registers to IT8628E

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -73,6 +73,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                          chip == Chip.IT8665E ||
                          chip == Chip.IT8686E ||
                          chip == Chip.IT8688E ||
+                         chip == Chip.IT8628E ||
                          chip == Chip.IT8620E ||
                          chip == Chip.IT879XE;
 


### PR DESCRIPTION
My motherboard (GA-H170-HD3) contains the IT8628E. Without the extra registers enabled, setting any controller speed in LibreHardwareMonitor causes the fan speed to drop to a very low speed. Enabling the extra registers allows LibreHardwareMonitor to set the fan speeds correctly.