### PR TITLE
Fixed compatibility with older AMD/ATI cards when calling ADL2_Adapter_FrameMetrics_Caps

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Gpu/AmdGpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Gpu/AmdGpu.cs
@@ -131,8 +131,8 @@ namespace LibreHardwareMonitor.Hardware.Gpu
             int enabled = 0;
             int version = 0;
 
-            if (AtiAdlxx.ADL2_Adapter_FrameMetrics_Caps(_context, _adapterIndex, ref supported) == AtiAdlxx.ADLStatus.ADL_OK)
-            {
+            if (AtiAdlxx.ADL_Method_Exists("ADL2_Adapter_FrameMetrics_Caps") && AtiAdlxx.ADL2_Adapter_FrameMetrics_Caps(_context, _adapterIndex, ref supported) == AtiAdlxx.ADLStatus.ADL_OK)
+            { 
                 if (supported == AtiAdlxx.ADL_TRUE && AtiAdlxx.ADL2_Adapter_FrameMetrics_Start(_context, _adapterIndex, 0) == AtiAdlxx.ADLStatus.ADL_OK)
                 {
                     _frameMetricsStarted = true;

--- a/LibreHardwareMonitorLib/Hardware/Gpu/AmdGpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Gpu/AmdGpu.cs
@@ -132,7 +132,7 @@ namespace LibreHardwareMonitor.Hardware.Gpu
             int version = 0;
 
             if (AtiAdlxx.ADL_Method_Exists("ADL2_Adapter_FrameMetrics_Caps") && AtiAdlxx.ADL2_Adapter_FrameMetrics_Caps(_context, _adapterIndex, ref supported) == AtiAdlxx.ADLStatus.ADL_OK)
-            { 
+            {
                 if (supported == AtiAdlxx.ADL_TRUE && AtiAdlxx.ADL2_Adapter_FrameMetrics_Start(_context, _adapterIndex, 0) == AtiAdlxx.ADLStatus.ADL_OK)
                 {
                     _frameMetricsStarted = true;

--- a/LibreHardwareMonitorLib/Interop/AtiAdlxx.cs
+++ b/LibreHardwareMonitorLib/Interop/AtiAdlxx.cs
@@ -135,9 +135,13 @@ namespace LibreHardwareMonitor.Interop
         public static bool ADL_Method_Exists(string ADL_Method)
         {
             IntPtr module = Kernel32.LoadLibrary(DllName);
-            bool ret = Kernel32.GetProcAddress(module, ADL_Method) != IntPtr.Zero;
-            Kernel32.FreeLibrary(module);
-            return ret;
+            if (module != IntPtr.Zero)
+            {
+                bool result = Kernel32.GetProcAddress(module, ADL_Method) != IntPtr.Zero;
+                Kernel32.FreeLibrary(module);
+                return result;
+            }
+            return false;
         }
 
         public static ADLStatus ADL_Main_Control_Create(int enumConnectedAdapters)

--- a/LibreHardwareMonitorLib/Interop/AtiAdlxx.cs
+++ b/LibreHardwareMonitorLib/Interop/AtiAdlxx.cs
@@ -130,7 +130,15 @@ namespace LibreHardwareMonitor.Interop
         public static extern ADLStatus ADL2_Adapter_FrameMetrics_Start(IntPtr context, int adapterIndex, int displayIndex);
 
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern ADLStatus ADL2_Adapter_FrameMetrics_Stop(IntPtr context, int adapterIndex, int displayIndex);       
+        public static extern ADLStatus ADL2_Adapter_FrameMetrics_Stop(IntPtr context, int adapterIndex, int displayIndex);
+
+        public static bool ADL_Method_Exists(string ADL_Method)
+        {
+            IntPtr module = Kernel32.LoadLibrary(DllName);
+            bool ret = Kernel32.GetProcAddress(module, ADL_Method) != IntPtr.Zero;
+            Kernel32.FreeLibrary(module);
+            return ret;
+        }
 
         public static ADLStatus ADL_Main_Control_Create(int enumConnectedAdapters)
         {


### PR DESCRIPTION
AtiDlxx.ADL2_Adapter_FrameMetrics_Caps is not present in older drivers, so calling it in Hardware/Gpu/AmdGpu.cs was throwing an exception preventing LHM to detect older cards. My proposed fix is to add a method in AtiDlxx.cs to check if a method is present in the DLL file and calling it in AmdGpu.cs before the actual method.
It can be used with any method, so in the future it would be wiser to use this instead of assuming that the method exists to ensure compatibility.

Added a function ADL_Method_Exists in Interop/AtiDlxx.cs to check if an entry point of a given method name exists.
Added a call to ADL_Method_Exists in Hardware/Gpu/AmdGpu.cs before calling AtiDlxx.ADL2_Adapter_FrameMetrics_Caps.

Issue: #529 