### PR TITLE
Add support for AMD Ryzen 5000 processors

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
@@ -164,7 +164,7 @@ namespace LibreHardwareMonitor.Hardware.CPU
                     Ring0.WritePciConfig(0x00, FAMILY_17H_PCI_CONTROL_REGISTER, F17H_M01H_SVI + 0x8);
                     Ring0.ReadPciConfig(0x00, FAMILY_17H_PCI_CONTROL_REGISTER + 4, out smuSvi0Tfn);
 
-                    bool isZen2 = false;
+                    bool supportsPerCCDTemperatures = false;
 
                     // TODO: find a better way because these will probably keep changing in the future.
 
@@ -176,14 +176,15 @@ namespace LibreHardwareMonitor.Hardware.CPU
                         {
                             sviPlane0Offset = F17H_M01H_SVI + 0x14;
                             sviPlane1Offset = F17H_M01H_SVI + 0x10;
-                            isZen2 = true;
+                            supportsPerCCDTemperatures = true;
                             break;
                         }
                         case 0x71: // Zen 2.
+                        case 0x21: // Zen 3.
                         {
                             sviPlane0Offset = F17H_M01H_SVI + 0x10;
                             sviPlane1Offset = F17H_M01H_SVI + 0xC;
-                            isZen2 = true;
+                            supportsPerCCDTemperatures = true;
                             break;
                         }
                         default: // Zen and Zen+.
@@ -268,9 +269,9 @@ namespace LibreHardwareMonitor.Hardware.CPU
                         _coreTemperatureTctlTdie.Value = t;
                         _hardware.ActivateSensor(_coreTemperatureTctlTdie);
                     }
-
+                     
                     // Tested only on R5 3600 & Threadripper 3960X.
-                    if (isZen2)
+                    if (supportsPerCCDTemperatures)
                     {
                         for (uint i = 0; i < _ccdTemperatures.Length; i++)
                         {
@@ -339,7 +340,7 @@ namespace LibreHardwareMonitor.Hardware.CPU
                 }
 
                 // SoC (0x02), not every Zen cpu has this voltage.
-                if (cpu.Model == 0x71 || cpu.Model == 0x31 || (smuSvi0Tfn & 0x02) == 0)
+                if (cpu.Model == 0x21 || cpu.Model == 0x71 || cpu.Model == 0x31 || (smuSvi0Tfn & 0x02) == 0)
                 {
                     svi0PlaneXVddCor = (smuSvi0TelPlane1 >> 16) & 0xff;
                     vcc = 1.550 - vidStep * svi0PlaneXVddCor;

--- a/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
@@ -269,7 +269,7 @@ namespace LibreHardwareMonitor.Hardware.CPU
                         _coreTemperatureTctlTdie.Value = t;
                         _hardware.ActivateSensor(_coreTemperatureTctlTdie);
                     }
-                     
+
                     // Tested only on R5 3600 & Threadripper 3960X.
                     if (supportsPerCCDTemperatures)
                     {

--- a/LibreHardwareMonitorLib/Hardware/Cpu/CpuGroup.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/CpuGroup.cs
@@ -51,6 +51,7 @@ namespace LibreHardwareMonitor.Hardware.CPU
                                 _hardware.Add(new Amd10Cpu(index, coreThreads, settings));
                                 break;
                             case 0x17:
+                            case 0x19:
                                 _hardware.Add(new Amd17Cpu(index, coreThreads, settings));
                                 break;
                             default:

--- a/LibreHardwareMonitorLib/Hardware/Cpu/CpuId.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/CpuId.cs
@@ -168,7 +168,7 @@ namespace LibreHardwareMonitor.Hardware.CPU
                     threadMaskWith = 0;
                     coreMaskWith = NextLog2(corePerPackage);
 
-                    if (Family == 0x17)
+                    if (Family == 0x17 || Family == 0x19)
                     {
                         // ApicIdCoreIdSize: APIC ID size.
                         // cores per DIE


### PR DESCRIPTION
resolves #310 (may not work for all future zen 3 chips, but should good for ryzen 5000)

Zen 3 seems to much be pretty much the same as Zen2 sensor-wise. Just a new a family and model.

I discovered a couple oddities while exploring and testing though.

1. Calculation of frequencies is currently done with a hard-coded base clock of 100MHz. We should be using the sensed base-clock, 99.8MHz on my system. We should create a seperate issue for that.
2. While per-core frequencies/VID/multipliers seem mostly accurate, it seems that the way we are currently setting CPU affinities may not be working. There are many duplicated values and values not included, seems like they are running on the wrong cores. This is what made me think the per-core stats weren't wroking at all originally. Again, probably separate issue.

![ryzen 5800x test](https://i.imgur.com/TrAtYOF.png)