### PR TITLE
[Bugfix] Allow GET access to Computer SMBios table

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Computer.cs
+++ b/LibreHardwareMonitorLib/Hardware/Computer.cs
@@ -84,7 +84,7 @@ namespace LibreHardwareMonitor.Hardware
             get
             {
                 if (!_open)
-                    throw new InvalidOperationException("Computer's SMBIOS table cannot be accessed before opening.");
+                    throw new InvalidOperationException("SMBIOS cannot be accessed before opening.");
 
                 return _smbios;
             }


### PR DESCRIPTION
Easy access to an already open SMBios table will not do any harm and may facilitate management when someone using the library wants information from it.