### PR TITLE
Fix NullReferenceException, if NZXT CAM is running at the same time

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Controller/Nzxt/KrakenX3.cs
+++ b/LibreHardwareMonitorLib/Hardware/Controller/Nzxt/KrakenX3.cs
@@ -104,7 +104,7 @@ namespace LibreHardwareMonitor.Hardware.Controller.Nzxt
         public override void Close()
         {
             base.Close();
-            _stream.Close();
+            _stream?.Close();
         }
 
         private void ContinuousRead(object state)

--- a/LibreHardwareMonitorLib/Hardware/SMBios.cs
+++ b/LibreHardwareMonitorLib/Hardware/SMBios.cs
@@ -528,8 +528,9 @@ namespace LibreHardwareMonitor.Hardware
             {
                 if (month > 12) 
                 {
+                    int tmp = month;
                     month = day;
-                    day = month;
+                    day = tmp;
                 }
                 return new DateTime(year < 100 ? 1900 + year : year, month, day);
             }

--- a/LibreHardwareMonitorLib/Hardware/SMBios.cs
+++ b/LibreHardwareMonitorLib/Hardware/SMBios.cs
@@ -528,7 +528,6 @@ namespace LibreHardwareMonitor.Hardware
             {
                 if (month > 12) 
                 {
-                    int tmp = month;
                     month = day;
                     day = month;
                 }


### PR DESCRIPTION
In constructor, HidDevice tries to open stream and returns false (and _stream is null), if NZXT CAM software is running at the same time with LibreHardwareMonitor. [Line 43](https://github.com/JokkeeZ/LibreHardwareMonitor/blob/f9407bd214946ada2bfaaa5612450d3789bb0387/LibreHardwareMonitorLib/Hardware/Controller/Nzxt/KrakenX3.cs#L43)

On application exit, `_stream.Close();` is called, and it caused an NullReferenceException, since `_stream` was not opened.

EDIT: Also removed unnecessary variable declaration.