### PR TITLE
Add support for the Gigabyte B360 AORUS GAMING 3 WIFI-CF mainboard.

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -323,6 +323,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     return Model.X570_GAMING_X;
                 case var _ when name.Equals("TUF GAMING B550M-PLUS (WI-FI)", StringComparison.OrdinalIgnoreCase):
                     return Model.TUF_GAMING_B550M_PLUS_WIFI;
+                case var _ when name.Equals("B360 AORUS GAMING 3 WIFI-CF", StringComparison.OrdinalIgnoreCase):
+                return Model.B360_AORUS_GAMING_3_WIFI_CF;
                 case var _ when name.Equals("B560M AORUS ELITE", StringComparison.OrdinalIgnoreCase):
                     return Model.B560M_AORUS_ELITE;
                 case var _ when name.Equals("Base Board Product Name", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -86,6 +86,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
         AB350_Gaming_3,
         AX370_Gaming_5,
         AX370_Gaming_K7,
+        B360_AORUS_GAMING_3_WIFI_CF,
         B560M_AORUS_ELITE,
         EP45_DS3R,
         EP45_UD3R,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1362,6 +1362,36 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
 
                             break;
                         }
+                        case Model.B360_AORUS_GAMING_3_WIFI_CF: // IT8688E
+                        {
+                            v.Add(new Voltage("Vcore", 0));
+                            v.Add(new Voltage("+3.3V", 1, 29.4f, 45.3f));
+                            v.Add(new Voltage("+12V", 2, 10f, 2f));
+                            v.Add(new Voltage("+5V", 3, 15f, 10f));
+                            v.Add(new Voltage("CPU Vcore", 4, 0, 1));
+                            v.Add(new Voltage("CPU VCCSA", 5, 0, 1));
+                            v.Add(new Voltage("DIMM AB", 6, 0, 1));
+                            v.Add(new Voltage("3VSB", 7, 1, 1));
+                            v.Add(new Voltage("VBat", 8, 1, 1));
+                            t.Add(new Temperature("System #1", 0));
+                            t.Add(new Temperature("EC_TEMP1", 1));
+                            t.Add(new Temperature("CPU", 2));
+                            t.Add(new Temperature("PCIe x16", 3));
+                            t.Add(new Temperature("VRM MOS", 4));
+                            t.Add(new Temperature("PCH", 5));
+                            f.Add(new Fan("CPU Fan", 0));
+                            f.Add(new Fan("System Fan #1", 1));
+                            f.Add(new Fan("System Fan #2", 2));
+                            f.Add(new Fan("PCH Fan", 3));
+                            f.Add(new Fan("CPU OPT Fan", 4));
+                            c.Add(new Ctrl("CPU Fan", 0));
+                            c.Add(new Ctrl("System Fan #1", 1));
+                            c.Add(new Ctrl("System Fan #2", 2));
+                            c.Add(new Ctrl("PCH Fan", 3));
+                            c.Add(new Ctrl("CPU OPT Fan", 4));
+
+                            break;
+                        }
                         case Model.X570_AORUS_MASTER: // IT8688E
                         {
                             v.Add(new Voltage("Vcore", 0));


### PR DESCRIPTION
This mainboard uses the IT8686E controller, and it only needed to be
added to the list reusing most of the values from X570_AORUS_MASTER.