### PR TITLE
Added fan control support for motherboards with W836XX chips

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/W836XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/W836XX.cs
@@ -14,12 +14,28 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
 {
     internal class W836XX : ISuperIO
     {
+
         private readonly ushort _address;
         private readonly bool[] _peciTemperature = new bool[0];
         private readonly byte _revision;
         private readonly byte[] _voltageBank = new byte[0];
         private readonly float _voltageGain = 0.008f;
         private readonly byte[] _voltageRegister = new byte[0];
+
+        // Added to control fans. 
+        private readonly byte[] _fanPwmRegister = new byte[0];
+        private readonly byte[] _fanControlModeRegister = new byte[0];
+        private readonly byte[] _fanControlValue = new byte[0];
+        private readonly byte[] _fanSecondaryControlModeRegister = new byte[0];
+        private readonly byte[] _fanSecondaryControlValue = new byte[0];
+        private readonly byte[] _fanTertiaryControlModeRegister = new byte[0];
+        private readonly byte[] _fanTertiaryControlValue = new byte[0];
+
+        private readonly byte[] _initialFanControlValue = new byte[0];
+        private readonly byte[] _initialFanSecondaryControlValue = new byte[0];
+        private readonly byte[] _initialFanTertiaryControlValue = new byte[0];
+
+        private bool[] _restoreDefaultFanPwmControlRequired = new bool[0];
 
         public W836XX(Chip chip, byte revision, ushort address)
         {
@@ -37,56 +53,104 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
             {
                 case Chip.W83667HG:
                 case Chip.W83667HGB:
-                    // note temperature sensor registers that read PECI
-                    byte flag = ReadByte(0, TEMPERATURE_SOURCE_SELECT_REG);
-                    _peciTemperature[0] = (flag & 0x04) != 0;
-                    _peciTemperature[1] = (flag & 0x40) != 0;
-                    _peciTemperature[2] = false;
-                    break;
+                // note temperature sensor registers that read PECI
+                byte flag = ReadByte(0, TEMPERATURE_SOURCE_SELECT_REG);
+                _peciTemperature[0] = (flag & 0x04) != 0;
+                _peciTemperature[1] = (flag & 0x40) != 0;
+                _peciTemperature[2] = false;
+                break;
                 case Chip.W83627DHG:
                 case Chip.W83627DHGP:
-                    // note temperature sensor registers that read PECI
-                    byte sel = ReadByte(0, TEMPERATURE_SOURCE_SELECT_REG);
-                    _peciTemperature[0] = (sel & 0x07) != 0;
-                    _peciTemperature[1] = (sel & 0x70) != 0;
-                    _peciTemperature[2] = false;
-                    break;
+                // note temperature sensor registers that read PECI
+                byte sel = ReadByte(0, TEMPERATURE_SOURCE_SELECT_REG);
+                _peciTemperature[0] = (sel & 0x07) != 0;
+                _peciTemperature[1] = (sel & 0x70) != 0;
+                _peciTemperature[2] = false;
+                break;
                 default:
-                    // no PECI support
-                    _peciTemperature[0] = false;
-                    _peciTemperature[1] = false;
-                    _peciTemperature[2] = false;
-                    break;
+                // no PECI support
+                _peciTemperature[0] = false;
+                _peciTemperature[1] = false;
+                _peciTemperature[2] = false;
+                break;
             }
 
             switch (chip)
             {
                 case Chip.W83627EHF:
-                    Voltages = new float?[10];
-                    _voltageRegister = new byte[] { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x50, 0x51, 0x52 };
-                    _voltageBank = new byte[] { 0, 0, 0, 0, 0, 0, 0, 5, 5, 5 };
-                    _voltageGain = 0.008f;
-                    Fans = new float?[5];
-                    break;
+                Voltages = new float?[10];
+                _voltageRegister = new byte[] { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x50, 0x51, 0x52 };
+                _voltageBank = new byte[] { 0, 0, 0, 0, 0, 0, 0, 5, 5, 5 };
+                _voltageGain = 0.008f;
+                Fans = new float?[5];
+                _fanPwmRegister = new byte[] { 0x01, 0x03, 0x11 }; // Fan PWM values.
+                _fanControlModeRegister = new byte[] { 0x04, 0x04, 0x12 }; // Primary control register.
+                _fanControlValue = new byte[] { 0b11110011, 0b11001111, 0b11111001 }; // Values to gain control of fans.
+                _initialFanControlValue = new byte[3]; // To store default value.
+                _initialFanSecondaryControlValue = new byte[3]; // To store default value.
+                Controls = new float?[3];
+                break;
                 case Chip.W83627DHG:
                 case Chip.W83627DHGP:
+                Voltages = new float?[9];
+                _voltageRegister = new byte[] { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x50, 0x51 };
+                _voltageBank = new byte[] { 0, 0, 0, 0, 0, 0, 0, 5, 5 };
+                _voltageGain = 0.008f;
+                Fans = new float?[5];
+                _fanPwmRegister = new byte[] { 0x01, 0x03, 0x11 }; // Fan PWM values
+                _fanControlModeRegister = new byte[] { 0x04, 0x04, 0x12 }; // added. Primary control register
+                _fanControlValue = new byte[] { 0b11110011, 0b11001111, 0b11111001 }; // Values to gain control of fans
+                _initialFanControlValue = new byte[3]; // added to store default value
+                _initialFanSecondaryControlValue = new byte[3]; // To store default value.
+                Controls = new float?[3];
+                break;
                 case Chip.W83667HG:
                 case Chip.W83667HGB:
-                    Voltages = new float?[9];
-                    _voltageRegister = new byte[] { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x50, 0x51 };
-                    _voltageBank = new byte[] { 0, 0, 0, 0, 0, 0, 0, 5, 5 };
-                    _voltageGain = 0.008f;
-                    Fans = new float?[5];
-                    break;
+                Voltages = new float?[9];
+                _voltageRegister = new byte[] { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x50, 0x51 };
+                _voltageBank = new byte[] { 0, 0, 0, 0, 0, 0, 0, 5, 5 };
+                _voltageGain = 0.008f;
+                Fans = new float?[5];
+                _fanPwmRegister = new byte[] { 0x01, 0x03, 0x11 }; // Fan PWM values.
+                _fanControlModeRegister = new byte[] { 0x04, 0x04, 0x12 }; // Primary control register.
+                _fanControlValue = new byte[] { 0b11110011, 0b11001111, 0b11111001 }; // Values to gain control of fans.
+                _fanSecondaryControlModeRegister = new byte[] { 0x7c, 0x7c, 0x7c }; // Secondary control register for SmartFan4.
+                _fanSecondaryControlValue = new byte[] { 0b11101111, 0b11011111, 0b10111111 }; // Values for secondary register to gain control of fans.
+                _fanTertiaryControlModeRegister = new byte[] { 0x62, 0x7c, 0x62 }; // Tertiary control register. 2nd fan doesn't have Tertiary control, same as secondary to avoid change.
+                _fanTertiaryControlValue = new byte[] { 0b11101111, 0b11011111, 0b11011111 }; // Values for tertiary register to gain control of fans. 2nd fan doesn't have Tertiary control, same as secondary to avoid change.
+                _initialFanControlValue = new byte[3]; // To store default value.
+                _initialFanSecondaryControlValue = new byte[3]; // To store default value.
+                _initialFanTertiaryControlValue = new byte[3]; // To store default value.
+                Controls = new float?[3];
+                break;
                 case Chip.W83627HF:
+                Voltages = new float?[7];
+                _voltageRegister = new byte[] { 0x20, 0x21, 0x22, 0x23, 0x24, 0x50, 0x51 };
+                _voltageBank = new byte[] { 0, 0, 0, 0, 0, 5, 5 };
+                _voltageGain = 0.016f;
+                Fans = new float?[3];
+                _fanPwmRegister = new byte[] { 0x5A, 0x5B }; // Fan PWM values.
+                Controls = new float?[2];
+                break;
                 case Chip.W83627THF:
+                Voltages = new float?[7];
+                _voltageRegister = new byte[] { 0x20, 0x21, 0x22, 0x23, 0x24, 0x50, 0x51 };
+                _voltageBank = new byte[] { 0, 0, 0, 0, 0, 5, 5 };
+                _voltageGain = 0.016f;
+                Fans = new float?[3];
+                _fanPwmRegister = new byte[] { 0x01, 0x03, 0x11 }; // Fan PWM values.
+                _fanControlModeRegister = new byte[] { 0x04, 0x04, 0x12 }; // Primary control register.
+                _fanControlValue = new byte[] { 0b11110011, 0b11001111, 0b11111001 }; // Values to gain control of fans.
+                _initialFanControlValue = new byte[3]; // To store default value.
+                Controls = new float?[3];
+                break;
                 case Chip.W83687THF:
-                    Voltages = new float?[7];
-                    _voltageRegister = new byte[] { 0x20, 0x21, 0x22, 0x23, 0x24, 0x50, 0x51 };
-                    _voltageBank = new byte[] { 0, 0, 0, 0, 0, 5, 5 };
-                    _voltageGain = 0.016f;
-                    Fans = new float?[3];
-                    break;
+                Voltages = new float?[7];
+                _voltageRegister = new byte[] { 0x20, 0x21, 0x22, 0x23, 0x24, 0x50, 0x51 };
+                _voltageBank = new byte[] { 0, 0, 0, 0, 0, 5, 5 };
+                _voltageGain = 0.016f;
+                Fans = new float?[3];
+                break;
             }
         }
 
@@ -105,11 +169,99 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
             return null;
         }
 
-        public void WriteGpio(int index, byte value)
-        { }
+        public void WriteGpio(int index, byte value) { }
 
         public void SetControl(int index, byte? value)
-        { }
+        {
+            if (index < 0 || index >= Controls.Length)
+                throw new ArgumentOutOfRangeException("index");
+
+            if (!Ring0.WaitIsaBusMutex(10))
+                return;
+
+            if (value.HasValue)
+            {
+                SaveDefaultFanPwmControl(index);
+                if (_fanControlModeRegister.Length > 0)
+                {
+                    WriteByte(0, _fanControlModeRegister[index], (byte)(_fanControlValue[index] & ReadByte(0, _fanControlModeRegister[index])));
+                    if (_fanSecondaryControlModeRegister.Length > 0)
+                    {
+                        if (_fanSecondaryControlModeRegister[index] != _fanControlModeRegister[index])
+                        {
+                            WriteByte(0, _fanSecondaryControlModeRegister[index], (byte)(_fanSecondaryControlValue[index] & ReadByte(0, _fanSecondaryControlModeRegister[index])));
+                        }
+                        if (_fanTertiaryControlModeRegister.Length > 0)
+                        {
+                            if (_fanTertiaryControlModeRegister[index] != _fanSecondaryControlModeRegister[index])
+                            {
+                                WriteByte(0, _fanTertiaryControlModeRegister[index], (byte)(_fanTertiaryControlValue[index] & ReadByte(0, _fanTertiaryControlModeRegister[index])));
+                            }
+                        }
+                    }
+                }
+                // set output value
+                WriteByte(0, _fanPwmRegister[index], (byte)(value.Value));
+            }
+            else
+            {
+                RestoreDefaultFanPwmControl(index);
+            }
+
+            Ring0.ReleaseIsaBusMutex();
+        }
+
+        private void SaveDefaultFanPwmControl(int index) //added to save initial control values
+        {
+            if (_fanControlModeRegister.Length > 0 && _initialFanControlValue.Length > 0 && _fanControlValue.Length > 0 && _restoreDefaultFanPwmControlRequired.Length > 0)
+            {
+                if (!_restoreDefaultFanPwmControlRequired[index])
+                {
+                    _initialFanControlValue[index] = ReadByte(0, _fanControlModeRegister[index]);
+                    if (_fanSecondaryControlModeRegister.Length > 0 && _initialFanSecondaryControlValue.Length > 0 && _fanSecondaryControlValue.Length > 0)
+                    {
+                        if (_fanSecondaryControlModeRegister[index] != _fanControlModeRegister[index])
+                        {
+                            _initialFanSecondaryControlValue[index] = ReadByte(0, _fanSecondaryControlModeRegister[index]);
+                        }
+                        if (_fanTertiaryControlModeRegister.Length > 0 && _initialFanTertiaryControlValue.Length > 0 && _fanTertiaryControlValue.Length > 0)
+                        {
+                            if (_fanTertiaryControlModeRegister[index] != _fanSecondaryControlModeRegister[index])
+                            {
+                                _initialFanTertiaryControlValue[index] = ReadByte(0, _fanTertiaryControlModeRegister[index]);
+                            }
+                        }
+                    }
+                    _restoreDefaultFanPwmControlRequired[index] = true;
+                }
+            }
+        }
+
+        private void RestoreDefaultFanPwmControl(int index) //added to restore initial control values
+        {
+            if (_fanControlModeRegister.Length > 0 && _initialFanControlValue.Length > 0 && _fanControlValue.Length > 0 && _restoreDefaultFanPwmControlRequired.Length > 0)
+            {
+                if (_restoreDefaultFanPwmControlRequired[index])
+                {
+                    WriteByte(0, _fanControlModeRegister[index], (byte)((_initialFanControlValue[index] & ~_fanControlValue[index]) | ReadByte(0, _fanControlModeRegister[index]))); //bitwise operands to change only desired bits
+                    if (_fanSecondaryControlModeRegister.Length > 0 && _initialFanSecondaryControlValue.Length > 0 && _fanSecondaryControlValue.Length > 0)
+                    {
+                        if (_fanSecondaryControlModeRegister[index] != _fanControlModeRegister[index])
+                        {
+                            WriteByte(0, _fanSecondaryControlModeRegister[index], (byte)((_initialFanSecondaryControlValue[index] & ~_fanSecondaryControlValue[index]) | ReadByte(0, _fanSecondaryControlModeRegister[index]))); //bitwise operands to change only desired bits
+                        }
+                        if (_fanTertiaryControlModeRegister.Length > 0 && _initialFanTertiaryControlValue.Length > 0 && _fanTertiaryControlValue.Length > 0)
+                        {
+                            if (_fanTertiaryControlModeRegister[index] != _fanSecondaryControlModeRegister[index])
+                            {
+                                WriteByte(0, _fanTertiaryControlModeRegister[index], (byte)((_initialFanTertiaryControlValue[index] & ~_fanTertiaryControlValue[index]) | ReadByte(0, _fanTertiaryControlModeRegister[index]))); //bitwise operands to change only desired bits
+                            }
+                        }
+                    }
+                    _restoreDefaultFanPwmControlRequired[index] = false;
+                }
+            }
+        }
 
         public void Update()
         {
@@ -186,9 +338,9 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
 
                 // assemble fan divisor
                 int divisorBits = (int)(
-                    (((bits >> FAN_DIV_BIT2[i]) & 1) << 2) |
-                    (((bits >> FAN_DIV_BIT1[i]) & 1) << 1) |
-                    ((bits >> FAN_DIV_BIT0[i]) & 1));
+                  (((bits >> FAN_DIV_BIT2[i]) & 1) << 2) |
+                  (((bits >> FAN_DIV_BIT1[i]) & 1) << 1) |
+                  ((bits >> FAN_DIV_BIT0[i]) & 1));
 
                 int divisor = 1 << divisorBits;
 
@@ -208,7 +360,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
             }
 
             // write new fan divisors
