### PR TITLE
Add missing clamp around pump speed index

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Controller/Nzxt/KrakenX3.cs
+++ b/LibreHardwareMonitorLib/Hardware/Controller/Nzxt/KrakenX3.cs
@@ -150,7 +150,8 @@ namespace LibreHardwareMonitor.Hardware.Controller.Nzxt
                     }
                     else if (_pump.Value != _rawData[19])
                     {
-                        byte pumpSpeedIndex = (byte)_pump.Value;
+                        float value = _pump.Value.GetValueOrDefault();
+                        byte pumpSpeedIndex = (byte)(value > 100 ? 100 : (value < 0) ? 0 : value); // Clamp the value, anything out of range will fail
                         _stream.Write(_setPumpTargetMap[pumpSpeedIndex]);
                     }
                     else


### PR DESCRIPTION
The pump speed index is clamped on line 91 but was not clamped on line 154.
This was throwing an IndexOutOfRangeException on my machine.