### PR TITLE
Update Nct677X.cs to fix #313

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
@@ -475,7 +475,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                         }
                         else
                         {
-                            Fans[i] = null;
+                            Fans[i] = 0;
                         }
                     }
                     else


### PR DESCRIPTION
Changing fan RPM reading hitting _maxFanCount (max slowness) to report 0 RPM instead of NULL for NCT677X