-            for (int i = FAN_BIT_REG.Length - 1; i >= 0; i--)
+            /*for (int i = FAN_BIT_REG.Length - 1; i >= 0; i--)
             {
                 byte oldByte = (byte)(bits & 0xFF);
                 byte newByte = (byte)(newBits & 0xFF);
@@ -216,6 +368,12 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                 newBits >>= 8;
                 if (oldByte != newByte)
                     WriteByte(0, FAN_BIT_REG[i], newByte);
+            }*/
+
+            for (int i = 0; i < Controls.Length; i++)
+            {
+                byte value = ReadByte(0, _fanPwmRegister[i]);
+                Controls[i] = (float)Math.Round((value) * 100.0f / 0xFF);
             }
 
             Ring0.ReleaseIsaBusMutex();

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -282,7 +282,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                 }
                 case Chip.W83627EHF:
                 {
-                    GetWinbondConfigurationEhf(manufacturer, model, v, t, f);
+                    GetWinbondConfigurationEhf(manufacturer, model, v, t, f, c);
 
                     break;
                 }
@@ -291,11 +291,30 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                 case Chip.W83667HG:
                 case Chip.W83667HGB:
                 {
-                    GetWinbondConfigurationHg(manufacturer, model, v, t, f);
+                    GetWinbondConfigurationHg(manufacturer, model, v, t, f, c);
 
                     break;
                 }
                 case Chip.W83627HF:
