### PR TITLE
Remove .NET Core 3.1 incompatible WinForms controls

### DIFF
--- a/LibreHardwareMonitor/UI/Gadget.cs
+++ b/LibreHardwareMonitor/UI/Gadget.cs
@@ -114,15 +114,15 @@ namespace LibreHardwareMonitor.UI
             }
         }
 
-        public ContextMenu ContextMenu
+        public ContextMenuStrip ContextMenuStrip
         {
             get
             {
-                return _window.ContextMenu;
+                return _window.ContextMenuStrip;
             }
             set
             {
-                _window.ContextMenu = value;
+                _window.ContextMenuStrip = value;
             }
         }
 

--- a/LibreHardwareMonitor/UI/GadgetWindow.cs
+++ b/LibreHardwareMonitor/UI/GadgetWindow.cs
@@ -73,11 +73,6 @@ namespace LibreHardwareMonitor.UI
             NativeMethods.SetWindowPos(handle, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOSENDCHANGING);
         }
 
-        private void ShowContextMenu(Point position)
-        {
-            NativeMethods.TrackPopupMenuEx(ContextMenu.Handle, TPM_RIGHTBUTTON | TPM_VERTICAL, position.X, position.Y, Handle, IntPtr.Zero);
-        }
-
         private CreateParams CreateParams
         {
             get
@@ -134,8 +129,7 @@ namespace LibreHardwareMonitor.UI
                     break;
                 case WM_NCRBUTTONUP:
                     {
-                        if (ContextMenu != null)
-                            ShowContextMenu(new Point(Macros.GET_X_LPARAM(message.LParam),Macros.GET_Y_LPARAM(message.LParam)));
+                        ContextMenuStrip?.Show(new Point(Macros.GET_X_LPARAM(message.LParam), Macros.GET_Y_LPARAM(message.LParam)));
                         message.Result = IntPtr.Zero;
                     }
                     break;
@@ -377,7 +371,7 @@ namespace LibreHardwareMonitor.UI
             }
         }
 
-        public ContextMenu ContextMenu { get; set; }
+        public ContextMenuStrip ContextMenuStrip { get; set; }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
         private struct BlendFunction

--- a/LibreHardwareMonitor/UI/MainForm.Designer.cs
+++ b/LibreHardwareMonitor/UI/MainForm.Designer.cs
@@ -46,85 +46,86 @@ namespace LibreHardwareMonitor.UI
             this.nodeTextBoxValue = new Aga.Controls.Tree.NodeControls.NodeTextBox();
             this.nodeTextBoxMin = new Aga.Controls.Tree.NodeControls.NodeTextBox();
             this.nodeTextBoxMax = new Aga.Controls.Tree.NodeControls.NodeTextBox();
-            this.mainMenu = new System.Windows.Forms.MainMenu(this.components);
-            this.fileMenuItem = new System.Windows.Forms.MenuItem();
-            this.saveReportMenuItem = new System.Windows.Forms.MenuItem();
-            this.MenuItem2 = new System.Windows.Forms.MenuItem();
-            this.resetMenuItem = new System.Windows.Forms.MenuItem();
-            this.menuItem5 = new System.Windows.Forms.MenuItem();
-            this.mainboardMenuItem = new System.Windows.Forms.MenuItem();
-            this.cpuMenuItem = new System.Windows.Forms.MenuItem();
-            this.ramMenuItem = new System.Windows.Forms.MenuItem();
-            this.gpuMenuItem = new System.Windows.Forms.MenuItem();
-            this.fanControllerMenuItem = new System.Windows.Forms.MenuItem();
-            this.hddMenuItem = new System.Windows.Forms.MenuItem();
-            this.nicMenuItem = new System.Windows.Forms.MenuItem();
-            this.menuItem6 = new System.Windows.Forms.MenuItem();
-            this.exitMenuItem = new System.Windows.Forms.MenuItem();
-            this.viewMenuItem = new System.Windows.Forms.MenuItem();
-            this.resetMinMaxMenuItem = new System.Windows.Forms.MenuItem();
-            this.MenuItem3 = new System.Windows.Forms.MenuItem();
-            this.hiddenMenuItem = new System.Windows.Forms.MenuItem();
-            this.plotMenuItem = new System.Windows.Forms.MenuItem();
-            this.gadgetMenuItem = new System.Windows.Forms.MenuItem();
-            this.MenuItem1 = new System.Windows.Forms.MenuItem();
-            this.columnsMenuItem = new System.Windows.Forms.MenuItem();
-            this.valueMenuItem = new System.Windows.Forms.MenuItem();
-            this.minMenuItem = new System.Windows.Forms.MenuItem();
-            this.maxMenuItem = new System.Windows.Forms.MenuItem();
-            this.optionsMenuItem = new System.Windows.Forms.MenuItem();
-            this.startMinMenuItem = new System.Windows.Forms.MenuItem();
-            this.minTrayMenuItem = new System.Windows.Forms.MenuItem();
-            this.minCloseMenuItem = new System.Windows.Forms.MenuItem();
-            this.startupMenuItem = new System.Windows.Forms.MenuItem();
-            this.separatorMenuItem = new System.Windows.Forms.MenuItem();
-            this.temperatureUnitsMenuItem = new System.Windows.Forms.MenuItem();
-            this.celsiusMenuItem = new System.Windows.Forms.MenuItem();
-            this.fahrenheitMenuItem = new System.Windows.Forms.MenuItem();
-            this.plotLocationMenuItem = new System.Windows.Forms.MenuItem();
-            this.plotWindowMenuItem = new System.Windows.Forms.MenuItem();
-            this.plotBottomMenuItem = new System.Windows.Forms.MenuItem();
-            this.plotRightMenuItem = new System.Windows.Forms.MenuItem();
-            this.logSeparatorMenuItem = new System.Windows.Forms.MenuItem();
-            this.logSensorsMenuItem = new System.Windows.Forms.MenuItem();
-            this.loggingIntervalMenuItem = new System.Windows.Forms.MenuItem();
-            this.log1sMenuItem = new System.Windows.Forms.MenuItem();
-            this.log2sMenuItem = new System.Windows.Forms.MenuItem();
-            this.log5sMenuItem = new System.Windows.Forms.MenuItem();
-            this.log10sMenuItem = new System.Windows.Forms.MenuItem();
-            this.log30sMenuItem = new System.Windows.Forms.MenuItem();
-            this.log1minMenuItem = new System.Windows.Forms.MenuItem();
-            this.log2minMenuItem = new System.Windows.Forms.MenuItem();
-            this.log5minMenuItem = new System.Windows.Forms.MenuItem();
-            this.log10minMenuItem = new System.Windows.Forms.MenuItem();
-            this.log30minMenuItem = new System.Windows.Forms.MenuItem();
-            this.log1hMenuItem = new System.Windows.Forms.MenuItem();
-            this.log2hMenuItem = new System.Windows.Forms.MenuItem();
-            this.log6hMenuItem = new System.Windows.Forms.MenuItem();
-            this.sensorValuesTimeWindowMenuItem = new System.Windows.Forms.MenuItem();
-            this.timeWindow30sMenuItem = new System.Windows.Forms.MenuItem();
-            this.timeWindow1minMenuItem = new System.Windows.Forms.MenuItem();
-            this.timeWindow2minMenuItem = new System.Windows.Forms.MenuItem();
-            this.timeWindow5minMenuItem = new System.Windows.Forms.MenuItem();
-            this.timeWindow10minMenuItem = new System.Windows.Forms.MenuItem();
-            this.timeWindow30minMenuItem = new System.Windows.Forms.MenuItem();
-            this.timeWindow1hMenuItem = new System.Windows.Forms.MenuItem();
-            this.timeWindow2hMenuItem = new System.Windows.Forms.MenuItem();
-            this.timeWindow6hMenuItem = new System.Windows.Forms.MenuItem();
-            this.timeWindow12hMenuItem = new System.Windows.Forms.MenuItem();
-            this.timeWindow24hMenuItem = new System.Windows.Forms.MenuItem();
-            this.webMenuItemSeparator = new System.Windows.Forms.MenuItem();
-            this.webMenuItem = new System.Windows.Forms.MenuItem();
-            this.runWebServerMenuItem = new System.Windows.Forms.MenuItem();
-            this.serverPortMenuItem = new System.Windows.Forms.MenuItem();
-            this.authWebServerMenuItem = new System.Windows.Forms.MenuItem();
-            this.helpMenuItem = new System.Windows.Forms.MenuItem();
-            this.aboutMenuItem = new System.Windows.Forms.MenuItem();
-            this.treeContextMenu = new System.Windows.Forms.ContextMenu();
+            this.mainMenu = new System.Windows.Forms.MenuStrip();
+            this.fileMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveReportMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.MenuItem2 = new System.Windows.Forms.ToolStripSeparator();
+            this.resetMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuItem5 = new System.Windows.Forms.ToolStripMenuItem();
+            this.mainboardMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.cpuMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.ramMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.gpuMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.fanControllerMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.hddMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.nicMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuItem6 = new System.Windows.Forms.ToolStripSeparator();
+            this.exitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.viewMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resetMinMaxMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.MenuItem3 = new System.Windows.Forms.ToolStripSeparator();
+            this.hiddenMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.plotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.gadgetMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.MenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            this.columnsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.valueMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.minMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.maxMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.optionsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.startMinMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.minTrayMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.minCloseMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.startupMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.separatorMenuItem = new System.Windows.Forms.ToolStripSeparator();
+            this.temperatureUnitsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.celsiusMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.fahrenheitMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.plotLocationMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.plotWindowMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.plotBottomMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.plotRightMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.logSeparatorMenuItem = new System.Windows.Forms.ToolStripSeparator();
+            this.logSensorsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.loggingIntervalMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.log1sMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.log2sMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.log5sMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.log10sMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.log30sMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.log1minMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.log2minMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.log5minMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.log10minMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.log30minMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.log1hMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.log2hMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.log6hMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.sensorValuesTimeWindowMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.timeWindow30sMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.timeWindow1minMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.timeWindow2minMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.timeWindow5minMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.timeWindow10minMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.timeWindow30minMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.timeWindow1hMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.timeWindow2hMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.timeWindow6hMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.timeWindow12hMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.timeWindow24hMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.webMenuItemSeparator = new System.Windows.Forms.ToolStripSeparator();
+            this.webMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.runWebServerMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.serverPortMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.authWebServerMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.helpMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.aboutMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.treeContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.saveFileDialog = new System.Windows.Forms.SaveFileDialog();
             this.timer = new System.Windows.Forms.Timer(this.components);
             this.splitContainer = new LibreHardwareMonitor.UI.SplitContainerAdv();
             this.treeView = new Aga.Controls.Tree.TreeViewAdv();
+            this.mainMenu.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer)).BeginInit();
             this.splitContainer.Panel1.SuspendLayout();
             this.splitContainer.SuspendLayout();
