### PR TITLE
Fix float to byte conversion.

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Controller/Nzxt/KrakenX3.cs
+++ b/LibreHardwareMonitorLib/Hardware/Controller/Nzxt/KrakenX3.cs
@@ -129,6 +129,7 @@ namespace LibreHardwareMonitor.Hardware.Controller.Nzxt
                 catch (ObjectDisposedException)
                 {
                     // Could be unplugged, or the app is stopping...
+                    return;
                 }
             }
         }

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -87,7 +87,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             }
                             case ControlMode.Software:
                             {
-                                superIO.SetControl(index, (byte)(cc.SoftwareValue * 2.55));
+                                superIO.SetControl(index, GetSoftwareValueAsByte(cc));
                                 break;
                             }
                             default:
@@ -100,7 +100,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     control.SoftwareControlValueChanged += cc =>
                     {
                         if (cc.ControlMode == ControlMode.Software)
-                            superIO.SetControl(index, (byte)(cc.SoftwareValue * 2.55));
+                            superIO.SetControl(index, GetSoftwareValueAsByte(cc));
                     };
 
                     switch (control.ControlMode)
@@ -117,7 +117,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                         }
                         case ControlMode.Software:
                         {
-                            superIO.SetControl(index, (byte)(control.SoftwareValue * 2.55));
+                            superIO.SetControl(index, GetSoftwareValueAsByte(control));
 
                             break;
                         }
@@ -128,6 +128,13 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     ActivateSensor(sensor);
                 }
             }
+        }
+
+        private static byte GetSoftwareValueAsByte(Control control)
+        {
+            const float percentToByteRatio = 2.55f;
+            float value = control.SoftwareValue * percentToByteRatio;
+            return (byte)value;
         }
 
         private void CreateFanSensors(ISuperIO superIO, ISettings settings, IList<Fan> f)


### PR DESCRIPTION
The conversion was using an implicit double between the float value to the byte value, which cause some issue with a software value of 100f, which resulted to 254 instead of 255.

Extracted the conversion as a function.

The problem simplified:
```c#
float floatValue = 100f;
float byteValue = floatValue * 2.55f;

// 254
byte a = (byte)((floatValue * 2.55f));
// 255
byte b = (byte)(byteValue);

// false
Console.WriteLine(a == b);
```