### PR TITLE
Fix error check.

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Network/Network.cs
+++ b/LibreHardwareMonitorLib/Hardware/Network/Network.cs
@@ -98,7 +98,7 @@ namespace LibreHardwareMonitor.Hardware.Network
                 _bytesDownloaded = interfaceStats.BytesReceived;
                 _lastTick = newTick;
             }
-            catch (NetworkInformationException networkInformationException) when (unchecked(networkInformationException.NativeErrorCode == (int)0x80004005))
+            catch (NetworkInformationException networkInformationException) when (unchecked(networkInformationException.HResult == (int)0x80004005))
             {
                 foreach (NetworkInterface networkInterface in NetworkInterface.GetAllNetworkInterfaces())
                 {


### PR DESCRIPTION
In case when the interface is removed (File Not Found error), the value of NativeErrorCode is 2, while the value of HResult is 0x80004005.

Fixes fix of #191.