@@ -211,45 +212,51 @@ namespace LibreHardwareMonitor.UI
             // 
             // mainMenu
             // 
-            this.mainMenu.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.mainMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileMenuItem,
             this.viewMenuItem,
             this.optionsMenuItem,
             this.helpMenuItem});
+            this.mainMenu.Location = new System.Drawing.Point(0, 0);
+            this.mainMenu.Name = "mainMenu";
+            this.mainMenu.Size = new System.Drawing.Size(418, 24);
+            this.mainMenu.TabIndex = 1;
             // 
             // fileMenuItem
             // 
-            this.fileMenuItem.Index = 0;
-            this.fileMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.fileMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.saveReportMenuItem,
             this.MenuItem2,
             this.resetMenuItem,
             this.menuItem5,
             this.menuItem6,
             this.exitMenuItem});
+            this.fileMenuItem.Name = "fileMenuItem";
+            this.fileMenuItem.Size = new System.Drawing.Size(37, 20);
             this.fileMenuItem.Text = "File";
             // 
             // saveReportMenuItem
             // 
-            this.saveReportMenuItem.Index = 0;
+            this.saveReportMenuItem.Name = "saveReportMenuItem";
+            this.saveReportMenuItem.Size = new System.Drawing.Size(145, 22);
             this.saveReportMenuItem.Text = "Save Report...";
             this.saveReportMenuItem.Click += new System.EventHandler(this.SaveReportMenuItem_Click);
             // 
             // MenuItem2
             // 
-            this.MenuItem2.Index = 1;
-            this.MenuItem2.Text = "-";
+            this.MenuItem2.Name = "MenuItem2";
+            this.MenuItem2.Size = new System.Drawing.Size(142, 6);
             // 
             // resetMenuItem
             // 
-            this.resetMenuItem.Index = 2;
+            this.resetMenuItem.Name = "resetMenuItem";
+            this.resetMenuItem.Size = new System.Drawing.Size(145, 22);
             this.resetMenuItem.Text = "Reset";
             this.resetMenuItem.Click += new System.EventHandler(this.ResetClick);
             // 
             // menuItem5
             // 
-            this.menuItem5.Index = 3;
-            this.menuItem5.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.menuItem5.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mainboardMenuItem,
             this.cpuMenuItem,
             this.ramMenuItem,
@@ -257,58 +264,67 @@ namespace LibreHardwareMonitor.UI
             this.fanControllerMenuItem,
             this.hddMenuItem,
             this.nicMenuItem});
+            this.menuItem5.Name = "menuItem5";
+            this.menuItem5.Size = new System.Drawing.Size(145, 22);
             this.menuItem5.Text = "Hardware";
             // 
             // mainboardMenuItem
             // 
-            this.mainboardMenuItem.Index = 0;
+            this.mainboardMenuItem.Name = "mainboardMenuItem";
+            this.mainboardMenuItem.Size = new System.Drawing.Size(160, 22);
             this.mainboardMenuItem.Text = "Motherboard";
             // 
             // cpuMenuItem
             // 
-            this.cpuMenuItem.Index = 1;
+            this.cpuMenuItem.Name = "cpuMenuItem";
+            this.cpuMenuItem.Size = new System.Drawing.Size(160, 22);
             this.cpuMenuItem.Text = "CPU";
             // 
             // ramMenuItem
             // 
-            this.ramMenuItem.Index = 2;
+            this.ramMenuItem.Name = "ramMenuItem";
+            this.ramMenuItem.Size = new System.Drawing.Size(160, 22);
             this.ramMenuItem.Text = "RAM";
             // 
             // gpuMenuItem
             // 
-            this.gpuMenuItem.Index = 3;
+            this.gpuMenuItem.Name = "gpuMenuItem";
+            this.gpuMenuItem.Size = new System.Drawing.Size(160, 22);
             this.gpuMenuItem.Text = "GPU";
             // 
             // fanControllerMenuItem
             // 
-            this.fanControllerMenuItem.Index = 4;
+            this.fanControllerMenuItem.Name = "fanControllerMenuItem";
+            this.fanControllerMenuItem.Size = new System.Drawing.Size(160, 22);
             this.fanControllerMenuItem.Text = "Fan Controllers";
             // 
             // hddMenuItem
             // 
-            this.hddMenuItem.Index = 5;
+            this.hddMenuItem.Name = "hddMenuItem";
+            this.hddMenuItem.Size = new System.Drawing.Size(160, 22);
             this.hddMenuItem.Text = "Hard Disk Drives";
             // 
             // nicMenuItem
             // 
-            this.nicMenuItem.Index = 6;
+            this.nicMenuItem.Name = "nicMenuItem";
+            this.nicMenuItem.Size = new System.Drawing.Size(160, 22);
             this.nicMenuItem.Text = "Network";
             // 
             // menuItem6
             // 
-            this.menuItem6.Index = 4;
-            this.menuItem6.Text = "-";
+            this.menuItem6.Name = "menuItem6";
+            this.menuItem6.Size = new System.Drawing.Size(142, 6);
             // 
             // exitMenuItem
             // 
-            this.exitMenuItem.Index = 5;
+            this.exitMenuItem.Name = "exitMenuItem";
+            this.exitMenuItem.Size = new System.Drawing.Size(145, 22);
             this.exitMenuItem.Text = "Exit";
             this.exitMenuItem.Click += new System.EventHandler(this.ExitClick);
             // 
             // viewMenuItem
             // 
-            this.viewMenuItem.Index = 1;
-            this.viewMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.viewMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.resetMinMaxMenuItem,
             this.MenuItem3,
             this.hiddenMenuItem,
@@ -316,67 +332,76 @@ namespace LibreHardwareMonitor.UI
             this.gadgetMenuItem,
             this.MenuItem1,
             this.columnsMenuItem});
+            this.viewMenuItem.Name = "viewMenuItem";
+            this.viewMenuItem.Size = new System.Drawing.Size(44, 20);
             this.viewMenuItem.Text = "View";
             // 
             // resetMinMaxMenuItem
             // 
-            this.resetMinMaxMenuItem.Index = 0;
+            this.resetMinMaxMenuItem.Name = "resetMinMaxMenuItem";
+            this.resetMinMaxMenuItem.Size = new System.Drawing.Size(188, 22);
             this.resetMinMaxMenuItem.Text = "Reset Min/Max";
             this.resetMinMaxMenuItem.Click += new System.EventHandler(this.ResetMinMaxMenuItem_Click);
             // 
             // MenuItem3
             // 
-            this.MenuItem3.Index = 1;
-            this.MenuItem3.Text = "-";
+            this.MenuItem3.Name = "MenuItem3";
+            this.MenuItem3.Size = new System.Drawing.Size(185, 6);
             // 
             // hiddenMenuItem
             // 
-            this.hiddenMenuItem.Index = 2;
+            this.hiddenMenuItem.Name = "hiddenMenuItem";
+            this.hiddenMenuItem.Size = new System.Drawing.Size(188, 22);
             this.hiddenMenuItem.Text = "Show Hidden Sensors";
             // 
             // plotMenuItem
             // 
-            this.plotMenuItem.Index = 3;
+            this.plotMenuItem.Name = "plotMenuItem";
+            this.plotMenuItem.Size = new System.Drawing.Size(188, 22);
             this.plotMenuItem.Text = "Show Plot";
             // 
             // gadgetMenuItem
             // 
-            this.gadgetMenuItem.Index = 4;
+            this.gadgetMenuItem.Name = "gadgetMenuItem";
+            this.gadgetMenuItem.Size = new System.Drawing.Size(188, 22);
             this.gadgetMenuItem.Text = "Show Gadget";
             // 
             // MenuItem1
             // 
-            this.MenuItem1.Index = 5;
-            this.MenuItem1.Text = "-";
+            this.MenuItem1.Name = "MenuItem1";
+            this.MenuItem1.Size = new System.Drawing.Size(185, 6);
             // 
             // columnsMenuItem
             // 
-            this.columnsMenuItem.Index = 6;
-            this.columnsMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.columnsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.valueMenuItem,
             this.minMenuItem,
             this.maxMenuItem});
+            this.columnsMenuItem.Name = "columnsMenuItem";
+            this.columnsMenuItem.Size = new System.Drawing.Size(188, 22);
             this.columnsMenuItem.Text = "Columns";
             // 
             // valueMenuItem
             // 
-            this.valueMenuItem.Index = 0;
+            this.valueMenuItem.Name = "valueMenuItem";
+            this.valueMenuItem.Size = new System.Drawing.Size(102, 22);
             this.valueMenuItem.Text = "Value";
             // 
             // minMenuItem
             // 
-            this.minMenuItem.Index = 1;
+            this.minMenuItem.Name = "minMenuItem";
+            this.minMenuItem.Size = new System.Drawing.Size(102, 22);
             this.minMenuItem.Text = "Min";
             // 
             // maxMenuItem
             // 
-            this.maxMenuItem.Index = 2;
+            this.maxMenuItem.Name = "maxMenuItem";
+            this.maxMenuItem.Size = new System.Drawing.Size(102, 22);
             this.maxMenuItem.Text = "Max";
             // 
             // optionsMenuItem
             // 
-            this.optionsMenuItem.Index = 2;
-            this.optionsMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.optionsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.startMinMenuItem,
             this.minTrayMenuItem,
             this.minCloseMenuItem,
@@ -390,96 +415,109 @@ namespace LibreHardwareMonitor.UI
             this.sensorValuesTimeWindowMenuItem,
             this.webMenuItemSeparator,
             this.webMenuItem});
+            this.optionsMenuItem.Name = "optionsMenuItem";
+            this.optionsMenuItem.Size = new System.Drawing.Size(61, 20);
             this.optionsMenuItem.Text = "Options";
             // 
             // startMinMenuItem
             // 
-            this.startMinMenuItem.Index = 0;
+            this.startMinMenuItem.Name = "startMinMenuItem";
+            this.startMinMenuItem.Size = new System.Drawing.Size(221, 22);
             this.startMinMenuItem.Text = "Start Minimized";
             // 
             // minTrayMenuItem
             // 
-            this.minTrayMenuItem.Index = 1;
+            this.minTrayMenuItem.Name = "minTrayMenuItem";
+            this.minTrayMenuItem.Size = new System.Drawing.Size(221, 22);
             this.minTrayMenuItem.Text = "Minimize To Tray";
             // 
             // minCloseMenuItem
             // 
-            this.minCloseMenuItem.Index = 2;
+            this.minCloseMenuItem.Name = "minCloseMenuItem";
+            this.minCloseMenuItem.Size = new System.Drawing.Size(221, 22);
             this.minCloseMenuItem.Text = "Minimize On Close";
             // 
             // startupMenuItem
             // 
-            this.startupMenuItem.Index = 3;
+            this.startupMenuItem.Name = "startupMenuItem";
+            this.startupMenuItem.Size = new System.Drawing.Size(221, 22);
             this.startupMenuItem.Text = "Run On Windows Startup";
             // 
             // separatorMenuItem
             // 
