### PR TITLE
Add support for ASRock X570 Phantom Gaming-ITX/TB3 (NCT6683D)

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -287,6 +287,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     return Model.X570_Pro4;
                 case var _ when name.Equals("X570 Taichi", StringComparison.OrdinalIgnoreCase):
                     return Model.X570_Taichi;
+                case var _ when name.Equals("X570 Phantom Gaming-ITX/TB3", StringComparison.OrdinalIgnoreCase):
+                    return Model.X570_Phantom_Gaming_ITX;
                 case var _ when name.Equals("AX370-Gaming 5", StringComparison.OrdinalIgnoreCase):
                     return Model.AX370_Gaming_5;
                 case var _ when name.Equals("TUF X470-PLUS GAMING", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
@@ -59,6 +59,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
         NCT6797D = 0xD451,
         NCT6798D = 0xD42B,
         NCT6687D = 0xD592,
+        NCT6683D = 0xc732,
 
         W83627DHG = 0xA020,
         W83627DHGP = 0xB070,
@@ -121,6 +122,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                 case Chip.NCT6797D: return "Nuvoton NCT6797D";
                 case Chip.NCT6798D: return "Nuvoton NCT6798D";
                 case Chip.NCT6687D: return "Nuvoton NCT6687D";
+                case Chip.NCT6683D: return "Nuvoton NCT6683D";
 
                 case Chip.W83627DHG: return "Winbond W83627DHG";
                 case Chip.W83627DHGP: return "Winbond W83627DHG-P";

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
@@ -512,6 +512,17 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
 
                     break;
                 }
+                case 199:
+                {
+                    switch (revision)
+                    {
+                        case 50:
+                            chip = Chip.NCT6683D;
+                            logicalDeviceNumber = WINBOND_NUVOTON_HARDWARE_MONITOR_LDN;
+                            break;
+                    }
+                    break;
+                }
             }
 
             if (chip == Chip.Unknown)
@@ -604,6 +615,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                     case Chip.NCT6797D:
                     case Chip.NCT6798D:
                     case Chip.NCT6687D:
+                    case Chip.NCT6683D:
                     {
                         _superIOs.Add(new Nct677X(chip, revision, address, port));
                         break;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
@@ -54,7 +54,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
 
                 _vBatMonitorControlRegister = 0x0318;
             }
-            else if (chip == Chip.NCT6687D)
+            else if (chip == Chip.NCT6687D || chip == Chip.NCT6683D)
             {
                 FAN_PWM_OUT_REG = new ushort[] { 0x160, 0x161, 0x162, 0x163, 0x164, 0x165, 0x166, 0x167 };
                 FAN_PWM_COMMAND_REG = new ushort[] { 0xA28, 0xA29, 0xA2A, 0xA2B, 0xA2C, 0xA2D, 0xA2E, 0xA2F };
@@ -280,6 +280,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
 
                     break;
                 }
+                case Chip.NCT6683D:
                 case Chip.NCT6687D:
                 {
                     Fans = new float?[8];
@@ -341,7 +342,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                     WriteByte(0x1BE, 0x64);
                     WriteByte(0x1BF, 0x65);
 
-                    _alternateTemperatureRegister = new ushort?[] { null };
+                    _alternateTemperatureRegister = new ushort?[] { };
 
                     break;
                 }