+                {
+                    v.Add(new Voltage("Vcore", 0));
+                    v.Add(new Voltage("Voltage #2", 1, true));
+                    v.Add(new Voltage("Voltage #3", 2, true));
+                    v.Add(new Voltage("AVCC", 3, 34, 51));
+                    v.Add(new Voltage("Voltage #5", 4, true));
+                    v.Add(new Voltage("+5VSB", 5, 34, 51));
+                    v.Add(new Voltage("VBat", 6));
+                    t.Add(new Temperature("CPU", 0));
+                    t.Add(new Temperature("Auxiliary", 1));
+                    t.Add(new Temperature("System", 2));
+                    f.Add(new Fan("System Fan", 0));
+                    f.Add(new Fan("CPU Fan", 1));
+                    f.Add(new Fan("Auxiliary Fan", 2));
+                    c.Add(new Ctrl("Fan 1", 0));
+                    c.Add(new Ctrl("Fan 2", 1));
+
+                    break;
+                }
                 case Chip.W83627THF:
                 case Chip.W83687THF:
                 {
@@ -312,6 +331,9 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     f.Add(new Fan("System Fan", 0));
                     f.Add(new Fan("CPU Fan", 1));
                     f.Add(new Fan("Auxiliary Fan", 2));
+                    c.Add(new Ctrl("System Fan", 0));
+                    c.Add(new Ctrl("CPU Fan", 1));
+                    c.Add(new Ctrl("Auxiliary Fan", 2));
 
                     break;
                 }