-            this.separatorMenuItem.Index = 4;
-            this.separatorMenuItem.Text = "-";
+            this.separatorMenuItem.Name = "separatorMenuItem";
+            this.separatorMenuItem.Size = new System.Drawing.Size(218, 6);
             // 
             // temperatureUnitsMenuItem
             // 
-            this.temperatureUnitsMenuItem.Index = 5;
-            this.temperatureUnitsMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.temperatureUnitsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.celsiusMenuItem,
             this.fahrenheitMenuItem});
+            this.temperatureUnitsMenuItem.Name = "temperatureUnitsMenuItem";
+            this.temperatureUnitsMenuItem.Size = new System.Drawing.Size(221, 22);
             this.temperatureUnitsMenuItem.Text = "Temperature Unit";
             // 
             // celsiusMenuItem
             // 
-            this.celsiusMenuItem.Index = 0;
-            this.celsiusMenuItem.RadioCheck = true;
+            this.celsiusMenuItem.CheckOnClick = true;
+            this.celsiusMenuItem.Name = "celsiusMenuItem";
+            this.celsiusMenuItem.Size = new System.Drawing.Size(130, 22);
             this.celsiusMenuItem.Text = "Celsius";
             this.celsiusMenuItem.Click += new System.EventHandler(this.CelsiusMenuItem_Click);
             // 
             // fahrenheitMenuItem
             // 
-            this.fahrenheitMenuItem.Index = 1;
-            this.fahrenheitMenuItem.RadioCheck = true;
+            this.fahrenheitMenuItem.CheckOnClick = true;
+            this.fahrenheitMenuItem.Name = "fahrenheitMenuItem";
+            this.fahrenheitMenuItem.Size = new System.Drawing.Size(130, 22);
             this.fahrenheitMenuItem.Text = "Fahrenheit";
             this.fahrenheitMenuItem.Click += new System.EventHandler(this.FahrenheitMenuItem_Click);
             // 
             // plotLocationMenuItem
             // 
-            this.plotLocationMenuItem.Index = 6;
-            this.plotLocationMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.plotLocationMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.plotWindowMenuItem,
             this.plotBottomMenuItem,
             this.plotRightMenuItem});
+            this.plotLocationMenuItem.Name = "plotLocationMenuItem";
+            this.plotLocationMenuItem.Size = new System.Drawing.Size(221, 22);
             this.plotLocationMenuItem.Text = "Plot Location";
             // 
             // plotWindowMenuItem
             // 
-            this.plotWindowMenuItem.Index = 0;
-            this.plotWindowMenuItem.RadioCheck = true;
+            this.plotWindowMenuItem.CheckOnClick = true;
+            this.plotWindowMenuItem.Name = "plotWindowMenuItem";
+            this.plotWindowMenuItem.Size = new System.Drawing.Size(118, 22);
             this.plotWindowMenuItem.Text = "Window";
             // 
             // plotBottomMenuItem
             // 
-            this.plotBottomMenuItem.Index = 1;
-            this.plotBottomMenuItem.RadioCheck = true;
+            this.plotBottomMenuItem.CheckOnClick = true;
+            this.plotBottomMenuItem.Name = "plotBottomMenuItem";
+            this.plotBottomMenuItem.Size = new System.Drawing.Size(118, 22);
             this.plotBottomMenuItem.Text = "Bottom";
             // 
             // plotRightMenuItem
             // 
-            this.plotRightMenuItem.Index = 2;
-            this.plotRightMenuItem.RadioCheck = true;
+            this.plotRightMenuItem.CheckOnClick = true;
+            this.plotRightMenuItem.Name = "plotRightMenuItem";
+            this.plotRightMenuItem.Size = new System.Drawing.Size(118, 22);
             this.plotRightMenuItem.Text = "Right";
             // 
             // logSeparatorMenuItem
             // 
-            this.logSeparatorMenuItem.Index = 7;
-            this.logSeparatorMenuItem.Text = "-";
+            this.logSeparatorMenuItem.Name = "logSeparatorMenuItem";
+            this.logSeparatorMenuItem.Size = new System.Drawing.Size(218, 6);
             // 
             // logSensorsMenuItem
             // 
-            this.logSensorsMenuItem.Index = 8;
+            this.logSensorsMenuItem.Name = "logSensorsMenuItem";
+            this.logSensorsMenuItem.Size = new System.Drawing.Size(221, 22);
             this.logSensorsMenuItem.Text = "Log Sensors";
             // 
             // loggingIntervalMenuItem
             // 
-            this.loggingIntervalMenuItem.Index = 9;
-            this.loggingIntervalMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.loggingIntervalMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.log1sMenuItem,
             this.log2sMenuItem,
             this.log5sMenuItem,
@@ -493,90 +531,104 @@ namespace LibreHardwareMonitor.UI
             this.log1hMenuItem,
             this.log2hMenuItem,
             this.log6hMenuItem});
+            this.loggingIntervalMenuItem.Name = "loggingIntervalMenuItem";
+            this.loggingIntervalMenuItem.Size = new System.Drawing.Size(221, 22);
             this.loggingIntervalMenuItem.Text = "Logging Interval";
             // 
             // log1sMenuItem
             // 
-            this.log1sMenuItem.Index = 0;
-            this.log1sMenuItem.RadioCheck = true;
+            this.log1sMenuItem.CheckOnClick = true;
+            this.log1sMenuItem.Name = "log1sMenuItem";
+            this.log1sMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log1sMenuItem.Text = "1s";
             // 
             // log2sMenuItem
             // 
-            this.log2sMenuItem.Index = 1;
-            this.log2sMenuItem.RadioCheck = true;
+            this.log2sMenuItem.CheckOnClick = true;
+            this.log2sMenuItem.Name = "log2sMenuItem";
+            this.log2sMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log2sMenuItem.Text = "2s";
             // 
             // log5sMenuItem
             // 
-            this.log5sMenuItem.Index = 2;
-            this.log5sMenuItem.RadioCheck = true;
+            this.log5sMenuItem.CheckOnClick = true;
+            this.log5sMenuItem.Name = "log5sMenuItem";
+            this.log5sMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log5sMenuItem.Text = "5s";
             // 
             // log10sMenuItem
             // 
-            this.log10sMenuItem.Index = 3;
-            this.log10sMenuItem.RadioCheck = true;
+            this.log10sMenuItem.CheckOnClick = true;
+            this.log10sMenuItem.Name = "log10sMenuItem";
+            this.log10sMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log10sMenuItem.Text = "10s";
             // 
             // log30sMenuItem
             // 
-            this.log30sMenuItem.Index = 4;
-            this.log30sMenuItem.RadioCheck = true;
+            this.log30sMenuItem.CheckOnClick = true;
+            this.log30sMenuItem.Name = "log30sMenuItem";
+            this.log30sMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log30sMenuItem.Text = "30s";
             // 
             // log1minMenuItem
             // 
-            this.log1minMenuItem.Index = 5;
-            this.log1minMenuItem.RadioCheck = true;
+            this.log1minMenuItem.CheckOnClick = true;
+            this.log1minMenuItem.Name = "log1minMenuItem";
+            this.log1minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log1minMenuItem.Text = "1min";
             // 
             // log2minMenuItem
             // 
-            this.log2minMenuItem.Index = 6;
-            this.log2minMenuItem.RadioCheck = true;
+            this.log2minMenuItem.CheckOnClick = true;
+            this.log2minMenuItem.Name = "log2minMenuItem";
+            this.log2minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log2minMenuItem.Text = "2min";
             // 
             // log5minMenuItem
             // 
-            this.log5minMenuItem.Index = 7;
-            this.log5minMenuItem.RadioCheck = true;
+            this.log5minMenuItem.CheckOnClick = true;
+            this.log5minMenuItem.Name = "log5minMenuItem";
+            this.log5minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log5minMenuItem.Text = "5min";
             // 
             // log10minMenuItem
             // 
-            this.log10minMenuItem.Index = 8;
-            this.log10minMenuItem.RadioCheck = true;
+            this.log10minMenuItem.CheckOnClick = true;
+            this.log10minMenuItem.Name = "log10minMenuItem";
+            this.log10minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log10minMenuItem.Text = "10min";
             // 
             // log30minMenuItem
             // 
-            this.log30minMenuItem.Index = 9;
-            this.log30minMenuItem.RadioCheck = true;
+            this.log30minMenuItem.CheckOnClick = true;
+            this.log30minMenuItem.Name = "log30minMenuItem";
+            this.log30minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log30minMenuItem.Text = "30min";
             // 
             // log1hMenuItem
             // 
-            this.log1hMenuItem.Index = 10;
-            this.log1hMenuItem.RadioCheck = true;
+            this.log1hMenuItem.CheckOnClick = true;
+            this.log1hMenuItem.Name = "log1hMenuItem";
+            this.log1hMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log1hMenuItem.Text = "1h";
             // 
             // log2hMenuItem
             // 
-            this.log2hMenuItem.Index = 11;
-            this.log2hMenuItem.RadioCheck = true;
+            this.log2hMenuItem.CheckOnClick = true;
+            this.log2hMenuItem.Name = "log2hMenuItem";
+            this.log2hMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log2hMenuItem.Text = "2h";
             // 
             // log6hMenuItem
             // 
-            this.log6hMenuItem.Index = 12;
-            this.log6hMenuItem.RadioCheck = true;
+            this.log6hMenuItem.CheckOnClick = true;
+            this.log6hMenuItem.Name = "log6hMenuItem";
+            this.log6hMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log6hMenuItem.Text = "6h";
             // 
             // sensorValuesTimeWindowMenuItem
             // 
-            this.sensorValuesTimeWindowMenuItem.Index = 10;
-            this.sensorValuesTimeWindowMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.sensorValuesTimeWindowMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.timeWindow30sMenuItem,
             this.timeWindow1minMenuItem,
             this.timeWindow2minMenuItem,
@@ -588,117 +640,141 @@ namespace LibreHardwareMonitor.UI
             this.timeWindow6hMenuItem,
             this.timeWindow12hMenuItem,
             this.timeWindow24hMenuItem});
+            this.sensorValuesTimeWindowMenuItem.Name = "sensorValuesTimeWindowMenuItem";
+            this.sensorValuesTimeWindowMenuItem.Size = new System.Drawing.Size(221, 22);
             this.sensorValuesTimeWindowMenuItem.Text = "Sensor Values Time Window";
             // 
             // timeWindow30sMenuItem
             // 
-            this.timeWindow30sMenuItem.Index = 0;
-            this.timeWindow30sMenuItem.RadioCheck = true;
+            this.timeWindow30sMenuItem.CheckOnClick = true;
+            this.timeWindow30sMenuItem.Name = "timeWindow30sMenuItem";
+            this.timeWindow30sMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow30sMenuItem.Text = "30s";
             // 
             // timeWindow1minMenuItem
             // 
