### PR TITLE
Add Gigabyte X570 Gaming X motherboard

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -311,6 +311,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     return Model.X470_AORUS_GAMING_7_WIFI;
                 case var _ when name.Equals("X570 AORUS MASTER", StringComparison.OrdinalIgnoreCase):
                     return Model.X570_AORUS_MASTER;
+                case var _ when name.Equals("X570 GAMING X", StringComparison.OrdinalIgnoreCase):
+                    return Model.X570_GAMING_X;
                 case var _ when name.Equals("TUF GAMING B550M-PLUS (WI-FI)", StringComparison.OrdinalIgnoreCase):
                     return Model.TUF_GAMING_B550M_PLUS_WIFI;    
                 case var _ when name.Equals("Base Board Product Name", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -127,6 +127,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
         Z68XP_UD3R,
         X470_AORUS_GAMING_7_WIFI,
         X570_AORUS_MASTER,
+        X570_GAMING_X,
 
         // Shuttle
         FH67,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1306,6 +1306,34 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
 
                             break;
                         }
+                        case Model.X570_GAMING_X: // IT8688E
+                        {
+                            v.Add(new Voltage("Vcore", 0));
+                            v.Add(new Voltage("+3.3V", 1, 29.4f, 45.3f));
+                            v.Add(new Voltage("+12V", 2, 10f, 2f));
+                            v.Add(new Voltage("+5V", 3, 15f, 10f));
+                            v.Add(new Voltage("Vcore SoC", 4));
+                            v.Add(new Voltage("VDDP", 5));
+                            v.Add(new Voltage("DIMM AB", 6));
+                            t.Add(new Temperature("System #1", 0));
+                            t.Add(new Temperature("System #2", 1));
+                            t.Add(new Temperature("CPU", 2));
+                            t.Add(new Temperature("PCIe x16", 3));
+                            t.Add(new Temperature("VRM MOS", 4));
+                            t.Add(new Temperature("PCH", 5));
+                            f.Add(new Fan("CPU Fan", 0));
+                            f.Add(new Fan("System Fan #1", 1));
+                            f.Add(new Fan("System Fan #2", 2));
+                            f.Add(new Fan("PCH Fan", 3));
+                            f.Add(new Fan("CPU OPT Fan", 4));
+                            c.Add(new Ctrl("CPU Fan", 0));
+                            c.Add(new Ctrl("System Fan #1", 1));
+                            c.Add(new Ctrl("System Fan #2", 2));
+                            c.Add(new Ctrl("PCH Fan", 3));
+                            c.Add(new Ctrl("CPU OPT Fan", 4));
+                            
+                            break;
+                        }
                         case Model.Z390_M_GAMING: // IT8688E
                         case Model.Z390_AORUS_ULTRA:
                         case Model.Z390_UD:


### PR DESCRIPTION
Adds Gigabyte X570 Gaming X motherboard to the supported hardware list.

Allows proper voltage reading and fan names.

Voltages and fans tested against Gigabyte SIV (system information viewer), and HWInfo64 (v7.06) on a revision 1.0 motherboard with F34 bios