### PR TITLE
Remove duplicate nvidia moniker in hardware name

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Gpu/NvidiaGpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Gpu/NvidiaGpu.cs
@@ -876,8 +876,10 @@ namespace LibreHardwareMonitor.Hardware.Gpu
         private static string GetName(NvApi.NvPhysicalGpuHandle handle)
         {
             if (NvApi.NvAPI_GPU_GetFullName(handle, out string gpuName) == NvApi.NvStatus.OK)
-                return "NVIDIA " + gpuName.Trim();
-
+            {
+                string name = gpuName.Trim();
+                return name.StartsWith("NVIDIA", StringComparison.OrdinalIgnoreCase) ? name : "NVIDIA " + name;
+            }
 
             return "NVIDIA";
         }


### PR DESCRIPTION
If the name of the GPU starts with "NVIDIA" then NVIDIA is listed twice in the
name (eg: NVIDIA NVIDIA GeForce GTX 1070).

The fix for this is to only prepend NVIDIA when the queried name does not
start with NVIDIA.

Verified locally.