### PR TITLE
Fixes: Fan speed reporting and control for IT8655E sensors.

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -75,7 +75,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                          chip == Chip.IT8688E ||
                          chip == Chip.IT8628E ||
                          chip == Chip.IT8620E ||
-                         chip == Chip.IT879XE;
+                         chip == Chip.IT879XE ||
+                         chip == Chip.IT8655E;
 
             switch (chip)
             {


### PR DESCRIPTION
### Problem

Motherboards with IT8655E sensors were observed to have at least 2 problems:

1. Fan speed readings were incorrect
1. Fan speed controls were not working

This was observed in at least 4 cases: #246 (see screenshot), #265 (see screenshot), #277 and in my own case (see comment in 277)

### Solution

While comparing following 2 files:

1. https://github.com/torvalds/linux/blob/master/drivers/hwmon/it87.c
2. https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/master/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs

I realized that there were 2 sets of fan control registers (default, ext) and default values for IT8655E were not working. This change uses alternate (ext) set of registers for IT8655E which are found to be working.

### Scope

Tested on ASUS EX-A320M-GAMING. 