-            this.timeWindow1minMenuItem.Index = 1;
-            this.timeWindow1minMenuItem.RadioCheck = true;
+            this.timeWindow1minMenuItem.CheckOnClick = true;
+            this.timeWindow1minMenuItem.Name = "timeWindow1minMenuItem";
+            this.timeWindow1minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow1minMenuItem.Text = "1min";
             // 
             // timeWindow2minMenuItem
             // 
-            this.timeWindow2minMenuItem.Index = 2;
-            this.timeWindow2minMenuItem.RadioCheck = true;
+            this.timeWindow2minMenuItem.CheckOnClick = true;
+            this.timeWindow2minMenuItem.Name = "timeWindow2minMenuItem";
+            this.timeWindow2minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow2minMenuItem.Text = "2min";
             // 
             // timeWindow5minMenuItem
             // 
-            this.timeWindow5minMenuItem.Index = 3;
-            this.timeWindow5minMenuItem.RadioCheck = true;
+            this.timeWindow5minMenuItem.CheckOnClick = true;
+            this.timeWindow5minMenuItem.Name = "timeWindow5minMenuItem";
+            this.timeWindow5minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow5minMenuItem.Text = "5min";
             // 
             // timeWindow10minMenuItem
             // 
-            this.timeWindow10minMenuItem.Index = 4;
-            this.timeWindow10minMenuItem.RadioCheck = true;
+            this.timeWindow10minMenuItem.CheckOnClick = true;
+            this.timeWindow10minMenuItem.Name = "timeWindow10minMenuItem";
+            this.timeWindow10minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow10minMenuItem.Text = "10min";
             // 
             // timeWindow30minMenuItem
             // 
-            this.timeWindow30minMenuItem.Index = 5;
-            this.timeWindow30minMenuItem.RadioCheck = true;
+            this.timeWindow30minMenuItem.CheckOnClick = true;
+            this.timeWindow30minMenuItem.Name = "timeWindow30minMenuItem";
+            this.timeWindow30minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow30minMenuItem.Text = "30min";
             // 
             // timeWindow1hMenuItem
             // 
-            this.timeWindow1hMenuItem.Index = 6;
-            this.timeWindow1hMenuItem.RadioCheck = true;
+            this.timeWindow1hMenuItem.CheckOnClick = true;
+            this.timeWindow1hMenuItem.Name = "timeWindow1hMenuItem";
+            this.timeWindow1hMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow1hMenuItem.Text = "1h";
             // 
             // timeWindow2hMenuItem
             // 
-            this.timeWindow2hMenuItem.Index = 7;
-            this.timeWindow2hMenuItem.RadioCheck = true;
+            this.timeWindow2hMenuItem.CheckOnClick = true;
+            this.timeWindow2hMenuItem.Name = "timeWindow2hMenuItem";
+            this.timeWindow2hMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow2hMenuItem.Text = "2n";
             // 
             // timeWindow6hMenuItem
             // 
-            this.timeWindow6hMenuItem.Index = 8;
-            this.timeWindow6hMenuItem.RadioCheck = true;
+            this.timeWindow6hMenuItem.CheckOnClick = true;
+            this.timeWindow6hMenuItem.Name = "timeWindow6hMenuItem";
+            this.timeWindow6hMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow6hMenuItem.Text = "6h";
             // 
             // timeWindow12hMenuItem
             // 
-            this.timeWindow12hMenuItem.Index = 9;
-            this.timeWindow12hMenuItem.RadioCheck = true;
+            this.timeWindow12hMenuItem.CheckOnClick = true;
+            this.timeWindow12hMenuItem.Name = "timeWindow12hMenuItem";
+            this.timeWindow12hMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow12hMenuItem.Text = "12h";
             // 
             // timeWindow24hMenuItem
             // 
-            this.timeWindow24hMenuItem.Index = 10;
-            this.timeWindow24hMenuItem.RadioCheck = true;
+            this.timeWindow24hMenuItem.CheckOnClick = true;
+            this.timeWindow24hMenuItem.Name = "timeWindow24hMenuItem";
+            this.timeWindow24hMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow24hMenuItem.Text = "24h";
             // 
             // webMenuItemSeparator
             // 
-            this.webMenuItemSeparator.Index = 11;
-            this.webMenuItemSeparator.Text = "-";
+            this.webMenuItemSeparator.Name = "webMenuItemSeparator";
+            this.webMenuItemSeparator.Size = new System.Drawing.Size(218, 6);
             // 
             // webMenuItem
             // 
-            this.webMenuItem.Index = 12;
-            this.webMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.webMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.runWebServerMenuItem,
             this.serverPortMenuItem,
             this.authWebServerMenuItem});
+            this.webMenuItem.Name = "webMenuItem";
+            this.webMenuItem.Size = new System.Drawing.Size(221, 22);
             this.webMenuItem.Text = "Remote Web Server";
             // 
             // runWebServerMenuItem
             // 
-            this.runWebServerMenuItem.Index = 0;
+            this.runWebServerMenuItem.Name = "runWebServerMenuItem";
+            this.runWebServerMenuItem.Size = new System.Drawing.Size(153, 22);
             this.runWebServerMenuItem.Text = "Run";
             // 
             // serverPortMenuItem
             // 
-            this.serverPortMenuItem.Index = 1;
+            this.serverPortMenuItem.Name = "serverPortMenuItem";
+            this.serverPortMenuItem.Size = new System.Drawing.Size(153, 22);
             this.serverPortMenuItem.Text = "Port";
             this.serverPortMenuItem.Click += new System.EventHandler(this.ServerPortMenuItem_Click);
             // 
             // authWebServerMenuItem
             // 
-            this.authWebServerMenuItem.Index = 2;
+            this.authWebServerMenuItem.Name = "authWebServerMenuItem";
+            this.authWebServerMenuItem.Size = new System.Drawing.Size(153, 22);
             this.authWebServerMenuItem.Text = "Authentication";
             this.authWebServerMenuItem.Click += new System.EventHandler(this.AuthWebServerMenuItem_Click);
             // 
             // helpMenuItem
             // 
-            this.helpMenuItem.Index = 3;
-            this.helpMenuItem.MenuItems.AddRange(new System.Windows.Forms.MenuItem[] {
+            this.helpMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.aboutMenuItem});
+            this.helpMenuItem.Name = "helpMenuItem";
+            this.helpMenuItem.Size = new System.Drawing.Size(44, 20);
             this.helpMenuItem.Text = "Help";
             // 
             // aboutMenuItem
             // 
-            this.aboutMenuItem.Index = 0;
+            this.aboutMenuItem.Name = "aboutMenuItem";
+            this.aboutMenuItem.Size = new System.Drawing.Size(107, 22);
             this.aboutMenuItem.Text = "About";
             this.aboutMenuItem.Click += new System.EventHandler(this.AboutMenuItem_Click);
+            // 
+            // treeContextMenu
+            // 
+            this.treeContextMenu.Name = "treeContextMenu";
+            this.treeContextMenu.Size = new System.Drawing.Size(61, 4);
             // 
             // saveFileDialog
             // 
@@ -775,13 +851,16 @@ namespace LibreHardwareMonitor.UI
             this.ClientSize = new System.Drawing.Size(418, 533);
             this.Controls.Add(this.splitContainer);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Menu = this.mainMenu;
+            this.MainMenuStrip = this.mainMenu;
             this.Name = "MainForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
             this.Text = "Libre Hardware Monitor";
             this.Load += new System.EventHandler(this.MainForm_Load);
             this.ResizeEnd += new System.EventHandler(this.MainForm_MoveOrResize);
             this.Move += new System.EventHandler(this.MainForm_MoveOrResize);
+            this.mainMenu.ResumeLayout(false);
+            this.mainMenu.PerformLayout();
+            this.Controls.Add(mainMenu);
             this.splitContainer.Panel1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer)).EndInit();
             this.splitContainer.ResumeLayout(false);
@@ -792,9 +871,9 @@ namespace LibreHardwareMonitor.UI
         #endregion
 
         private Aga.Controls.Tree.TreeViewAdv treeView;
-        private System.Windows.Forms.MainMenu mainMenu;
-        private System.Windows.Forms.MenuItem fileMenuItem;
-        private System.Windows.Forms.MenuItem exitMenuItem;
+        private System.Windows.Forms.MenuStrip mainMenu;
+        private System.Windows.Forms.ToolStripMenuItem fileMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem exitMenuItem;
         private Aga.Controls.Tree.TreeColumn sensor;
         private Aga.Controls.Tree.TreeColumn value;
         private Aga.Controls.Tree.TreeColumn min;
@@ -805,81 +884,81 @@ namespace LibreHardwareMonitor.UI
         private Aga.Controls.Tree.NodeControls.NodeTextBox nodeTextBoxMin;
         private Aga.Controls.Tree.NodeControls.NodeTextBox nodeTextBoxMax;
         private SplitContainerAdv splitContainer;
-        private System.Windows.Forms.MenuItem viewMenuItem;
-        private System.Windows.Forms.MenuItem plotMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem viewMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem plotMenuItem;
         private Aga.Controls.Tree.NodeControls.NodeCheckBox nodeCheckBox;
-        private System.Windows.Forms.MenuItem helpMenuItem;
-        private System.Windows.Forms.MenuItem aboutMenuItem;
-        private System.Windows.Forms.MenuItem saveReportMenuItem;
-        private System.Windows.Forms.MenuItem optionsMenuItem;
-        private System.Windows.Forms.MenuItem hddMenuItem;
-        private System.Windows.Forms.MenuItem minTrayMenuItem;
-        private System.Windows.Forms.MenuItem separatorMenuItem;
-        private System.Windows.Forms.ContextMenu treeContextMenu;
-        private System.Windows.Forms.MenuItem startMinMenuItem;
-        private System.Windows.Forms.MenuItem startupMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem helpMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem aboutMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem saveReportMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem optionsMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem hddMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem minTrayMenuItem;
+        private System.Windows.Forms.ToolStripSeparator separatorMenuItem;
+        private System.Windows.Forms.ContextMenuStrip treeContextMenu;
+        private System.Windows.Forms.ToolStripMenuItem startMinMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem startupMenuItem;
         private System.Windows.Forms.SaveFileDialog saveFileDialog;
         private System.Windows.Forms.Timer timer;
