### PR TITLE
Add support to IT8631E

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
@@ -29,6 +29,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
 
         IT8620E = 0x8620,
         IT8628E = 0x8628,
+        IT8631E = 0x8631,
         IT8655E = 0x8655,
         IT8665E = 0x8665,
         IT8686E = 0x8686,
@@ -93,6 +94,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
 
                 case Chip.IT8620E: return "ITE IT8620E";
                 case Chip.IT8628E: return "ITE IT8628E";
+                case Chip.IT8631E: return "ITE IT8631E";
                 case Chip.IT8655E: return "ITE IT8655E";
                 case Chip.IT8665E: return "ITE IT8665E";
                 case Chip.IT8686E: return "ITE IT8686E";

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -78,10 +78,19 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                          chip == Chip.IT8628E ||
                          chip == Chip.IT8620E ||
                          chip == Chip.IT879XE ||
-                         chip == Chip.IT8655E;
+                         chip == Chip.IT8655E ||
+                         chip == Chip.IT8631E;
 
             switch (chip)
             {
+                case Chip.IT8631E:
+                {
+                    Voltages = new float?[9];
+                    Temperatures = new float?[2];
+                    Fans = new float?[2];
+                    Controls = new float?[2];
+                    break;
+                }
                 case Chip.IT8665E:
                 case Chip.IT8686E:
                 {
@@ -149,6 +158,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                 // All others 16mV.
                 case Chip.IT8620E:
                 case Chip.IT8628E:
+                case Chip.IT8631E:
                 case Chip.IT8721F:
                 case Chip.IT8728F:
                 case Chip.IT8771E:

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
@@ -675,6 +675,9 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                 case 0x8628:
                     chip = Chip.IT8628E;
                     break;
+                case 0x8631: 
+                    chip = Chip.IT8631E; 
+                    break;
                 case 0x8665:
                     chip = Chip.IT8665E;
                     break;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -236,6 +236,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                 }
                 case Chip.IT8620E:
                 case Chip.IT8628E:
+                case Chip.IT8631E:
                 case Chip.IT8655E:
                 case Chip.IT8665E:
                 case Chip.IT8686E:


### PR DESCRIPTION
Add support to HP Pavilion Gaming TG01-2013n
Motherboard:
    HP name: Erica
    SSID: 8643
Chipset:
    AMD Promontory B550A

