### PR TITLE
Add D5Next Pump from AquaComputer to supported devices

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/AquaComputerGroup.cs
+++ b/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/AquaComputerGroup.cs
@@ -27,15 +27,14 @@ namespace LibreHardwareMonitor.Hardware.Controller.AquaComputer
                 switch (dev.ProductID)
                 {
                     case 0xF00E:
-                        {
-                            var device = new D5Next(dev, settings);
-                            _report.AppendLine($"Device name: {productName}");
-                            _report.AppendLine($"Firmware version: {device.FirmwareVersion}");
-                            _report.AppendLine();
-                            _hardware.Add(device);
-
-                            break;
-                        }
+                    {
+                        var device = new D5Next(dev, settings);
+                        _report.AppendLine($"Device name: {productName}");
+                        _report.AppendLine($"Firmware version: {device.FirmwareVersion}");
+                        _report.AppendLine();
+                        _hardware.Add(device);
+                        break;
+                    }
                     case 0xf0b6:
                     {
                         var device = new AquastreamXT(dev, settings);

--- a/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/AquaComputerGroup.cs
+++ b/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/AquaComputerGroup.cs
@@ -26,6 +26,16 @@ namespace LibreHardwareMonitor.Hardware.Controller.AquaComputer
 
                 switch (dev.ProductID)
                 {
+                    case 0xF00E:
+                        {
+                            var device = new D5Next(dev, settings);
+                            _report.AppendLine($"Device name: {productName}");
+                            _report.AppendLine($"Firmware version: {device.FirmwareVersion}");
+                            _report.AppendLine();
+                            _hardware.Add(device);
+
+                            break;
+                        }
                     case 0xf0b6:
                     {
                         var device = new AquastreamXT(dev, settings);

--- a/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/D5Next.cs
+++ b/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/D5Next.cs
@@ -1,0 +1,79 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (C) LibreHardwareMonitor and Contributors.
+// All Rights Reserved.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using HidSharp;
+
+namespace LibreHardwareMonitor.Hardware.Controller.AquaComputer
+{
+
+    internal sealed class D5Next : Hardware
+    {
+        private readonly Sensor _fanControl;
+        private const byte D5_REPORT_ID = 0x3;
+
+        //Available Reports, found them by looking at the below methods
+        //var test = dev.GetRawReportDescriptor();
+        //var test2 = dev.GetReportDescriptor();
+
+        // ID 1; Length 158; INPUT
+        // ID 2; Length 11; OUTPUT
+        // ID 3; Length 1025; <-- works FEATURE
+        // ID 8; Length 1025; <-- works FEATURE
+        // ID 12; Length 1025; <-- 0xC FEATURE
+
+        private readonly byte[] _rawData = new byte[1025];
+        private readonly Sensor[] _rpmSensors = new Sensor[1];
+        private readonly HidStream _stream;
+        private readonly Sensor[] _temperatures = new Sensor[1];
+
+        public D5Next(HidDevice dev, ISettings settings) : base("D5Next", new Identifier(dev.DevicePath), settings)
+        {
+            if (dev.TryOpen(out _stream))
+            {
+                //Reading output report instead of feature report, as the measurements are in the output report
+                _stream.Read(_rawData);
+
+                Name = $"D5Next";
+                FirmwareVersion = Convert.ToUInt16(_rawData[14] | (_rawData[13] << 8));
+                _temperatures[0] = new Sensor("Water Temperature", 0, SensorType.Temperature, this, new ParameterDescription[0], settings);
+                ActivateSensor(_temperatures[0]);
+                
+                _rpmSensors[0] = new Sensor("Pump", 0, SensorType.Fan, this, new ParameterDescription[0], settings);
+                ActivateSensor(_rpmSensors[0]);
+
+            }
+        }
+
+        public ushort FirmwareVersion { get; private set; }
+
+        public override HardwareType HardwareType
+        {
+            get { return HardwareType.Cooler; }
+        }
+
+
+        public override void Close()
+        {
+            _stream.Close();
+
+            base.Close();
+        }
+
+        public override void Update()
+        {
+            //Reading output report instead of feature report, as the measurements are in the output report
+            _stream.Read(_rawData);
+
+
+            _temperatures[0].Value = (_rawData[88] | (_rawData[87] << 8)) / 100f; //Water Temp
+
+            _rpmSensors[0].Value = (_rawData[117] | (_rawData[116] << 8)); //Pump RPM
+
+        }
+    }
+}

--- a/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/D5Next.cs
+++ b/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/D5Next.cs
@@ -4,18 +4,12 @@
 // All Rights Reserved.
 
 using System;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using HidSharp;
 
 namespace LibreHardwareMonitor.Hardware.Controller.AquaComputer
 {
-
     internal sealed class D5Next : Hardware
     {
-        private readonly Sensor _fanControl;
-        private const byte D5_REPORT_ID = 0x3;
-
         //Available Reports, found them by looking at the below methods
         //var test = dev.GetRawReportDescriptor();
         //var test2 = dev.GetReportDescriptor();
@@ -45,7 +39,6 @@ namespace LibreHardwareMonitor.Hardware.Controller.AquaComputer
                 
                 _rpmSensors[0] = new Sensor("Pump", 0, SensorType.Fan, this, new ParameterDescription[0], settings);
                 ActivateSensor(_rpmSensors[0]);
-
             }
         }
 
@@ -60,7 +53,6 @@ namespace LibreHardwareMonitor.Hardware.Controller.AquaComputer
         public override void Close()
         {
             _stream.Close();
-
             base.Close();
         }
 
@@ -68,12 +60,8 @@ namespace LibreHardwareMonitor.Hardware.Controller.AquaComputer
         {
             //Reading output report instead of feature report, as the measurements are in the output report
             _stream.Read(_rawData);
-
-
             _temperatures[0].Value = (_rawData[88] | (_rawData[87] << 8)) / 100f; //Water Temp
-
             _rpmSensors[0].Value = (_rawData[117] | (_rawData[116] << 8)); //Pump RPM
-
         }
     }
 }

--- a/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/D5Next.cs
+++ b/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/D5Next.cs
@@ -49,7 +49,6 @@ namespace LibreHardwareMonitor.Hardware.Controller.AquaComputer
             get { return HardwareType.Cooler; }
         }
 
-
         public override void Close()
         {
             _stream.Close();


### PR DESCRIPTION
This fixes #357 . Took me some time but it now shows the water temperature and pump rpm in the monitor.
![grafik](https://user-images.githubusercontent.com/1320525/104092319-7b6f0980-5283-11eb-8cee-4aa38371df64.png)

Please merge this so that it can be integrated into https://github.com/Rem0o/FanControl.Releases to control the fans based on the water temperature :)