-        private System.Windows.Forms.MenuItem hiddenMenuItem;
-        private System.Windows.Forms.MenuItem MenuItem1;
-        private System.Windows.Forms.MenuItem columnsMenuItem;
-        private System.Windows.Forms.MenuItem valueMenuItem;
-        private System.Windows.Forms.MenuItem minMenuItem;
-        private System.Windows.Forms.MenuItem maxMenuItem;
-        private System.Windows.Forms.MenuItem temperatureUnitsMenuItem;
-        private System.Windows.Forms.MenuItem webMenuItemSeparator;
-        private System.Windows.Forms.MenuItem celsiusMenuItem;
-        private System.Windows.Forms.MenuItem fahrenheitMenuItem;
-        private System.Windows.Forms.MenuItem MenuItem2;
-        private System.Windows.Forms.MenuItem resetMinMaxMenuItem;
-        private System.Windows.Forms.MenuItem MenuItem3;
-        private System.Windows.Forms.MenuItem gadgetMenuItem;
-        private System.Windows.Forms.MenuItem minCloseMenuItem;
-        private System.Windows.Forms.MenuItem resetMenuItem;
-        private System.Windows.Forms.MenuItem menuItem6;
-        private System.Windows.Forms.MenuItem plotLocationMenuItem;
-        private System.Windows.Forms.MenuItem plotWindowMenuItem;
-        private System.Windows.Forms.MenuItem plotBottomMenuItem;
-        private System.Windows.Forms.MenuItem plotRightMenuItem;
-        private System.Windows.Forms.MenuItem webMenuItem;
-        private System.Windows.Forms.MenuItem runWebServerMenuItem;
-        private System.Windows.Forms.MenuItem serverPortMenuItem;
-        private System.Windows.Forms.MenuItem menuItem5;
-        private System.Windows.Forms.MenuItem mainboardMenuItem;
-        private System.Windows.Forms.MenuItem cpuMenuItem;
-        private System.Windows.Forms.MenuItem gpuMenuItem;
-        private System.Windows.Forms.MenuItem fanControllerMenuItem;
-        private System.Windows.Forms.MenuItem ramMenuItem;
-        private System.Windows.Forms.MenuItem logSensorsMenuItem;
-        private System.Windows.Forms.MenuItem logSeparatorMenuItem;
-        private System.Windows.Forms.MenuItem loggingIntervalMenuItem;
-        private System.Windows.Forms.MenuItem log1sMenuItem;
-        private System.Windows.Forms.MenuItem log2sMenuItem;
-        private System.Windows.Forms.MenuItem log5sMenuItem;
-        private System.Windows.Forms.MenuItem log10sMenuItem;
-        private System.Windows.Forms.MenuItem log30sMenuItem;
-        private System.Windows.Forms.MenuItem log1minMenuItem;
-        private System.Windows.Forms.MenuItem log2minMenuItem;
-        private System.Windows.Forms.MenuItem log5minMenuItem;
-        private System.Windows.Forms.MenuItem log10minMenuItem;
-        private System.Windows.Forms.MenuItem log30minMenuItem;
-        private System.Windows.Forms.MenuItem log1hMenuItem;
-        private System.Windows.Forms.MenuItem log2hMenuItem;
-        private System.Windows.Forms.MenuItem log6hMenuItem;
-        private System.Windows.Forms.MenuItem nicMenuItem;
-        private System.Windows.Forms.MenuItem sensorValuesTimeWindowMenuItem;
-        private System.Windows.Forms.MenuItem timeWindow30sMenuItem;
-        private System.Windows.Forms.MenuItem timeWindow1minMenuItem;
-        private System.Windows.Forms.MenuItem timeWindow2minMenuItem;
-        private System.Windows.Forms.MenuItem timeWindow5minMenuItem;
-        private System.Windows.Forms.MenuItem timeWindow10minMenuItem;
-        private System.Windows.Forms.MenuItem timeWindow30minMenuItem;
-        private System.Windows.Forms.MenuItem timeWindow1hMenuItem;
-        private System.Windows.Forms.MenuItem timeWindow2hMenuItem;
-        private System.Windows.Forms.MenuItem timeWindow6hMenuItem;
-        private System.Windows.Forms.MenuItem timeWindow12hMenuItem;
-        private System.Windows.Forms.MenuItem timeWindow24hMenuItem;
-        private System.Windows.Forms.MenuItem authWebServerMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem hiddenMenuItem;
+        private System.Windows.Forms.ToolStripSeparator MenuItem1;
+        private System.Windows.Forms.ToolStripMenuItem columnsMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem valueMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem minMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem maxMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem temperatureUnitsMenuItem;
+        private System.Windows.Forms.ToolStripSeparator webMenuItemSeparator;
+        private ToolStripRadioButtonMenuItem celsiusMenuItem;
+        private ToolStripRadioButtonMenuItem fahrenheitMenuItem;
+        private System.Windows.Forms.ToolStripSeparator MenuItem2;
+        private System.Windows.Forms.ToolStripMenuItem resetMinMaxMenuItem;
+        private System.Windows.Forms.ToolStripSeparator MenuItem3;
+        private System.Windows.Forms.ToolStripMenuItem gadgetMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem minCloseMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem resetMenuItem;
+        private System.Windows.Forms.ToolStripSeparator menuItem6;
+        private System.Windows.Forms.ToolStripMenuItem plotLocationMenuItem;
+        private ToolStripRadioButtonMenuItem plotWindowMenuItem;
+        private ToolStripRadioButtonMenuItem plotBottomMenuItem;
+        private ToolStripRadioButtonMenuItem plotRightMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem webMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem runWebServerMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem serverPortMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem menuItem5;
+        private System.Windows.Forms.ToolStripMenuItem mainboardMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem cpuMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem gpuMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem fanControllerMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem ramMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem logSensorsMenuItem;
+        private System.Windows.Forms.ToolStripSeparator logSeparatorMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem loggingIntervalMenuItem;
+        private ToolStripRadioButtonMenuItem log1sMenuItem;
+        private ToolStripRadioButtonMenuItem log2sMenuItem;
+        private ToolStripRadioButtonMenuItem log5sMenuItem;
+        private ToolStripRadioButtonMenuItem log10sMenuItem;
+        private ToolStripRadioButtonMenuItem log30sMenuItem;
+        private ToolStripRadioButtonMenuItem log1minMenuItem;
+        private ToolStripRadioButtonMenuItem log2minMenuItem;
+        private ToolStripRadioButtonMenuItem log5minMenuItem;
+        private ToolStripRadioButtonMenuItem log10minMenuItem;
+        private ToolStripRadioButtonMenuItem log30minMenuItem;
+        private ToolStripRadioButtonMenuItem log1hMenuItem;
+        private ToolStripRadioButtonMenuItem log2hMenuItem;
+        private ToolStripRadioButtonMenuItem log6hMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem nicMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem sensorValuesTimeWindowMenuItem;
+        private ToolStripRadioButtonMenuItem timeWindow30sMenuItem;
+        private ToolStripRadioButtonMenuItem timeWindow1minMenuItem;
+        private ToolStripRadioButtonMenuItem timeWindow2minMenuItem;
+        private ToolStripRadioButtonMenuItem timeWindow5minMenuItem;
+        private ToolStripRadioButtonMenuItem timeWindow10minMenuItem;
+        private ToolStripRadioButtonMenuItem timeWindow30minMenuItem;
+        private ToolStripRadioButtonMenuItem timeWindow1hMenuItem;
+        private ToolStripRadioButtonMenuItem timeWindow2hMenuItem;
+        private ToolStripRadioButtonMenuItem timeWindow6hMenuItem;
+        private ToolStripRadioButtonMenuItem timeWindow12hMenuItem;
+        private ToolStripRadioButtonMenuItem timeWindow24hMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem authWebServerMenuItem;
     }
 }
 

--- a/LibreHardwareMonitor/UI/MainForm.cs
+++ b/LibreHardwareMonitor/UI/MainForm.cs
@@ -766,65 +766,65 @@ namespace LibreHardwareMonitor.UI
             {
                 if (info.Node.Tag is SensorNode node && node.Sensor != null)
                 {
-                    treeContextMenu.MenuItems.Clear();
+                    treeContextMenu.Items.Clear();
                     if (node.Sensor.Parameters.Count > 0)
                     {
-                        MenuItem item = new MenuItem("Parameters...");
+                        ToolStripItem item = new ToolStripMenuItem("Parameters...");
                         item.Click += delegate
                         {
                             ShowParameterForm(node.Sensor);
                         };
-                        treeContextMenu.MenuItems.Add(item);
+                        treeContextMenu.Items.Add(item);
                     }
                     if (nodeTextBoxText.EditEnabled)
                     {
-                        MenuItem item = new MenuItem("Rename");
+                        ToolStripItem item = new ToolStripMenuItem("Rename");
                         item.Click += delegate
                         {
                             nodeTextBoxText.BeginEdit();
                         };
-                        treeContextMenu.MenuItems.Add(item);
+                        treeContextMenu.Items.Add(item);
                     }
                     if (node.IsVisible)
                     {
-                        MenuItem item = new MenuItem("Hide");
+                        ToolStripItem item = new ToolStripMenuItem("Hide");
                         item.Click += delegate
                         {
                             node.IsVisible = false;
                         };
-                        treeContextMenu.MenuItems.Add(item);
+                        treeContextMenu.Items.Add(item);
                     }
                     else
                     {
-                        MenuItem item = new MenuItem("Unhide");
+                        ToolStripItem item = new ToolStripMenuItem("Unhide");
                         item.Click += delegate
                         {
                             node.IsVisible = true;
                         };
-                        treeContextMenu.MenuItems.Add(item);
+                        treeContextMenu.Items.Add(item);
                     }
-                    treeContextMenu.MenuItems.Add(new MenuItem("-"));
+                    treeContextMenu.Items.Add(new ToolStripSeparator());
                     {
-                        MenuItem item = new MenuItem("Pen Color...");
+                        ToolStripItem item = new ToolStripMenuItem("Pen Color...");
                         item.Click += delegate
                         {
                             ColorDialog dialog = new ColorDialog { Color = node.PenColor.GetValueOrDefault() };
                             if (dialog.ShowDialog() == DialogResult.OK)
                                 node.PenColor = dialog.Color;
                         };
-                        treeContextMenu.MenuItems.Add(item);
+                        treeContextMenu.Items.Add(item);
                     }
                     {
-                        MenuItem item = new MenuItem("Reset Pen Color");
+                        ToolStripItem item = new ToolStripMenuItem("Reset Pen Color");
                         item.Click += delegate
                         {
                             node.PenColor = null;
                         };
-                        treeContextMenu.MenuItems.Add(item);
+                        treeContextMenu.Items.Add(item);
                     }
-                    treeContextMenu.MenuItems.Add(new MenuItem("-"));
+                    treeContextMenu.Items.Add(new ToolStripSeparator());
                     {
-                        MenuItem item = new MenuItem("Show in Tray") { Checked = _systemTray.Contains(node.Sensor) };
+                        ToolStripMenuItem item = new ToolStripMenuItem("Show in Tray") { Checked = _systemTray.Contains(node.Sensor) };
                         item.Click += delegate
                         {
                             if (item.Checked)
@@ -832,11 +832,11 @@ namespace LibreHardwareMonitor.UI
                             else
                                 _systemTray.Add(node.Sensor, true);
                         };
-                        treeContextMenu.MenuItems.Add(item);
+                        treeContextMenu.Items.Add(item);
                     }
                     if (_gadget != null)
                     {
-                        MenuItem item = new MenuItem("Show in Gadget") { Checked = _gadget.Contains(node.Sensor) };
+                        ToolStripMenuItem item = new ToolStripMenuItem("Show in Gadget") { Checked = _gadget.Contains(node.Sensor) };
                         item.Click += delegate
                         {
                             if (item.Checked)
@@ -848,29 +848,29 @@ namespace LibreHardwareMonitor.UI
                                 _gadget.Add(node.Sensor);
                             }
                         };
-                        treeContextMenu.MenuItems.Add(item);
+                        treeContextMenu.Items.Add(item);
                     }
                     if (node.Sensor.Control != null)
                     {
-                        treeContextMenu.MenuItems.Add(new MenuItem("-"));
+                        treeContextMenu.Items.Add(new ToolStripSeparator());
                         IControl control = node.Sensor.Control;
-                        MenuItem controlItem = new MenuItem("Control");
-                        MenuItem defaultItem = new MenuItem("Default") { Checked = control.ControlMode == ControlMode.Default };
-                        controlItem.MenuItems.Add(defaultItem);
+                        ToolStripMenuItem controlItem = new ToolStripMenuItem("Control");
+                        ToolStripItem defaultItem = new ToolStripMenuItem("Default") { Checked = control.ControlMode == ControlMode.Default };
+                        controlItem.DropDownItems.Add(defaultItem);
                         defaultItem.Click += delegate
                         {
                             control.SetDefault();
                         };
-                        MenuItem manualItem = new MenuItem("Manual");
-                        controlItem.MenuItems.Add(manualItem);
+                        ToolStripMenuItem manualItem = new ToolStripMenuItem("Manual");
+                        controlItem.DropDownItems.Add(manualItem);
                         manualItem.Checked = control.ControlMode == ControlMode.Software;
                         for (int i = 0; i <= 100; i += 5)
                         {
                             if (i <= control.MaxSoftwareValue &&
                                 i >= control.MinSoftwareValue)
                             {
-                                MenuItem item = new MenuItem(i + " %") { RadioCheck = true };
-                                manualItem.MenuItems.Add(item);
+                                ToolStripMenuItem item = new ToolStripRadioButtonMenuItem(i + " %");
+                                manualItem.DropDownItems.Add(item);
                                 item.Checked = control.ControlMode == ControlMode.Software && Math.Round(control.SoftwareValue) == i;
                                 int softwareValue = i;
                                 item.Click += delegate
@@ -879,7 +879,7 @@ namespace LibreHardwareMonitor.UI
                                 };
                             }
                         }
-                        treeContextMenu.MenuItems.Add(controlItem);
+                        treeContextMenu.Items.Add(controlItem);
                     }
 
                     treeContextMenu.Show(treeView, new Point(m.X, m.Y));
