### PR TITLE
Samsung 980 pro NVME Fix

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Storage/NVMeSmart.cs
+++ b/LibreHardwareMonitorLib/Hardware/Storage/NVMeSmart.cs
@@ -33,8 +33,8 @@ namespace LibreHardwareMonitor.Hardware.Storage
                 }
             }
 
-            // Test intel protocol.
-            if (NVMeDrive == null && storageInfo.Name.ToLower().Contains("intel"))
+            // Test Intel protocol.
+            if (NVMeDrive == null && storageInfo.Name.IndexOf("Intel", StringComparison.OrdinalIgnoreCase) > -1)
             {
                 _handle = NVMeIntel.IdentifyDevice(storageInfo);
                 if (_handle != null)
@@ -43,8 +43,8 @@ namespace LibreHardwareMonitor.Hardware.Storage
                 }
             }
 
-            // Test intel raid protocol.
-            if (NVMeDrive == null && storageInfo.Name.ToLower().Contains("intel"))
+            // Test Intel raid protocol.
+            if (NVMeDrive == null && storageInfo.Name.IndexOf("Intel", StringComparison.OrdinalIgnoreCase) > -1)
             {
                 _handle = NVMeIntelRst.IdentifyDevice(storageInfo);
                 if (_handle != null)
@@ -53,7 +53,7 @@ namespace LibreHardwareMonitor.Hardware.Storage
                 }
             }
 
-            // Test windows generic driver protocol.
+            // Test Windows generic driver protocol.
             if (NVMeDrive == null)
             {
                 _handle = NVMeWindows.IdentifyDevice(storageInfo);

--- a/LibreHardwareMonitorLib/Hardware/Storage/NVMeSmart.cs
+++ b/LibreHardwareMonitorLib/Hardware/Storage/NVMeSmart.cs
@@ -20,10 +20,11 @@ namespace LibreHardwareMonitor.Hardware.Storage
             _driveNumber = storageInfo.Index;
             NVMeDrive = null;
 
-            //test samsung protocol
-            //exlude samsung 980 pro, this sdd use the NVMeWindows generic protocol
-            //samsung 980 pro can accessed via IdentifyDevice and IdentifyController but not by HealthInfoLog
-            if (NVMeDrive == null && storageInfo.Name.ToLower().Contains("samsung") && storageInfo.Name.ToLower().Contains("980 pro") == false)
+            // Test samsung protocol.
+
+            // Exclude Samsung 980 Pro, this SSD uses the NVMeWindows generic protocol.
+            // Samsung 980 Pro can accessed via IdentifyDevice and IdentifyController but not by HealthInfoLog.
+            if (NVMeDrive == null && storageInfo.Name.IndexOf("Samsung", StringComparison.OrdinalIgnoreCase) > -1 && storageInfo.Name.ToLower().IndexOf("980 Pro", StringComparison.OrdinalIgnoreCase) == -1)
             {
                 _handle = NVMeSamsung.IdentifyDevice(storageInfo);
                 if (_handle != null)
@@ -32,7 +33,7 @@ namespace LibreHardwareMonitor.Hardware.Storage
                 }
             }
 
-            //test intel protocol
+            // Test intel protocol.
             if (NVMeDrive == null && storageInfo.Name.ToLower().Contains("intel"))
             {
                 _handle = NVMeIntel.IdentifyDevice(storageInfo);
@@ -42,7 +43,7 @@ namespace LibreHardwareMonitor.Hardware.Storage
                 }
             }
 
-            //test intel raid protocol
+            // Test intel raid protocol.
             if (NVMeDrive == null && storageInfo.Name.ToLower().Contains("intel"))
             {
                 _handle = NVMeIntelRst.IdentifyDevice(storageInfo);
@@ -52,7 +53,7 @@ namespace LibreHardwareMonitor.Hardware.Storage
                 }
             }
 
-            //test windows generic driver protocol
+            // Test windows generic driver protocol.
             if (NVMeDrive == null)
             {
                 _handle = NVMeWindows.IdentifyDevice(storageInfo);

--- a/LibreHardwareMonitorLib/Hardware/Storage/NVMeSmart.cs
+++ b/LibreHardwareMonitorLib/Hardware/Storage/NVMeSmart.cs
@@ -24,7 +24,7 @@ namespace LibreHardwareMonitor.Hardware.Storage
 
             // Exclude Samsung 980 Pro, this SSD uses the NVMeWindows generic protocol.
             // Samsung 980 Pro can accessed via IdentifyDevice and IdentifyController but not by HealthInfoLog.
-            if (NVMeDrive == null && storageInfo.Name.IndexOf("Samsung", StringComparison.OrdinalIgnoreCase) > -1 && storageInfo.Name.ToLower().IndexOf("980 Pro", StringComparison.OrdinalIgnoreCase) == -1)
+            if (NVMeDrive == null && storageInfo.Name.IndexOf("Samsung", StringComparison.OrdinalIgnoreCase) > -1 && storageInfo.Name.IndexOf("980 Pro", StringComparison.OrdinalIgnoreCase) == -1)
             {
                 _handle = NVMeSamsung.IdentifyDevice(storageInfo);
                 if (_handle != null)

--- a/LibreHardwareMonitorLib/Hardware/Storage/NVMeSmart.cs
+++ b/LibreHardwareMonitorLib/Hardware/Storage/NVMeSmart.cs
@@ -21,7 +21,9 @@ namespace LibreHardwareMonitor.Hardware.Storage
             NVMeDrive = null;
 
             //test samsung protocol
-            if (NVMeDrive == null && storageInfo.Name.ToLower().Contains("samsung"))
+            //exlude samsung 980 pro, this sdd use the NVMeWindows generic protocol
+            //samsung 980 pro can accessed via IdentifyDevice and IdentifyController but not by HealthInfoLog
+            if (NVMeDrive == null && storageInfo.Name.ToLower().Contains("samsung") && storageInfo.Name.ToLower().Contains("980 pro") == false)
             {
                 _handle = NVMeSamsung.IdentifyDevice(storageInfo);
                 if (_handle != null)


### PR DESCRIPTION
Exclude Samsung 980 pro from Samsung protocol, this sdd use the NVMeWindows generic protocol
Samsung 980 pro can accessed via IdentifyDevice and IdentifyController but not by HealthInfoLog
https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/issues/370

Testet with a Samsung 980 Pro 250 GB SSD.