### PR TITLE
Add option for clearing saved sensor values to free up memory.

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Computer.cs
+++ b/LibreHardwareMonitorLib/Hardware/Computer.cs
@@ -303,6 +303,21 @@ namespace LibreHardwareMonitor.Hardware
             }
         }
 
+        public void ResetValues()
+        {
+            lock (_lock)
+            {
+                // Use a for-loop instead of foreach to avoid a collection modified exception after sleep, even though everything is under a lock.
+                for (int i = 0; i < _groups.Count; i++)
+                {
+                    IGroup group = _groups[i];
+
+                    for (int j = 0; j < group.Hardware.Count; j++)
+                        group.Hardware[j].ResetValues();
+                }
+            }
+        }
+
         private void HardwareAddedEvent(IHardware hardware)
         {
             HardwareAdded?.Invoke(hardware);

--- a/LibreHardwareMonitorLib/Hardware/Hardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Hardware.cs
@@ -71,6 +71,12 @@ namespace LibreHardwareMonitor.Hardware
             visitor.VisitHardware(this);
         }
 
+        public void ResetValues()
+        {
+            foreach (ISensor sensor in _active)
+                sensor.ResetValues();
+        }
+
         public virtual void Traverse(IVisitor visitor)
         {
             foreach (ISensor sensor in _active)

--- a/LibreHardwareMonitorLib/Hardware/IHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/IHardware.cs
@@ -39,6 +39,8 @@ namespace LibreHardwareMonitor.Hardware
 
         void Update();
 
+        void ResetValues();
+
         event SensorEventHandler SensorAdded;
 
         event SensorEventHandler SensorRemoved;

--- a/LibreHardwareMonitorLib/Hardware/ISensor.cs
+++ b/LibreHardwareMonitorLib/Hardware/ISensor.cs
@@ -71,5 +71,7 @@ namespace LibreHardwareMonitor.Hardware
         void ResetMin();
 
         void ResetMax();
+
+        void ResetValues();
     }
 }

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Motherboard.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Motherboard.cs
@@ -129,6 +129,12 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
             visitor.VisitHardware(this);
         }
 
+        public void ResetValues()
+        {
+            foreach (IHardware hardware in SubHardware)
+                hardware.ResetValues();
+        }
+
         public void Traverse(IVisitor visitor)
         {
             foreach (IHardware hardware in SubHardware)

--- a/LibreHardwareMonitorLib/Hardware/Sensor.cs
+++ b/LibreHardwareMonitorLib/Hardware/Sensor.cs
@@ -151,6 +151,15 @@ namespace LibreHardwareMonitor.Hardware
             Max = null;
         }
 
+        public void ResetValues()
+        {
+            float? lastValue = Value;
+            _values.Clear();
+
+
+            AppendValue(lastValue ?? float.NaN, DateTime.UtcNow);
+        }
+
         public void Accept(IVisitor visitor)
         {
             if (visitor == null)


### PR DESCRIPTION
Referring to #450, I believe that this option may be useful in some cases.

### What are we changing?
We add options to clear the Enumerable containing all Values of the given Sensor.

### How do we facilitate access?
The method is also added to the `Computer` class so that the developer can conveniently reset all sensors.

### Why is it useful?
In this way, we can free up memory or start collecting data from scratch.