@@ -887,16 +887,16 @@ namespace LibreHardwareMonitor.UI
 
                 if (info.Node.Tag is HardwareNode hardwareNode && hardwareNode.Hardware != null)
                 {
-                    treeContextMenu.MenuItems.Clear();
+                    treeContextMenu.Items.Clear();
 
                     if (nodeTextBoxText.EditEnabled)
                     {
-                        MenuItem item = new MenuItem("Rename");
+                        ToolStripItem item = new ToolStripMenuItem("Rename");
                         item.Click += delegate
                         {
                             nodeTextBoxText.BeginEdit();
                         };
-                        treeContextMenu.MenuItems.Add(item);
+                        treeContextMenu.Items.Add(item);
                     }
 
                     treeContextMenu.Show(treeView, new Point(m.X, m.Y));

--- a/LibreHardwareMonitor/UI/MainForm.resx
+++ b/LibreHardwareMonitor/UI/MainForm.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="mainMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>373, 17</value>
-  </metadata>
   <metadata name="treeContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>

--- a/LibreHardwareMonitor/UI/NotifyIconAdv.cs
+++ b/LibreHardwareMonitor/UI/NotifyIconAdv.cs
@@ -263,25 +263,6 @@ namespace LibreHardwareMonitor.UI
             }
         }
 
-        public ContextMenu ContextMenu
-        {
-            get
-            {
-                if (_genericNotifyIcon != null)
-                    return _genericNotifyIcon.ContextMenu;
-
-
-                return _windowsNotifyIcon.ContextMenu;
-            }
-            set
-            {
-                if (_genericNotifyIcon != null)
-                    _genericNotifyIcon.ContextMenu = value;
-                else
-                    _windowsNotifyIcon.ContextMenu = value;
-            }
-        }
-
         public ContextMenuStrip ContextMenuStrip
         {
             get
@@ -410,7 +391,6 @@ namespace LibreHardwareMonitor.UI
             public string BalloonTipText { get; set; }
             public ToolTipIcon BalloonTipIcon { get; set; }
             public string BalloonTipTitle { get; set; }
-            public ContextMenu ContextMenu { get; set; }
             public ContextMenuStrip ContextMenuStrip { get; set; }
 
             public Icon Icon
@@ -494,7 +474,6 @@ namespace LibreHardwareMonitor.UI
                         UpdateNotifyIcon(false);
                         _window.DestroyHandle();
                         _window = null;
-                        ContextMenu = null;
                         ContextMenuStrip = null;
                     }
                 }
@@ -545,24 +524,12 @@ namespace LibreHardwareMonitor.UI
 
             private void ShowContextMenu()
             {
-                if (ContextMenu == null && ContextMenuStrip == null)
+                if (ContextMenuStrip == null)
                     return;
 
                 NativeMethods.Point p = new NativeMethods.Point();
                 NativeMethods.GetCursorPos(ref p);
                 NativeMethods.SetForegroundWindow(new HandleRef(_window, _window.Handle));
-
-                if (ContextMenu != null)
-                {
-                    ContextMenu.GetType().InvokeMember("OnPopup",
-                      BindingFlags.NonPublic | BindingFlags.InvokeMethod |
-                      BindingFlags.Instance, null, ContextMenu,
-                      new object[] { EventArgs.Empty });
-
-                    NativeMethods.TrackPopupMenuEx(new HandleRef(ContextMenu, ContextMenu.Handle), 72, p.X, p.Y, new HandleRef(_window, _window.Handle), IntPtr.Zero);
-                    NativeMethods.PostMessage(new HandleRef(_window, _window.Handle), WM_NULL, 0, 0);
-                    return;
-                }
 
                 ContextMenuStrip?.GetType().InvokeMember("ShowInTaskbar",
                                                          BindingFlags.NonPublic | BindingFlags.InvokeMethod |
@@ -670,12 +637,6 @@ namespace LibreHardwareMonitor.UI
 
             private void ProcessInitMenuPopup(ref Message message)
             {
-                if (ContextMenu != null &&
-                    (bool)ContextMenu.GetType().InvokeMember("ProcessInitMenuPopup", BindingFlags.NonPublic | BindingFlags.InvokeMethod | BindingFlags.Instance, null, ContextMenu, new object[] { message.WParam }))
-                {
-                    return;
-                }
-
                 _window.DefWndProc(ref message);
             }
 
@@ -717,7 +678,7 @@ namespace LibreHardwareMonitor.UI
                                 ProcessMouseDown(MouseButtons.Right, false);
                                 return;
                             case WM_RBUTTONUP:
-                                if (ContextMenu != null || ContextMenuStrip != null)
+                                if (ContextMenuStrip != null)
                                     ShowContextMenu();
                                 ProcessMouseUp(MouseButtons.Right);
                                 return;

--- a/LibreHardwareMonitor/UI/PlotPanel.cs
+++ b/LibreHardwareMonitor/UI/PlotPanel.cs
@@ -46,7 +46,7 @@ namespace LibreHardwareMonitor.UI
             SetDpi();
             _model = CreatePlotModel();
 
-            _plot = new PlotView { Dock = DockStyle.Fill, Model = _model, BackColor = Color.White, ContextMenu = CreateMenu() };
+            _plot = new PlotView { Dock = DockStyle.Fill, Model = _model, BackColor = Color.White, ContextMenuStrip = CreateMenu() };
             
             UpdateAxesPosition();
 
@@ -66,20 +66,20 @@ namespace LibreHardwareMonitor.UI
             }
         }
 
