### PR TITLE
Extend ASUS EC detection to other Crosshair VIII models

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -141,7 +141,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     return Model.P55_Deluxe;
                 case var _ when name.Equals("Crosshair III Formula", StringComparison.OrdinalIgnoreCase):
                     return Model.CROSSHAIR_III_FORMULA;
-                case var _ when name.Equals("ROG CROSSHAIR VIII HERO", StringComparison.OrdinalIgnoreCase):
+                case var _ when name.StartsWith("ROG CROSSHAIR VIII", StringComparison.OrdinalIgnoreCase):
                     return Model.ROG_CROSSHAIR_VIII_HERO;
                 case var _ when name.Equals("M2N-SLI DELUXE", StringComparison.OrdinalIgnoreCase):
                     return Model.M2N_SLI_Deluxe;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -142,9 +142,9 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                 case var _ when name.Equals("Crosshair III Formula", StringComparison.OrdinalIgnoreCase):
                     return Model.CROSSHAIR_III_FORMULA;
                 case var _ when name.Equals("ROG CROSSHAIR VIII HERO", StringComparison.OrdinalIgnoreCase):
-                return Model.ROG_CROSSHAIR_VIII_HERO;
+                    return Model.ROG_CROSSHAIR_VIII_HERO;
                 case var _ when name.Equals("ROG CROSSHAIR VIII DARK HERO", StringComparison.OrdinalIgnoreCase):
-                return Model.ROG_CROSSHAIR_VIII_DARK_HERO;
+                    return Model.ROG_CROSSHAIR_VIII_DARK_HERO;
                 case var _ when name.Equals("M2N-SLI DELUXE", StringComparison.OrdinalIgnoreCase):
                     return Model.M2N_SLI_Deluxe;
                 case var _ when name.Equals("M4A79XTD EVO", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -141,8 +141,10 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     return Model.P55_Deluxe;
                 case var _ when name.Equals("Crosshair III Formula", StringComparison.OrdinalIgnoreCase):
                     return Model.CROSSHAIR_III_FORMULA;
-                case var _ when name.StartsWith("ROG CROSSHAIR VIII", StringComparison.OrdinalIgnoreCase):
-                    return Model.ROG_CROSSHAIR_VIII_HERO;
+                case var _ when name.Equals("ROG CROSSHAIR VIII HERO", StringComparison.OrdinalIgnoreCase):
+                return Model.ROG_CROSSHAIR_VIII_HERO;
+                case var _ when name.Equals("ROG CROSSHAIR VIII DARK HERO", StringComparison.OrdinalIgnoreCase):
+                return Model.ROG_CROSSHAIR_VIII_DARK_HERO;
                 case var _ when name.Equals("M2N-SLI DELUXE", StringComparison.OrdinalIgnoreCase):
                     return Model.M2N_SLI_Deluxe;
                 case var _ when name.Equals("M4A79XTD EVO", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
@@ -70,7 +70,6 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc.EC
                 }
             }
 
-
             switch (model)
             {
                 case Model.ROG_CROSSHAIR_VIII_HERO:

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
@@ -43,6 +43,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc.EC
             {
                 case Model.ROG_STRIX_X570_E_GAMING:
                 case Model.ROG_CROSSHAIR_VIII_HERO:
+                case Model.ROG_CROSSHAIR_VIII_DARK_HERO:
                 {
                     sources.AddRange(new EmbeddedControllerSource[]
                     {
@@ -52,7 +53,6 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc.EC
                         new("T Sensor", 0x3D, SensorType.Temperature, ReadByte),
                         new("VRM", 0x3E, SensorType.Temperature, ReadByte),
                         new("CPU Opt", 0xB0, SensorType.Fan, ReadWordBE),
-                        new("Chipset", 0xB4, SensorType.Fan, ReadWordBE),
                         new("CPU", 0xF4, SensorType.Current, ReadByte)
                     });
 
@@ -62,7 +62,19 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc.EC
 
             switch (model)
             {
+                case Model.ROG_STRIX_X570_E_GAMING:
                 case Model.ROG_CROSSHAIR_VIII_HERO:
+                {
+                    sources.Add(new EmbeddedControllerSource("Chipset", 0xB4, SensorType.Fan, ReadWordBE));
+                    break;
+                }
+            }
+
+
+            switch (model)
+            {
+                case Model.ROG_CROSSHAIR_VIII_HERO:
+                case Model.ROG_CROSSHAIR_VIII_DARK_HERO:
                 {
                     // TODO: "why 42?" is a silly question, I know, but still, why? On the serious side, it might be 41.6(6)
                     sources.Add(new EmbeddedControllerSource("Flow Rate", 0xBC, SensorType.Flow, (ecIO, port) => ecIO.ReadWordBE(port) / 42f * 60f));

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -38,6 +38,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
         // ASUS
         CROSSHAIR_III_FORMULA,
         ROG_CROSSHAIR_VIII_HERO,
+        ROG_CROSSHAIR_VIII_DARK_HERO,
         ROG_STRIX_X470_I,
         ROG_STRIX_X570_E_GAMING,
         M2N_SLI_Deluxe,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2314,6 +2314,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             break;
                         }
                         case Model.ROG_CROSSHAIR_VIII_HERO: // NCT6798D
+                        case Model.ROG_CROSSHAIR_VIII_DARK_HERO: // NCT6798D
                         {
                             v.Add(new Voltage("Vcore", 0));
                             v.Add(new Voltage("Voltage #2", 1, true));


### PR DESCRIPTION
Tested to work on my CROSSHAIR VIII Dark Hero.
*Should* also work on the Impact, Formula and Extreme boards since they use the same sensors and thereby most likely the same EC.

Alternatively, an extra case with `name.Equals("ROG CROSSHAIR VIII DARK HERO", StringComparison.OrdinalIgnoreCase)` could be used instead.