### PR TITLE
ADL Overdrive 6 support and integration

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Gpu/AmdGpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Gpu/AmdGpu.cs
@@ -125,7 +125,7 @@ namespace LibreHardwareMonitor.Hardware.Gpu
                 {
                     AtiAdlxx.ADLOD6FanSpeedValue fanSpeedValue = new AtiAdlxx.ADLOD6FanSpeedValue
                     {
-                        SpeedType = AtiAdlxx.ADL_OD6_FANSPEED_TYPE.ADL_OD6_FANSPEED_TYPE_PERCENT,
+                        SpeedType = AtiAdlxx.ADL_DL_FANCTRL_SPEED_TYPE_PERCENT,
                         FanSpeed = (int)control.SoftwareValue
                     };
 
@@ -214,7 +214,7 @@ namespace LibreHardwareMonitor.Hardware.Gpu
                 }
 
                 AtiAdlxx.ADLFanSpeedValue fanSpeedValue = new AtiAdlxx.ADLFanSpeedValue { SpeedType = AtiAdlxx.ADL_DL_FANCTRL_SPEED_TYPE_RPM };
-                AtiAdlxx.ADLOD6FanSpeedValue fanSpeed6Value = new AtiAdlxx.ADLOD6FanSpeedValue { SpeedType = AtiAdlxx.ADL_OD6_FANSPEED_TYPE.ADL_OD6_FANSPEED_TYPE_RPM };
+                AtiAdlxx.ADLOD6FanSpeedValue fanSpeed6Value = new AtiAdlxx.ADLOD6FanSpeedValue { SpeedType = AtiAdlxx.ADL_DL_FANCTRL_SPEED_TYPE_RPM };
                 if (_currentOverdriveApiLevel <= 5 && AtiAdlxx.ADL_Overdrive5_FanSpeed_Get(_adapterIndex, 0, ref fanSpeedValue) == AtiAdlxx.ADLStatus.ADL_OK)
                 {
                     _fan.Value = fanSpeedValue.FanSpeed;
@@ -231,7 +231,7 @@ namespace LibreHardwareMonitor.Hardware.Gpu
                 }
 
                 fanSpeedValue = new AtiAdlxx.ADLFanSpeedValue { SpeedType = AtiAdlxx.ADL_DL_FANCTRL_SPEED_TYPE_PERCENT };
-                fanSpeed6Value = new AtiAdlxx.ADLOD6FanSpeedValue { SpeedType = AtiAdlxx.ADL_OD6_FANSPEED_TYPE.ADL_OD6_FANSPEED_TYPE_PERCENT };
+                fanSpeed6Value = new AtiAdlxx.ADLOD6FanSpeedValue { SpeedType = AtiAdlxx.ADL_DL_FANCTRL_SPEED_TYPE_PERCENT };
                 if (_currentOverdriveApiLevel <= 5 && AtiAdlxx.ADL_Overdrive5_FanSpeed_Get(_adapterIndex, 0, ref fanSpeedValue) == AtiAdlxx.ADLStatus.ADL_OK)
                 {
                     _controlSensor.Value = fanSpeedValue.FanSpeed;

--- a/LibreHardwareMonitorLib/Interop/AtiAdlxx.cs
+++ b/LibreHardwareMonitorLib/Interop/AtiAdlxx.cs
@@ -369,19 +369,13 @@ namespace LibreHardwareMonitor.Interop
         internal struct ADLOD6FanSpeedValue
         {
             /// Indicates the units of the fan speed.  Possible values: \ref ADL_OD6_FANSPEED_TYPE_PERCENT, \ref ADL_OD6_FANSPEED_TYPE_RPM
-            public ADL_OD6_FANSPEED_TYPE SpeedType;
+            public int SpeedType;
             /// Fan speed value (units as indicated above)
             public int FanSpeed;
             /// Value for future extension
             public int ExtValue;
             /// Mask for future extension
             public int ExtMask;
-        }
-
-        internal enum ADL_OD6_FANSPEED_TYPE
-        {
-            ADL_OD6_FANSPEED_TYPE_PERCENT = 0x00000001,
-            ADL_OD6_FANSPEED_TYPE_RPM = 0x00000002
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/LibreHardwareMonitorLib/Interop/AtiAdlxx.cs
+++ b/LibreHardwareMonitorLib/Interop/AtiAdlxx.cs
@@ -97,6 +97,15 @@ namespace LibreHardwareMonitor.Interop
         public static extern ADLStatus ADL_Overdrive5_FanSpeed_Set(int adapterIndex, int thermalControllerIndex, ref ADLFanSpeedValue fanSpeedValue);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern ADLStatus ADL_Overdrive6_FanSpeed_Get(int adapterIndex, ref ADLOD6FanSpeedValue FanSpeedValue);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern ADLStatus ADL_Overdrive6_FanSpeed_Set(int adapterIndex, ref ADLOD6FanSpeedValue FanSpeedValue);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern ADLStatus ADL_Overdrive6_FanSpeed_Reset(int adapterIndex);
+
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         public static extern ADLStatus ADL2_OverdriveN_PerformanceStatus_Get(IntPtr context, int adapterIndex, out ADLODNPerformanceStatus performanceStatus);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
@@ -355,7 +364,26 @@ namespace LibreHardwareMonitor.Interop
             public int FanSpeed;
             public int Flags;
         }
-        
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct ADLOD6FanSpeedValue
+        {
+            /// Indicates the units of the fan speed.  Possible values: \ref ADL_OD6_FANSPEED_TYPE_PERCENT, \ref ADL_OD6_FANSPEED_TYPE_RPM
+            public ADL_OD6_FANSPEED_TYPE SpeedType;
+            /// Fan speed value (units as indicated above)
+            public int FanSpeed;
+            /// Value for future extension
+            public int ExtValue;
+            /// Mask for future extension
+            public int ExtMask;
+        }
+
+        internal enum ADL_OD6_FANSPEED_TYPE
+        {
+            ADL_OD6_FANSPEED_TYPE_PERCENT = 0x00000001,
+            ADL_OD6_FANSPEED_TYPE_RPM = 0x00000002
+        }
+
         [StructLayout(LayoutKind.Sequential)]
         internal struct ADLFanSpeedInfo
         {


### PR DESCRIPTION
https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/issues/276

* ADL_Overdrive6_FanSpeed_Reset
* ADL_Overdrive6_FanSpeed_Set
* ADL_Overdrive6_FanSpeed_Get

Used this doc: https://github.com/GPUOpen-LibrariesAndSDKs/display-library/blob/209538e1dc7273f7459411a3a5044ffe2437ed95/Public-Documents/html/group__OVERDRIVE6API.html

I don't have a NAVI GPU on hand (5XXX or 6XXX XT).

Could somebody with these GPU try this to see if the RPM, % and changing fan speed works?