@@ -2689,7 +2711,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
             }
         }
 
-        private static void GetWinbondConfigurationEhf(Manufacturer manufacturer, Model model, IList<Voltage> v, IList<Temperature> t, IList<Fan> f)
+        private static void GetWinbondConfigurationEhf(Manufacturer manufacturer, Model model, IList<Voltage> v, IList<Temperature> t, IList<Fan> f, IList<Ctrl> c)
         {
             switch (manufacturer)
             {
@@ -2710,6 +2732,9 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             t.Add(new Temperature("Motherboard", 2));
                             f.Add(new Fan("CPU Fan", 0));
                             f.Add(new Fan("Chassis Fan", 1));
+                            c.Add(new Ctrl("System Fan", 0));
+                            c.Add(new Ctrl("CPU Fan", 1));
+                            c.Add(new Ctrl("Auxiliary Fan", 2));
 
                             break;
                         }
@@ -2733,6 +2758,9 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             f.Add(new Fan("Auxiliary Fan", 2));
                             f.Add(new Fan("CPU Fan #2", 3));
                             f.Add(new Fan("Auxiliary Fan #2", 4));
+                            c.Add(new Ctrl("System Fan", 0));
+                            c.Add(new Ctrl("CPU Fan", 1));
+                            c.Add(new Ctrl("Auxiliary Fan", 2));
 
                             break;
                         }