-        private ContextMenu CreateMenu()
+        private ContextMenuStrip CreateMenu()
         {
-            ContextMenu menu = new ContextMenu();
+            ContextMenuStrip menu = new ContextMenuStrip();
 
-            MenuItem stackedAxesMenuItem = new MenuItem("Stacked Axes");
+            ToolStripMenuItem stackedAxesMenuItem = new ToolStripMenuItem("Stacked Axes");
             _stackedAxes = new UserOption("stackedAxes", true, stackedAxesMenuItem, _settings);
             _stackedAxes.Changed += (sender, e) =>
             {
                 UpdateAxesPosition();
                 InvalidatePlot();
             };
-            menu.MenuItems.Add(stackedAxesMenuItem);
+            menu.Items.Add(stackedAxesMenuItem);
 
-            MenuItem showAxesLabelsMenuItem = new MenuItem("Show Axes Labels");
+            ToolStripMenuItem showAxesLabelsMenuItem = new ToolStripMenuItem("Show Axes Labels");
             _showAxesLabels = new UserOption("showAxesLabels", true, showAxesLabelsMenuItem, _settings);
             _showAxesLabels.Changed += (sender, e) =>
             {
@@ -88,28 +88,28 @@ namespace LibreHardwareMonitor.UI
                 else
                     _model.PlotMargins = new OxyThickness(0);
             };
-            menu.MenuItems.Add(showAxesLabelsMenuItem);
+            menu.Items.Add(showAxesLabelsMenuItem);
 
-            MenuItem timeAxisMenuItem = new MenuItem("Time Axis");
-            MenuItem[] timeAxisMenuItems =
-                { new MenuItem("Enable Zoom"),
-                new MenuItem("Auto", (s, e) => { TimeAxisZoom(0, double.NaN); }),
-                new MenuItem("5 min", (s, e) => { TimeAxisZoom(0, 5 * 60); }),
-                new MenuItem("10 min", (s, e) => { TimeAxisZoom(0, 10 * 60); }),
-                new MenuItem("20 min", (s, e) => { TimeAxisZoom(0, 20 * 60); }),
-                new MenuItem("30 min", (s, e) => { TimeAxisZoom(0, 30 * 60); }),
-                new MenuItem("45 min", (s, e) => { TimeAxisZoom(0, 45 * 60); }),
-                new MenuItem("1 h", (s, e) => { TimeAxisZoom(0, 60 * 60); }),
-                new MenuItem("1.5 h", (s, e) => { TimeAxisZoom(0, 1.5 * 60 * 60); }),
-                new MenuItem("2 h", (s, e) => { TimeAxisZoom(0, 2 * 60 * 60); }),
-                new MenuItem("3 h", (s, e) => { TimeAxisZoom(0, 3 * 60 * 60); }),
-                new MenuItem("6 h", (s, e) => { TimeAxisZoom(0, 6 * 60 * 60); }),
-                new MenuItem("12 h", (s, e) => { TimeAxisZoom(0, 12 * 60 * 60); }),
-                new MenuItem("24 h", (s, e) => { TimeAxisZoom(0, 24 * 60 * 60); }) };
+            ToolStripMenuItem timeAxisMenuItem = new ToolStripMenuItem("Time Axis");
+            ToolStripMenuItem[] timeAxisMenuItems =
+                { new ToolStripMenuItem("Enable Zoom"),
+                new ToolStripMenuItem("Auto", null, (s, e) => { TimeAxisZoom(0, double.NaN); }),
+                new ToolStripMenuItem("5 min", null, (s, e) => { TimeAxisZoom(0, 5 * 60); }),
+                new ToolStripMenuItem("10 min", null, (s, e) => { TimeAxisZoom(0, 10 * 60); }),
+                new ToolStripMenuItem("20 min", null, (s, e) => { TimeAxisZoom(0, 20 * 60); }),
+                new ToolStripMenuItem("30 min", null, (s, e) => { TimeAxisZoom(0, 30 * 60); }),
+                new ToolStripMenuItem("45 min", null, (s, e) => { TimeAxisZoom(0, 45 * 60); }),
+                new ToolStripMenuItem("1 h", null, (s, e) => { TimeAxisZoom(0, 60 * 60); }),
+                new ToolStripMenuItem("1.5 h", null, (s, e) => { TimeAxisZoom(0, 1.5 * 60 * 60); }),
+                new ToolStripMenuItem("2 h", null, (s, e) => { TimeAxisZoom(0, 2 * 60 * 60); }),
+                new ToolStripMenuItem("3 h", null, (s, e) => { TimeAxisZoom(0, 3 * 60 * 60); }),
+                new ToolStripMenuItem("6 h", null, (s, e) => { TimeAxisZoom(0, 6 * 60 * 60); }),
+                new ToolStripMenuItem("12 h", null, (s, e) => { TimeAxisZoom(0, 12 * 60 * 60); }),
+                new ToolStripMenuItem("24 h", null, (s, e) => { TimeAxisZoom(0, 24 * 60 * 60); }) };
 
-            foreach (MenuItem mi in timeAxisMenuItems)
-                timeAxisMenuItem.MenuItems.Add(mi);
-            menu.MenuItems.Add(timeAxisMenuItem);
+            foreach (ToolStripItem mi in timeAxisMenuItems)
+                timeAxisMenuItem.DropDownItems.Add(mi);
+            menu.Items.Add(timeAxisMenuItem);
 
             _timeAxisEnableZoom = new UserOption("timeAxisEnableZoom", true, timeAxisMenuItems[0], _settings);
             _timeAxisEnableZoom.Changed += (sender, e) =>
@@ -117,14 +117,14 @@ namespace LibreHardwareMonitor.UI
                 _timeAxis.IsZoomEnabled = _timeAxisEnableZoom.Value;
             };
 
-            MenuItem yAxesMenuItem = new MenuItem("Value Axes");
-            MenuItem[] yAxesMenuItems =
-                { new MenuItem("Enable Zoom"),
-                new MenuItem("Autoscale All", (s, e) => { AutoscaleAllYAxes(); }) };
+            ToolStripMenuItem yAxesMenuItem = new ToolStripMenuItem("Value Axes");
+            ToolStripMenuItem[] yAxesMenuItems =
+                { new ToolStripMenuItem("Enable Zoom"),
+                new ToolStripMenuItem("Autoscale All", null, (s, e) => { AutoscaleAllYAxes(); }) };
 
-            foreach (MenuItem mi in yAxesMenuItems)
-                yAxesMenuItem.MenuItems.Add(mi);
-            menu.MenuItems.Add(yAxesMenuItem);
+            foreach (ToolStripItem mi in yAxesMenuItems)
+                yAxesMenuItem.DropDownItems.Add(mi);
+            menu.Items.Add(yAxesMenuItem);
 
             _yAxesEnableZoom = new UserOption("yAxesEnableZoom", true, yAxesMenuItems[0], _settings);
             _yAxesEnableZoom.Changed += (sender, e) =>

--- a/LibreHardwareMonitor/UI/SensorGadget.cs
+++ b/LibreHardwareMonitor/UI/SensorGadget.cs
@@ -131,10 +131,10 @@ namespace LibreHardwareMonitor.UI
             SetFontSize(settings.GetValue("sensorGadget.FontSize", 7.5f));
             Resize(settings.GetValue("sensorGadget.Width", Size.Width));
 
-            ContextMenu contextMenu = new ContextMenu();
-            MenuItem hardwareNamesItem = new MenuItem("Hardware Names");
-            contextMenu.MenuItems.Add(hardwareNamesItem);
-            MenuItem fontSizeMenu = new MenuItem("Font Size");
+            ContextMenuStrip contextMenuStrip = new ContextMenuStrip();
+            ToolStripMenuItem hardwareNamesItem = new ToolStripMenuItem("Hardware Names");
+            contextMenuStrip.Items.Add(hardwareNamesItem);
+            ToolStripMenuItem fontSizeMenu = new ToolStripMenuItem("Font Size");
             for (int i = 0; i < 4; i++)
             {
                 float size;
@@ -148,42 +148,42 @@ namespace LibreHardwareMonitor.UI
                     default: throw new NotImplementedException();
                 }
 
-                MenuItem item = new MenuItem(name) { Checked = _fontSize == size };
+                ToolStripItem item = new ToolStripMenuItem(name) { Checked = _fontSize == size };
                 item.Click += delegate
                 {
                     SetFontSize(size);
                     settings.SetValue("sensorGadget.FontSize", size);
-                    foreach (MenuItem mi in fontSizeMenu.MenuItems)
+                    foreach (ToolStripMenuItem mi in fontSizeMenu.DropDownItems)
                         mi.Checked = mi == item;
                 };
-                fontSizeMenu.MenuItems.Add(item);
+                fontSizeMenu.DropDownItems.Add(item);
             }
-            contextMenu.MenuItems.Add(fontSizeMenu);
-            contextMenu.MenuItems.Add(new MenuItem("-"));
-            MenuItem lockItem = new MenuItem("Lock Position and Size");
-            contextMenu.MenuItems.Add(lockItem);
-            contextMenu.MenuItems.Add(new MenuItem("-"));
-            MenuItem alwaysOnTopItem = new MenuItem("Always on Top");
-            contextMenu.MenuItems.Add(alwaysOnTopItem);
-            MenuItem opacityMenu = new MenuItem("Opacity");
-            contextMenu.MenuItems.Add(opacityMenu);
+            contextMenuStrip.Items.Add(fontSizeMenu);
+            contextMenuStrip.Items.Add(new ToolStripSeparator());
+            ToolStripMenuItem lockItem = new ToolStripMenuItem("Lock Position and Size");
+            contextMenuStrip.Items.Add(lockItem);
+            contextMenuStrip.Items.Add(new ToolStripSeparator());
+            ToolStripMenuItem alwaysOnTopItem = new ToolStripMenuItem("Always on Top");
+            contextMenuStrip.Items.Add(alwaysOnTopItem);
+            ToolStripMenuItem opacityMenu = new ToolStripMenuItem("Opacity");
+            contextMenuStrip.Items.Add(opacityMenu);
             Opacity = (byte)settings.GetValue("sensorGadget.Opacity", 255);
 
             for (int i = 0; i < 5; i++)
             {
-                MenuItem item = new MenuItem((20 * (i + 1)).ToString() + " %");
+                ToolStripMenuItem item = new ToolStripMenuItem((20 * (i + 1)).ToString() + " %");
                 byte o = (byte)(51 * (i + 1));
                 item.Checked = Opacity == o;
                 item.Click += delegate
                 {
                     Opacity = o;
                     settings.SetValue("sensorGadget.Opacity", Opacity);
-                    foreach (MenuItem mi in opacityMenu.MenuItems)
+                    foreach (ToolStripMenuItem mi in opacityMenu.DropDownItems)
                         mi.Checked = mi == item;
                 };
-                opacityMenu.MenuItems.Add(item);
+                opacityMenu.DropDownItems.Add(item);
             }
-            ContextMenu = contextMenu;
+            ContextMenuStrip = contextMenuStrip;
 
             _hardwareNames = new UserOption("sensorGadget.Hardwarenames", true, hardwareNamesItem, settings);
             _hardwareNames.Changed += delegate

--- a/LibreHardwareMonitor/UI/SensorNotifyIcon.cs
+++ b/LibreHardwareMonitor/UI/SensorNotifyIcon.cs
@@ -43,21 +43,21 @@ namespace LibreHardwareMonitor.UI
             Color = settings.GetValue(new Identifier(sensor.Identifier, "traycolor").ToString(), defaultColor);
 
             _pen = new Pen(Color.FromArgb(96, Color.Black));
-            ContextMenu contextMenu = new ContextMenu();
-            MenuItem hideShowItem = new MenuItem("Hide/Show");
+            ContextMenuStrip contextMenuStrip = new ContextMenuStrip();
+            ToolStripItem hideShowItem = new ToolStripMenuItem("Hide/Show");
             hideShowItem.Click += delegate
             {
                 sensorSystemTray.SendHideShowCommand();
             };
-            contextMenu.MenuItems.Add(hideShowItem);
-            contextMenu.MenuItems.Add(new MenuItem("-"));
-            MenuItem removeItem = new MenuItem("Remove Sensor");
+            contextMenuStrip.Items.Add(hideShowItem);
+            contextMenuStrip.Items.Add(new ToolStripSeparator());
+            ToolStripItem removeItem = new ToolStripMenuItem("Remove Sensor");
             removeItem.Click += delegate
             {
                 sensorSystemTray.Remove(Sensor);
             };
-            contextMenu.MenuItems.Add(removeItem);
-            MenuItem colorItem = new MenuItem("Change Color...");
+            contextMenuStrip.Items.Add(removeItem);
+            ToolStripItem colorItem = new ToolStripMenuItem("Change Color...");
             colorItem.Click += delegate
             {
                 ColorDialog dialog = new ColorDialog { Color = Color };
@@ -68,15 +68,15 @@ namespace LibreHardwareMonitor.UI
                       "traycolor").ToString(), Color);
                 }
             };
-            contextMenu.MenuItems.Add(colorItem);
-            contextMenu.MenuItems.Add(new MenuItem("-"));
-            MenuItem exitItem = new MenuItem("Exit");
+            contextMenuStrip.Items.Add(colorItem);
+            contextMenuStrip.Items.Add(new ToolStripSeparator());
+            ToolStripItem exitItem = new ToolStripMenuItem("Exit");
             exitItem.Click += delegate
             {
                 sensorSystemTray.SendExitCommand();
             };
