### PR TITLE
Fixes for ASUS Crosshair VIII Hero

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedControllerReader.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedControllerReader.cs
@@ -5,5 +5,5 @@
 
 namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc.EC
 {
-    public delegate float EmbeddedControllerReader(IEmbeddedControllerIO ecIO, byte port);
+    public delegate float EmbeddedControllerReader(IEmbeddedControllerIO ecIO, ushort register);
 }

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedControllerSource.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedControllerSource.cs
@@ -7,17 +7,23 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc.EC
 {
     public class EmbeddedControllerSource
     {
-        public EmbeddedControllerSource(string name, byte port, SensorType type, EmbeddedControllerReader reader)
+        public EmbeddedControllerSource(string name, SensorType type, ushort register, byte size, float factor = 1.0f, uint blank = uint.MaxValue)
         {
             Name = name;
-            Port = port;
+
+            Register = register;
+            Size = size;
             Type = type;
-            Reader = reader;
+            Factor = factor;
+            Blank = blank;
         }
 
         public string Name { get; }
+        public ushort Register { get; }
+        public byte Size { get; }
+        public float Factor { get; }
 
-        public byte Port { get; }
+        public uint Blank { get; }
 
         public EmbeddedControllerReader Reader { get; }
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/IEmbeddedControllerIO.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/IEmbeddedControllerIO.cs
@@ -9,14 +9,6 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc.EC
 {
     public interface IEmbeddedControllerIO : IDisposable
     {
-        void WriteByte(byte register, byte value);
-
-        void WriteWord(byte register, ushort value);
-
-        byte ReadByte(byte register);
-
-        ushort ReadWordBE(byte register);
-
-        ushort ReadWordLE(byte register);
+        void Read(ushort[] registers, byte[] data);
     }
 }

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
@@ -224,15 +224,6 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                                 new TemperatureSourceData(SourceNct67Xxd.PECI_1_CAL, 0),
                                 new TemperatureSourceData(SourceNct67Xxd.VIRTUAL_TEMP, 0)
                             });
-
-                            if (chip == Chip.NCT6798D)
-                            {
-                                temperaturesSources.AddRange(new TemperatureSourceData[]
-                                {
-                                    new TemperatureSourceData(SourceNct67Xxd.WATER_IN, 0xC33),
-                                    new TemperatureSourceData(SourceNct67Xxd.WATER_OUT, 0xC39)
-                                });
-                            }
                             break;
                         }
                         default:
@@ -990,9 +981,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
             BYTE_TEMP1 = 27,
             PECI_0_CAL = 28,
             PECI_1_CAL = 29,
-            VIRTUAL_TEMP = 31,
-            WATER_IN = 32,
-            WATER_OUT = 33
+            VIRTUAL_TEMP = 31
         }
 
         [SuppressMessage("ReSharper", "InconsistentNaming")]

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2386,11 +2386,19 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             t.Add(new Temperature("Water In", 24));
                             t.Add(new Temperature("Water Out", 25));
 
-                            for (int i = 0; i < superIO.Fans.Length; i++)
-                                f.Add(new Fan("Fan #" + (i + 1), i));
+                            string[] fanControlNames = {"Chassis Fan 1", "CPU Fan", "Chassis Fan 2",
+                                "Chassis Fan 3", "High Amp Fan", "W_PUMP+", "AIO Pump"};
+                            System.Diagnostics.Debug.Assert(fanControlNames.Length == superIO.Fans.Length,
+                                string.Format("Expected {0} fan register in the SuperIO chip", fanControlNames.Length));
+                            System.Diagnostics.Debug.Assert(superIO.Fans.Length == superIO.Controls.Length,
+                                "Expected counts of fan controls and fan speed registers to be equal");
 
-                            for (int i = 0; i < superIO.Controls.Length; i++)
-                                c.Add(new Ctrl("Fan Control #" + (i + 1), i));
+                            for (int i = 0; i < fanControlNames.Length; i++)
+                                f.Add(new Fan(fanControlNames[i], i));
+                           
+                            for (int i = 0; i < fanControlNames.Length; i++)
+                                c.Add(new Ctrl(fanControlNames[i], i));
+
 
                             break;
                         }

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2383,8 +2383,6 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             t.Add(new Temperature("PECI 0 Calibrated", 21));
                             t.Add(new Temperature("PECI 1 Calibrated", 22));
                             t.Add(new Temperature("Virtual", 23));
-                            t.Add(new Temperature("Water In", 24));
-                            t.Add(new Temperature("Water Out", 25));
 
                             string[] fanControlNames = {"Chassis Fan 1", "CPU Fan", "Chassis Fan 2",
                                 "Chassis Fan 3", "High Amp Fan", "W_PUMP+", "AIO Pump"};


### PR DESCRIPTION
This implements bank switching for the EC controller and uses that to read water temperatures. The sensors in the Nuvoton chips that were thought to be water temperatures turned out to be QFan sources and are removed for now.

Also supplies correct default fan and controls names.

I plan to use ASUS WMI functions to read EC (and maybe Nuvoton) state to avoid race between LHM and ASUS AISuite and perhaps firmware when reading data. However, calling those methods in Windows did not work from the first attempt and hence this PR brings EC bank switching using the direct port write method, which is potentially dangerous (but other 3rd-party monitoring software use it anyway), and reduces the `IEmbeddedControllerIO` to the only function, available in the ASUS DSDT code. 