### PR TITLE
Add specific fan control case for NCT9796D-R

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
@@ -145,6 +145,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                             Controls = new float?[5];
                             break;
                         }
+                        case Chip.NCT6796DR:
                         case Chip.NCT6797D:
                         case Chip.NCT6798D:
                         {


### PR DESCRIPTION
NCT6796D-R has 7 fans (6 headers, plus SB fan).