### PR TITLE
Save report with log extension by default

### DIFF
--- a/LibreHardwareMonitor/UI/MainForm.Designer.cs
+++ b/LibreHardwareMonitor/UI/MainForm.Designer.cs
@@ -1,7 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 // Copyright (C) LibreHardwareMonitor and Contributors.
-// Partial Copyright (C) Michael M�ller <mmoeller@openhardwaremonitor.org> and Contributors.
+// Partial Copyright (C) Michael Möller <mmoeller@openhardwaremonitor.org> and Contributors.
 // All Rights Reserved.
 
 namespace LibreHardwareMonitor.UI


### PR DESCRIPTION
Many editors support **.log** file syntax highlighting by default, which can make it easier for users to read the values.

![image](https://user-images.githubusercontent.com/13592821/138811450-f71831c3-5872-45b7-9dad-1458da37213a.png)
