### PR TITLE
Impose WMI timeouts

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Storage/StorageGroup.cs
+++ b/LibreHardwareMonitorLib/Hardware/Storage/StorageGroup.cs
@@ -20,28 +20,27 @@ namespace LibreHardwareMonitor.Hardware.Storage
                 return;
 
             //https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-diskdrive
-            var mosDisks = new ManagementObjectSearcher("SELECT * FROM Win32_DiskDrive");
-            ManagementObjectCollection queryCollection = mosDisks.Get(); // get the results
-
-            foreach (ManagementBaseObject disk in queryCollection)
+            string query = "SELECT * FROM Win32_DiskDrive";
+            using (var mosDisks = new ManagementObjectSearcher(query) {Options = {Timeout = TimeSpan.FromSeconds(10)}})
+            using (ManagementObjectCollection queryCollection = mosDisks.Get())
             {
-                string deviceId = (string)disk.Properties["DeviceId"].Value; // is \\.\PhysicalDrive0..n
-                uint idx = Convert.ToUInt32(disk.Properties["Index"].Value);
-                ulong diskSize = Convert.ToUInt64(disk.Properties["Size"].Value);
-                int scsi = Convert.ToInt32(disk.Properties["SCSIPort"].Value);
-
-                if (deviceId != null)
+                foreach (ManagementBaseObject disk in queryCollection)
                 {
-                    var instance = AbstractStorage.CreateInstance(deviceId, idx, diskSize, scsi, settings);
-                    if (instance != null)
+                    string deviceId = (string)disk.Properties["DeviceId"].Value; // is \\.\PhysicalDrive0..n
+                    uint idx = Convert.ToUInt32(disk.Properties["Index"].Value);
+                    ulong diskSize = Convert.ToUInt64(disk.Properties["Size"].Value);
+                    int scsi = Convert.ToInt32(disk.Properties["SCSIPort"].Value);
+
+                    if (deviceId != null)
                     {
-                        _hardware.Add(instance);
+                        var instance = AbstractStorage.CreateInstance(deviceId, idx, diskSize, scsi, settings);
+                        if (instance != null)
+                        {
+                            _hardware.Add(instance);
+                        }
                     }
                 }
             }
-
-            queryCollection.Dispose();
-            mosDisks.Dispose();
         }
 
         public IReadOnlyList<IHardware> Hardware => _hardware;


### PR DESCRIPTION
WMI queries do not have a timeout by default and can subsequently hang.
This commit adds timeouts to avoid these hangs.

On timeout, `Get` will throw a `ManagementException` that has an error
code of `ManagementStatus.Timedout`. In the case of abstract storage,
this exception will be silently swallowed and the statistics from WMI
not updated until the next update interval, which seems appropriate.

The storage group, on the other hand, a timeout there would cause an
initialization exception which would be propagated up to the caller
(which seems ok as something must be terribly wrong for that WMI query
to fail).

The code was also updated to call dispose for all the WMI objects. I
don't see this causing a behavior difference, but I found it better to
be safe than sorry.

The timeout of 1 second was chosen on hardware update to match the 1
second timeout in TBalancer. The timeout of 5 seconds was chosen on
initialization to be a bit more forgiving.

(recommended to view this diff excluding whitespace)