-            contextMenu.MenuItems.Add(exitItem);
-            _notifyIcon.ContextMenu = contextMenu;
+            contextMenuStrip.Items.Add(exitItem);
+            _notifyIcon.ContextMenuStrip = contextMenuStrip;
             _notifyIcon.DoubleClick += delegate
             {
                 sensorSystemTray.SendHideShowCommand();

--- a/LibreHardwareMonitor/UI/SystemTray.cs
+++ b/LibreHardwareMonitor/UI/SystemTray.cs
@@ -31,21 +31,21 @@ namespace LibreHardwareMonitor.UI
 
             _mainIcon = new NotifyIconAdv();
 
-            ContextMenu contextMenu = new ContextMenu();
-            MenuItem hideShowItem = new MenuItem("Hide/Show");
+            ContextMenuStrip contextMenuStrip = new ContextMenuStrip();
+            ToolStripItem hideShowItem = new ToolStripMenuItem("Hide/Show");
             hideShowItem.Click += delegate
             {
                 SendHideShowCommand();
             };
-            contextMenu.MenuItems.Add(hideShowItem);
-            contextMenu.MenuItems.Add(new MenuItem("-"));
-            MenuItem exitItem = new MenuItem("Exit");
+            contextMenuStrip.Items.Add(hideShowItem);
+            contextMenuStrip.Items.Add(new ToolStripSeparator());
+            ToolStripItem exitItem = new ToolStripMenuItem("Exit");
             exitItem.Click += delegate
             {
                 SendExitCommand();
             };
-            contextMenu.MenuItems.Add(exitItem);
-            _mainIcon.ContextMenu = contextMenu;
+            contextMenuStrip.Items.Add(exitItem);
+            _mainIcon.ContextMenuStrip = contextMenuStrip;
             _mainIcon.DoubleClick += delegate
             {
                 SendHideShowCommand();

--- a/LibreHardwareMonitor/UI/ToolStripRadioButtonMenuItem.cs
+++ b/LibreHardwareMonitor/UI/ToolStripRadioButtonMenuItem.cs
@@ -1,0 +1,255 @@
+﻿using System;
+using System.Drawing;
+using System.Windows.Forms;
+using System.Windows.Forms.VisualStyles;
+
+namespace LibreHardwareMonitor.UI
+{
+    /// <summary>
+    /// https://docs.microsoft.com/en-us/dotnet/desktop/winforms/controls/how-to-display-option-buttons-in-a-menustrip-windows-forms
+    /// </summary>
+    public class ToolStripRadioButtonMenuItem : ToolStripMenuItem
+    {
+        public ToolStripRadioButtonMenuItem()
+            : base()
+        {
+            Initialize();
+        }
+
+        public ToolStripRadioButtonMenuItem(string text)
+            : base(text, null, (EventHandler)null)
+        {
+            Initialize();
+        }
+
+        public ToolStripRadioButtonMenuItem(Image image)
+            : base(null, image, (EventHandler)null)
+        {
+            Initialize();
+        }
+
+        public ToolStripRadioButtonMenuItem(string text, Image image)
+            : base(text, image, (EventHandler)null)
+        {
+            Initialize();
+        }
+
+        public ToolStripRadioButtonMenuItem(string text, Image image,
+            EventHandler onClick)
+            : base(text, image, onClick)
+        {
+            Initialize();
+        }
+
+        public ToolStripRadioButtonMenuItem(string text, Image image,
+            EventHandler onClick, string name)
+            : base(text, image, onClick, name)
+        {
+            Initialize();
+        }
+
+        public ToolStripRadioButtonMenuItem(string text, Image image,
+            params ToolStripItem[] dropDownItems)
+            : base(text, image, dropDownItems)
+        {
+            Initialize();
+        }
+
+        public ToolStripRadioButtonMenuItem(string text, Image image,
+            EventHandler onClick, Keys shortcutKeys)
+            : base(text, image, onClick)
+        {
+            Initialize();
+            ShortcutKeys = shortcutKeys;
+        }
+
+        // Called by all constructors to initialize CheckOnClick.
+        private void Initialize()
+        {
+            CheckOnClick = true;
+        }
+
+        protected override void OnCheckedChanged(EventArgs e)
+        {
+            base.OnCheckedChanged(e);
+
+            // If this item is no longer in the checked state or if its
+            // parent has not yet been initialized, do nothing.
+            if (!Checked || Parent == null) return;
+
+            // Clear the checked state for all siblings.
+            foreach (ToolStripItem item in Parent.Items)
+            {
+                if (item is ToolStripRadioButtonMenuItem radioItem
+                    && radioItem != this
+                    && radioItem.Checked)
+                {
+                    radioItem.Checked = false;
+
+                    // Only one item can be selected at a time,
+                    // so there is no need to continue.
+                    return;
+                }
+            }
+        }
+
+        protected override void OnClick(EventArgs e)
+        {
+            // If the item is already in the checked state, do not call
+            // the base method, which would toggle the value.
+            if (Checked) return;
+
+            base.OnClick(e);
+        }
+
+        // Let the item paint itself, and then paint the RadioButton
+        // where the check mark is normally displayed.
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            if (Image != null)
+            {
+                // If the client sets the Image property, the selection behavior
+                // remains unchanged, but the RadioButton is not displayed and the
+                // selection is indicated only by the selection rectangle.
+                base.OnPaint(e);
+                return;
+            }
+            else
+            {
+                // If the Image property is not set, call the base OnPaint method
+                // with the CheckState property temporarily cleared to prevent
+                // the check mark from being painted.
+                CheckState currentState = CheckState;
+                CheckState = CheckState.Unchecked;
+                base.OnPaint(e);
+                CheckState = currentState;
+            }
+
+            // Determine the correct state of the RadioButton.
+            RadioButtonState buttonState = RadioButtonState.UncheckedNormal;
+            if (Enabled)
+            {
+                if (mouseDownState)
+                {
+                    if (Checked)
+                        buttonState = RadioButtonState.CheckedPressed;
+                    else
+                        buttonState = RadioButtonState.UncheckedPressed;
+                }
+                else if (mouseHoverState)
+                {
+                    if (Checked) 
+                        buttonState = RadioButtonState.CheckedHot;
+                    else
+                        buttonState = RadioButtonState.UncheckedHot;
+                }
+                else
+                {
+                    if (Checked)
+                        buttonState = RadioButtonState.CheckedNormal;
+                }
+            }
+            else
+            {
+                if (Checked)
+                    buttonState = RadioButtonState.CheckedDisabled;
+                else 
+                    buttonState = RadioButtonState.UncheckedDisabled;
+            }
+
+            // Calculate the position at which to display the RadioButton.
+            int offset = (ContentRectangle.Height -
+                RadioButtonRenderer.GetGlyphSize(
+                e.Graphics, buttonState).Height) / 2;
+
+            Point imageLocation = new Point(
+                ContentRectangle.Location.X + 4,
+                ContentRectangle.Location.Y + offset);
+
+            // Paint the RadioButton.
+            RadioButtonRenderer.DrawRadioButton(e.Graphics, imageLocation, buttonState);
+        }
+
+        private bool mouseHoverState;
+
+        protected override void OnMouseEnter(EventArgs e)
+        {
+            mouseHoverState = true;
+
+            // Force the item to repaint with the new RadioButton state.
+            Invalidate();
+
+            base.OnMouseEnter(e);
+        }
+
+        protected override void OnMouseLeave(EventArgs e)
+        {
+            mouseHoverState = false;
+            base.OnMouseLeave(e);
+        }
+
+        private bool mouseDownState;
+
+        protected override void OnMouseDown(MouseEventArgs e)
+        {
+            mouseDownState = true;
+
+            // Force the item to repaint with the new RadioButton state.
+            Invalidate();
+
+            base.OnMouseDown(e);
+        }
+
+        protected override void OnMouseUp(MouseEventArgs e)
+        {
+            mouseDownState = false;
+            base.OnMouseUp(e);
+        }
+
+        // Enable the item only if its parent item is in the checked state
+        // and its Enabled property has not been explicitly set to false.
+        public override bool Enabled
+        {
+            get
+            {
+                // Use the base value in design mode to prevent the designer
+                // from setting the base value to the calculated value.
+                if (!DesignMode
+                    && OwnerItem is ToolStripMenuItem ownerMenuItem
+                    && ownerMenuItem.CheckOnClick)
+                {
+                    return base.Enabled && ownerMenuItem.Checked;
+                }
+                else
+                {
+                    return base.Enabled;
+                }
+            }
+            set
+            {
+                base.Enabled = value;
+            }
+        }
+
+        // When OwnerItem becomes available, if it is a ToolStripMenuItem
+        // with a CheckOnClick property value of true, subscribe to its
+        // CheckedChanged event.
+        protected override void OnOwnerChanged(EventArgs e)
+        {
+            if (OwnerItem is ToolStripMenuItem ownerMenuItem
+                && ownerMenuItem.CheckOnClick)
+            {
+                ownerMenuItem.CheckedChanged +=
+                    new EventHandler(OwnerMenuItem_CheckedChanged);
+            }
+            base.OnOwnerChanged(e);
+        }
+
+        // When the checked state of the parent item changes,
+        // repaint the item so that the new Enabled state is displayed.
+        private void OwnerMenuItem_CheckedChanged(object sender, EventArgs e)
+        {
+            Invalidate();
+        }
+    }
+}

--- a/LibreHardwareMonitor/UI/UserOption.cs
+++ b/LibreHardwareMonitor/UI/UserOption.cs
@@ -14,11 +14,11 @@ namespace LibreHardwareMonitor.UI
     {
         private readonly string _name;
         private bool _value;
-        private readonly MenuItem _menuItem;
+        private readonly ToolStripMenuItem _menuItem;
         private event EventHandler _changed;
         private readonly PersistentSettings _settings;
 
-        public UserOption(string name, bool value, MenuItem menuItem, PersistentSettings settings)
+        public UserOption(string name, bool value, ToolStripMenuItem menuItem, PersistentSettings settings)
         {
             _settings = settings;
             _name = name;

--- a/LibreHardwareMonitor/UI/UserRadioGroup.cs
+++ b/LibreHardwareMonitor/UI/UserRadioGroup.cs
@@ -14,11 +14,11 @@ namespace LibreHardwareMonitor.UI
     {
         private readonly string _name;
         private int _value;
-        private readonly MenuItem[] _menuItems;
+        private readonly ToolStripMenuItem[] _menuItems;
         private event EventHandler _changed;
         private readonly PersistentSettings _settings;
 
-        public UserRadioGroup(string name, int value, MenuItem[] menuItems, PersistentSettings settings)
+        public UserRadioGroup(string name, int value, ToolStripMenuItem[] menuItems, PersistentSettings settings)
         {
             _settings = settings;
             _name = name;


### PR DESCRIPTION
ContextMenu -> ContextMenuStrip
MenuItem -> ToolStripItem
MainMenu -> MenuStrip

Helps with #286, still requires porting the WMI code however