### PR TITLE
added Gigabyte Z170N-WIFI support and fixed iTE IT8628E

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -271,6 +271,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     return Model.Z68X_UD7_B3;
                 case var _ when name.Equals("Z68XP-UD3R", StringComparison.OrdinalIgnoreCase):
                     return Model.Z68XP_UD3R;
+                case var _ when name.Equals("Z170N-WIFI-CF", StringComparison.OrdinalIgnoreCase):
+                    return Model.Z170N_WIFI;
                 case var _ when name.Equals("Z390 M GAMING-CF", StringComparison.OrdinalIgnoreCase):
                     return Model.Z390_M_GAMING;
                 case var _ when name.Equals("Z390 AORUS ULTRA", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -83,6 +83,15 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
 
             switch (chip)
             {
+                case Chip.IT8628E:
+                {
+                    Voltages = new float?[10];
+                    Temperatures = new float?[6];
+                    //Number of fans and controls are merely a guess: could be higher but lower-bounded by 2.
+                    Fans = new float?[2];
+                    Controls = new float?[2];
+                    break;
+                }
                 case Chip.IT8631E:
                 {
                     Voltages = new float?[9];

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -87,9 +87,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                 {
                     Voltages = new float?[10];
                     Temperatures = new float?[6];
-                    //Number of fans and controls are merely a guess: could be higher but lower-bounded by 2.
-                    Fans = new float?[2];
-                    Controls = new float?[2];
+                    Fans = new float?[4];
+                    Controls = new float?[4];
                     break;
                 }
                 case Chip.IT8631E:

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -129,6 +129,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
         Z68X_UD3H_B3,
         Z68X_UD7_B3,
         Z68XP_UD3R,
+        Z170N_WIFI,
         X470_AORUS_GAMING_7_WIFI,
         X570_AORUS_MASTER,
         X570_GAMING_X,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1224,6 +1224,35 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
 
                             break;
                         }
+                        case Model.Z170N_WIFI: // ITE IT8628E
+                        {
+                            v.Add(new Voltage("Vcore", 0, 0, 1));
+                            v.Add(new Voltage("+3.3V", 1, 6.5F, 10));
+                            v.Add(new Voltage("+12V", 2, 5, 1));
+                            v.Add(new Voltage("+5V", 3, 1.5F, 1));
+                            // NO DIMM CD channels on this motherboard; gives a very tiny voltage reading
+                            // v.Add(new Voltage("DIMM CD", 4, 0, 1));
+                            v.Add(new Voltage("iGPU VAXG", 5, 0, 1));
+                            v.Add(new Voltage("DIMM AB", 6, 0, 1));
+                            v.Add(new Voltage("3VSB", 7, 10, 10));
+                            v.Add(new Voltage("VBat", 8, 10, 10));
+                            v.Add(new Voltage("AVCC3", 9, 54, 10));
+
+                            t.Add(new Temperature("System #1", 0));
+                            t.Add(new Temperature("PCH", 1));
+                            t.Add(new Temperature("CPU", 2));
+                            t.Add(new Temperature("PCIe x16", 3));
+                            t.Add(new Temperature("VRM", 4));
+                            t.Add(new Temperature("System #2", 5));
+
+                            f.Add(new Fan("CPU Fan", 0));
+                            f.Add(new Fan("System Fan", 1));
+
+                            c.Add(new Ctrl("CPU Fan", 0));
+                            c.Add(new Ctrl("System Fan", 1));
+
+                            break;
+                        }
                         case Model.AX370_Gaming_K7: // IT8686E
                         case Model.AX370_Gaming_5:
                         case Model.AB350_Gaming_3: // IT8686E


### PR DESCRIPTION
IT8628E reports 6 temperatures not 3. This change allows reporting for Gigabyte Z170N-WIFI VRM mosfet temperatures. A few minor things related to supporting the motherboard were cleaned up.