### PR TITLE
Add CI build number to project version when PR is merged

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,12 @@ jobs:
 
       - name: Update version
         if: github.event.action == 'closed' && github.event.pull_request.merged == true
-        run: "(Get-Content Directory.Build.props) | % { $_ -replace '<Version>(.+?)</Version>', '<Version>$1-ci${{github.run_number}}</Version>' } | Set-Content Directory.Build.props"
+        run: |
+            (Get-Content Directory.Build.props) | % { 
+                $m = [regex]::match($_, '<Version>(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?</Version>');
+                if(!$m.Success -or $m.Groups[4].Success -or $m.Groups[5].Success) { $_; }
+                else { $_ -replace $m.Value, ("<Version>{0}.{1}.{2}-ci${{ github.run_number }}</Version>" -f $m.Groups[1].Value,$m.Groups[2].Value,([convert]::ToInt32($m.Groups[3].Value)+1)); }
+            } | Set-Content Directory.Build.props
         
       - name: NuGet restore
         run: nuget restore LibreHardwareMonitor.sln

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,13 @@ jobs:
           path: |
             bin/Release/netstandard2.0
 
+      - name: Publish net50
+        uses: actions/upload-artifact@v2
+        with:
+          name: LibreHardwareMonitorLib-net50
+          path: |
+            bin/Release/net5.0
+
       - name: Publish nupkg
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,32 +5,46 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    types: [opened, synchronize, reopened, closed]
 
 jobs:
   build:
     runs-on: windows-latest
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    if: contains(github.event.head_commit.message, 'ci skip') == false
 
     steps:
       - uses: actions/checkout@v2
       - uses: nuget/setup-nuget@v1
       - uses: microsoft/setup-msbuild@v1.0.2
+
+      - name: Update version
+        if: github.event.action == 'closed' && github.event.pull_request.merged == true
+        run: "(Get-Content Directory.Build.props) | % { $_ -replace '<Version>(.+?)</Version>', '<Version>$1-ci${{github.run_number}}</Version>' } | Set-Content Directory.Build.props"
         
       - name: NuGet restore
         run: nuget restore LibreHardwareMonitor.sln
     
       - name: Build
         run: msbuild LibreHardwareMonitor.sln -p:Configuration=Release -m
-        
-      - uses: actions/upload-artifact@v2
+     
+      - name: Publish net452
+        uses: actions/upload-artifact@v2
         with:
-          name: Binaries
+          name: LibreHardwareMonitor-net452
           path: |
             bin/Release/net452
-        
-      - uses: actions/upload-artifact@v2
+            
+      - name: Publish netstandard20
+        uses: actions/upload-artifact@v2
         with:
-          name: NuGet
+          name: LibreHardwareMonitor-netstandard20
+          path: |
+            bin/Release/netstandard2.0
+
+      - name: Publish nupkg
+        uses: actions/upload-artifact@v2
+        with:
+          name: LibreHardwareMonitorLib-nupkg
           path: |
             bin/Release/LibreHardwareMonitorLib.*.nupkg
 
@@ -38,6 +52,7 @@ jobs:
         uses: rohith/publish-nuget@v2
         with:
           PROJECT_FILE_PATH: LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
+          VERSION_FILE_PATH: Directory.Build.props
           NUGET_KEY: ${{secrets.NUGET_API_KEY}}
           INCLUDE_SYMBOLS: false
           TAG_COMMIT: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,6 @@ name: CI
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
-    types: [opened, synchronize, reopened, closed]
 
 jobs:
   build:
@@ -16,9 +13,16 @@ jobs:
       - uses: actions/checkout@v2
       - uses: nuget/setup-nuget@v1
       - uses: microsoft/setup-msbuild@v1.0.2
+    
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            buildprops:
+              - 'Directory.Build.props'
 
       - name: Update version
-        if: github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: steps.changes.outputs.buildprops == 'false'
         run: |
             (Get-Content Directory.Build.props) | % { 
                 $m = [regex]::match($_, '<Version>(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?</Version>');

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Publish netstandard20
         uses: actions/upload-artifact@v2
         with:
-          name: LibreHardwareMonitor-netstandard20
+          name: LibreHardwareMonitorLib-netstandard20
           path: |
             bin/Release/netstandard2.0
 


### PR DESCRIPTION
Updates the `Directory.Build.props` version with a ci build number when a PR is merged, this will publish a new version of LibreHardwareMonitorLib to nuget that will be marked as prerelease. Don't know if this is a "proper" solution so feel free to close this, I dont really want to touch github actions again.

Also cleaned up artifact upload for net452, netstandard20 and nupkg.
Fixes #336.

As a side note I think github actions are terrible, they try to combine code in yaml with so many random restrictions that it becomes a chore to do anything (for example `env` context can be used in `steps.if` but not in `jobs.if`). I dont think I will ever use them, just using nuke build with plain C# code is way way better. `</rant>`