### PR TITLE
Added Gigabyte Z390 Aorus Pro labels

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -273,6 +273,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     return Model.Z390_M_GAMING;
                 case var _ when name.Equals("Z390 AORUS ULTRA", StringComparison.OrdinalIgnoreCase):
                     return Model.Z390_AORUS_ULTRA;
+                case var _ when name.Equals("Z390 AORUS PRO-CF", StringComparison.OrdinalIgnoreCase):
+                    return Model.Z390_AORUS_PRO;
                 case var _ when name.Equals("Z390 UD", StringComparison.OrdinalIgnoreCase):
                     return Model.Z390_UD;
                 case var _ when name.Equals("FH67", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -518,7 +518,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
 
         private readonly byte[] FAN_PWM_CTRL_REG;
         private readonly byte[] FAN_PWM_CTRL_EXT_REG = { 0x63, 0x6b, 0x73, 0x7b, 0xa3 };
-        private readonly byte[] FAN_TACHOMETER_EXT_REG = { 0x18, 0x19, 0x1a, 0x81, 0x83, 0x4c };
+        private readonly byte[] FAN_TACHOMETER_EXT_REG = { 0x18, 0x19, 0x1a, 0x81, 0x83, 0x4d };
         private readonly byte[] FAN_TACHOMETER_REG = { 0x0d, 0x0e, 0x0f, 0x80, 0x82, 0x4c };
 
         // Address of the Fan Controller Main Control Register.

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -119,6 +119,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
         X58A_UD3R,
         X79_UD3,
         Z390_AORUS_ULTRA,
+        Z390_AORUS_PRO,
         Z390_M_GAMING,
         Z390_UD,
         Z68A_D3H_B3,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1629,6 +1629,29 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
 
                             break;
                         }
+                        case Model.Z390_AORUS_PRO: // IT879XE
+                        {
+                            v.Add(new Voltage("VCore", 0));
+                            v.Add(new Voltage("DDRVTT AB", 1));
+                            v.Add(new Voltage("Chipset Core", 2));
+                            v.Add(new Voltage("VIN3", 3, true));
+                            v.Add(new Voltage("VCCIO", 4));
+                            v.Add(new Voltage("Voltage #7", 5, true));
+                            v.Add(new Voltage("DDR VPP", 6));
+                            v.Add(new Voltage("3VSB", 7, 1f, 1f));
+                            v.Add(new Voltage("VBat", 8, 1f, 1f));
+                            t.Add(new Temperature("PCIe x8", 0));
+                            t.Add(new Temperature("EC_TEMP2", 1));
+                            t.Add(new Temperature("System #2", 2));
+                            f.Add(new Fan("System Fan #5 Pump", 0));
+                            f.Add(new Fan("System Fan #6 Pump", 1));
+                            f.Add(new Fan("System Fan #4", 2));
+                            c.Add(new Ctrl("Fan Control #5", 0));
+                            c.Add(new Ctrl("Fan Control #6", 1));
+                            c.Add(new Ctrl("Fan Control #4", 2));
+
+                            break;
+                        }
                         default:
                         {
                             v.Add(new Voltage("Voltage #1", 0, true));


### PR DESCRIPTION
Added sensors labels for Gigabyte Z390 Aorus Pro motherboard.
Fixed typo in FAN_TACHOMETER_EXT_REG address.