### PR TITLE
Add embedded controller sensors for ROG STRIX X570-E GAMING

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -174,6 +174,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     return Model.LP_BI_P45_T2RS_Elite;
                 case var _ when name.Equals("ROG STRIX X470-I GAMING", StringComparison.OrdinalIgnoreCase):
                     return Model.ROG_STRIX_X470_I;
+                case var _ when name.Equals("ROG STRIX X570-E GAMING", StringComparison.OrdinalIgnoreCase):
+                    return Model.ROG_STRIX_X570_E_GAMING;
                 case var _ when name.Equals("LP DK P55-T3eH9", StringComparison.OrdinalIgnoreCase):
                     return Model.LP_DK_P55_T3EH9;
                 case var _ when name.Equals("A890GXM-A", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -39,6 +39,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
         CROSSHAIR_III_FORMULA,
         ROG_CROSSHAIR_VIII_HERO,
         ROG_STRIX_X470_I,
+        ROG_STRIX_X570_E_GAMING,
         M2N_SLI_Deluxe,
         M4A79XTD_EVO,
         P5W_DH_Deluxe,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Motherboard.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Motherboard.cs
@@ -164,6 +164,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
 
             switch (model)
             {
+                case Model.ROG_STRIX_X570_E_GAMING:
                 case Model.ROG_CROSSHAIR_VIII_HERO:
                 {
                     sources.AddRange(new EmbeddedControllerSource[]
@@ -175,11 +176,18 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                         new("VRM", 0x3E, SensorType.Temperature, EmbeddedController.ReadByte),
                         new("CPU Opt", 0xB0, SensorType.Fan, EmbeddedController.ReadWordBE),
                         new("Chipset", 0xB4, SensorType.Fan, EmbeddedController.ReadWordBE),
-                        // TODO: "why 42?" is a silly question, I know, but still, why? On the serious side, it might be 41.6(6)
-                        new("Flow Rate", 0xBC, SensorType.Flow, (ecIO, port) => ecIO.ReadWordBE(port) / 42f * 60f),
                         new("CPU", 0xF4, SensorType.Current, EmbeddedController.ReadByte)
                     });
+                    break;
+                }
+            }
 
+            switch (model)
+            {
+                case Model.ROG_CROSSHAIR_VIII_HERO:
+                {
+                    // TODO: "why 42?" is a silly question, I know, but still, why? On the serious side, it might be 41.6(6)
+                    sources.Add(new("Flow Rate", 0xBC, SensorType.Flow, (ecIO, port) => ecIO.ReadWordBE(port) / 42f * 60f));
                     break;
                 }
             }


### PR DESCRIPTION
Based on the information provided by @berniyh in [comment](https://github.com/electrified/asus-wmi-sensors/issues/62#issuecomment-617375332) and PR #453. 