@@ -384,7 +385,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
             {
                 SaveDefaultFanControl(index);
 
-                if (Chip != Chip.NCT6687D)
+                if (Chip != Chip.NCT6687D && Chip != Chip.NCT6683D)
                 {
                     // set manual mode
                     WriteByte(FAN_CONTROL_MODE_REG[index], 0);
@@ -473,6 +474,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                 switch (Chip)
                 {
                     case Chip.NCT6687D:
+                    case Chip.NCT6683D:
                     {
                         int value = (sbyte)ReadByte(_temperatureRegister[i]);
                         int half = (ReadByte((ushort)(_temperatureRegister[i] + 1)) >> 7) & 0x1;
@@ -594,7 +596,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
 
             for (int i = 0; i < Fans.Length; i++)
             {
-                if (Chip != Chip.NCT6687D)
+                if (Chip != Chip.NCT6687D && Chip != Chip.NCT6683D)
                 {
                     if (_fanCountRegister != null)
                     {
@@ -636,7 +638,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
 
             for (int i = 0; i < Controls.Length; i++)
             {
-                if (Chip != Chip.NCT6687D)
+                if (Chip != Chip.NCT6687D && Chip != Chip.NCT6683D)
                 {
                     int value = ReadByte(FAN_PWM_OUT_REG[i]);
                     Controls[i] = value / 2.55f;
@@ -778,7 +780,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
             r.AppendLine("        00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F");
             r.AppendLine();
 
-            if (Chip != Chip.NCT6687D)
+            if (Chip != Chip.NCT6687D && Chip != Chip.NCT6683D)
             {
                 foreach (ushort address in addresses)
                 {
@@ -821,7 +823,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
 
         private byte ReadByte(ushort address)
         {
-            if (Chip != Chip.NCT6687D)
+            if (Chip != Chip.NCT6687D && Chip != Chip.NCT6683D)
             {
                 byte bank = (byte)(address >> 8);
                 byte register = (byte)(address & 0xFF);
@@ -841,7 +843,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
 
         private void WriteByte(ushort address, byte value)
         {
-            if (Chip != Chip.NCT6687D)
+            if (Chip != Chip.NCT6687D && Chip != Chip.NCT6683D)
             {
                 byte bank = (byte)(address >> 8);
                 byte register = (byte)(address & 0xFF);
@@ -863,14 +865,14 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
 
         private bool IsNuvotonVendor()
         {
-            return Chip == Chip.NCT6687D || ((ReadByte(VENDOR_ID_HIGH_REGISTER) << 8) | ReadByte(VENDOR_ID_LOW_REGISTER)) == NUVOTON_VENDOR_ID;
+            return Chip == Chip.NCT6687D || Chip == Chip.NCT6683D || ((ReadByte(VENDOR_ID_HIGH_REGISTER) << 8) | ReadByte(VENDOR_ID_LOW_REGISTER)) == NUVOTON_VENDOR_ID;
         }
 
         private void SaveDefaultFanControl(int index)
         {
             if (!_restoreDefaultFanControlRequired[index])
             {
-                if (Chip != Chip.NCT6687D)
+                if (Chip != Chip.NCT6687D && Chip != Chip.NCT6683D)
                 {
                     _initialFanControlMode[index] = ReadByte(FAN_CONTROL_MODE_REG[index]);
                 }
@@ -890,7 +892,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
         {
             if (_restoreDefaultFanControlRequired[index])
             {
-                if (Chip != Chip.NCT6687D)
+                if (Chip != Chip.NCT6687D && Chip != Chip.NCT6683D)
                 {
                     WriteByte(FAN_CONTROL_MODE_REG[index], _initialFanControlMode[index]);
                     WriteByte(FAN_PWM_COMMAND_REG[index], _initialFanPwmCommand[index]);

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -33,6 +33,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
         Z77Pro4M,
         X570_Pro4,
         X570_Taichi,
+        X570_Phantom_Gaming_ITX,
 
         // ASUS
         CROSSHAIR_III_FORMULA,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -356,6 +356,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                 case Chip.NCT6796DR:
                 case Chip.NCT6797D:
                 case Chip.NCT6798D:
+                case Chip.NCT6683D:
                 {
                     GetNuvotonConfigurationD(superIO, manufacturer, model, v, t, f, c);
 
@@ -2087,6 +2088,39 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
 
                             break;
                         }                        
+                        case Model.X570_Phantom_Gaming_ITX:
+                        {
+                            v.Add(new Voltage("+12V", 0));
+                            v.Add(new Voltage("+5V", 1));
+                            v.Add(new Voltage("Vcore", 2));
+                            v.Add(new Voltage("Voltage #1", 3));
+                            v.Add(new Voltage("DIMM", 4));
+                            v.Add(new Voltage("CPU I/O", 5));
+                            v.Add(new Voltage("CPU SA", 6));
+                            v.Add(new Voltage("Voltage #2", 7));
+                            v.Add(new Voltage("AVCC3", 8));
+                            v.Add(new Voltage("VTT", 9));
+                            v.Add(new Voltage("VRef", 10));
+                            v.Add(new Voltage("VSB", 11));
+                            v.Add(new Voltage("AVSB", 12));
+                            v.Add(new Voltage("VBat", 13));
+
+                            t.Add(new Temperature("Motherboard", 0));
+                            //t.Add(new Temperature("System", 1)); //Unused
+                            t.Add(new Temperature("CPU", 2));
+                            t.Add(new Temperature("SB (Chipset)", 3));
+                            f.Add(new Fan("CPU Fan #1", 0)); //CPU_FAN1
+                            f.Add(new Fan("Chassis Fan #1", 1)); //CHA_FAN1/WP
+                            f.Add(new Fan("CPU Fan #2", 2)); //CPU_FAN2 (WP)
+                            f.Add(new Fan("Chipset Fan", 3));
+
+                            c.Add(new Ctrl("CPU Fan #1", 0));
+                            c.Add(new Ctrl("Chassis Fan", 1));
+                            c.Add(new Ctrl("CPU Fan #2", 2));
+                            c.Add(new Ctrl("Chipset Fan", 3));
+                            break;
+                        }
+						
                         default:
                         {
                             v.Add(new Voltage("Vcore", 0, 10, 10));


### PR DESCRIPTION
Add support for NCT6683D based on support for 6687D (eSIO series)
Add support for ASRock X570 Phantom-Gaming ITX/TB3 (Fixes Issue #220 )