@@ -2760,13 +2788,16 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     f.Add(new Fan("Auxiliary Fan", 2));
                     f.Add(new Fan("CPU Fan #2", 3));
                     f.Add(new Fan("Auxiliary Fan #2", 4));
+                    c.Add(new Ctrl("System Fan", 0));
+                    c.Add(new Ctrl("CPU Fan", 1));
+                    c.Add(new Ctrl("Auxiliary Fan", 2));
 
                     break;
                 }
             }
         }
 
-        private static void GetWinbondConfigurationHg(Manufacturer manufacturer, Model model, IList<Voltage> v, IList<Temperature> t, IList<Fan> f)
+        private static void GetWinbondConfigurationHg(Manufacturer manufacturer, Model model, IList<Voltage> v, IList<Temperature> t, IList<Fan> f, IList<Ctrl> c)
         {
             switch (manufacturer)
             {
@@ -2787,6 +2818,9 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             f.Add(new Fan("Chassis Fan", 0));
                             f.Add(new Fan("CPU Fan", 1));
                             f.Add(new Fan("Power Fan", 2));
+                            c.Add(new Ctrl("System Fan", 0));
+                            c.Add(new Ctrl("CPU Fan", 1));
+                            c.Add(new Ctrl("Auxiliary Fan", 2));
 
                             break;
                         }
@@ -2809,6 +2843,9 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             f.Add(new Fan("Auxiliary Fan", 2));
                             f.Add(new Fan("CPU Fan #2", 3));
                             f.Add(new Fan("Auxiliary Fan #2", 4));
+                            c.Add(new Ctrl("System Fan", 0));
+                            c.Add(new Ctrl("CPU Fan", 1));
+                            c.Add(new Ctrl("Auxiliary Fan", 2));
 
                             break;
                         }
