### PR TITLE
Add support for B560M AORUS PRO and B560M AORUS PRO AX

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -341,6 +341,10 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                 return Model.B360_AORUS_GAMING_3_WIFI_CF;
                 case var _ when name.Equals("B560M AORUS ELITE", StringComparison.OrdinalIgnoreCase):
                     return Model.B560M_AORUS_ELITE;
+                case var _ when name.Equals("B560M AORUS PRO", StringComparison.OrdinalIgnoreCase):
+                    return Model.B560M_AORUS_PRO;
+                case var _ when name.Equals("B560M AORUS PRO AX", StringComparison.OrdinalIgnoreCase):
+                    return Model.B560M_AORUS_PRO_AX;
                 case var _ when name.Equals("Base Board Product Name", StringComparison.OrdinalIgnoreCase):
                 case var _ when name.Equals("To be filled by O.E.M.", StringComparison.OrdinalIgnoreCase):
                     return Model.Unknown;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -95,6 +95,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
         AX370_Gaming_K7,
         B360_AORUS_GAMING_3_WIFI_CF,
         B560M_AORUS_ELITE,
+        B560M_AORUS_PRO,
+        B560M_AORUS_PRO_AX,
         EP45_DS3R,
         EP45_UD3R,
         EX58_EXTREME,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1332,6 +1332,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             break;
                         }
                         case Model.B560M_AORUS_ELITE: // IT8689E
+                        case Model.B560M_AORUS_PRO:
+                        case Model.B560M_AORUS_PRO_AX:
                         {
                             v.Add(new Voltage("Vcore", 0));
                             v.Add(new Voltage("+3.3V", 1, 29.4f, 45.3f));


### PR DESCRIPTION
- They are detected as ITE8689E
- Available sensors seems to match the ones from B560M Aorus Elite
- Sensor values for B560M Aorus Pro are matching hwinfo values using the settings
- Pro Ax should be same motherboard with extra WiFi chip