### PR TITLE
Add fan control for IT8728F

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -70,6 +70,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                 : new byte[] { 0x15, 0x16, 0x17, 0x7f, 0xa7 };
 
             _hasExtReg = chip == Chip.IT8721F ||
+                         chip == Chip.IT8728F ||
                          chip == Chip.IT8665E ||
                          chip == Chip.IT8686E ||
                          chip == Chip.IT8688E ||


### PR DESCRIPTION
Add support for controlling fans on the IT8728F controller, mostly used on Gigabyte 7/8 mainboards.
Fixes #294.

Hope this is the only change needed, but it seems so from previous commits and works on my machine.