@@ -2821,8 +2858,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     switch (model)
                     {
                         case Model.P6T: // W83667HG
-                        case Model.P6X58D_E: // W83667HG
-                        case Model.RAMPAGE_II_GENE: // W83667HG
+                        case Model.P6X58D_E: // W83667HG                 
+                        case Model.RAMPAGE_II_GENE: // W83667HG 
                         {
                             v.Add(new Voltage("Vcore", 0));
                             v.Add(new Voltage("+12V", 1, 11.5f, 1.91f));
@@ -2838,10 +2875,13 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             f.Add(new Fan("Power Fan", 2));
                             f.Add(new Fan("Chassis Fan #2", 3));
                             f.Add(new Fan("Chassis Fan #3", 4));
+                            c.Add(new Ctrl("System Fan", 0));
+                            c.Add(new Ctrl("CPU Fan", 1));
+                            c.Add(new Ctrl("Auxiliary Fan", 2));
 
                             break;
                         }
-                        case Model.RAMPAGE_EXTREME: // W83667HG
+                        case Model.RAMPAGE_EXTREME: // W83667HG 
                         {
                             v.Add(new Voltage("Vcore", 0));
                             v.Add(new Voltage("+12V", 1, 12, 2));
@@ -2857,6 +2897,9 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             f.Add(new Fan("Power Fan", 2));
                             f.Add(new Fan("Chassis Fan #2", 3));
                             f.Add(new Fan("Chassis Fan #3", 4));
+                            c.Add(new Ctrl("System Fan", 0));
+                            c.Add(new Ctrl("CPU Fan", 1));
+                            c.Add(new Ctrl("Auxiliary Fan", 2));
 
                             break;
                         }
@@ -2879,6 +2922,9 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             f.Add(new Fan("Auxiliary Fan", 2));
                             f.Add(new Fan("CPU Fan #2", 3));
                             f.Add(new Fan("Auxiliary Fan #2", 4));
+                            c.Add(new Ctrl("System Fan", 0));
+                            c.Add(new Ctrl("CPU Fan", 1));
+                            c.Add(new Ctrl("Auxiliary Fan", 2));
 
                             break;
                         }
@@ -2905,6 +2951,9 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     f.Add(new Fan("Auxiliary Fan", 2));
                     f.Add(new Fan("CPU Fan #2", 3));
                     f.Add(new Fan("Auxiliary Fan #2", 4));
+                    c.Add(new Ctrl("System Fan", 0));
+                    c.Add(new Ctrl("CPU Fan", 1));
+                    c.Add(new Ctrl("Auxiliary Fan", 2));
 
                     break;
                 }

--- a/LibreHardwareMonitorLib/Interop/AtiAdlxx.cs
+++ b/LibreHardwareMonitorLib/Interop/AtiAdlxx.cs
@@ -121,7 +121,7 @@ namespace LibreHardwareMonitor.Interop
         public static extern ADLStatus ADL_Graphics_Versions_Get(out ADLVersionsInfo versionInfo);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern ADLStatus ADL2_Adapter_FrameMetrics_Caps(IntPtr context, int adapterIndex, ref int supported);
+        private static extern ADLStatus ADL2_Adapter_FrameMetrics_Caps(IntPtr context, int adapterIndex, ref int supported);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
         public static extern ADLStatus ADL2_Adapter_FrameMetrics_Get(IntPtr context, int adapterIndex, int displayIndex, ref float fps);


### PR DESCRIPTION
Changes were based on datasheet information. Tested with a p6t and works perfectly. Had to comment "new fan divisors" part because it was messing with the RPM reads when fan speed is set anything different than 100%