### PR TITLE
Support Z690 Aorus Pro (DDR5)

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -291,6 +291,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     return Model.Z390_AORUS_PRO;
                 case var _ when name.Equals("Z390 UD", StringComparison.OrdinalIgnoreCase):
                     return Model.Z390_UD;
+                case var _ when name.Equals("Z690 AORUS PRO", StringComparison.OrdinalIgnoreCase):
+                    return Model.Z690_AORUS_PRO;
                 case var _ when name.Equals("FH67", StringComparison.OrdinalIgnoreCase):
                     return Model.FH67;
                 case var _ when name.Equals("AX370-Gaming K7", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
@@ -35,7 +35,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
         IT8686E = 0x8686,
         IT8688E = 0x8688,
         IT8689E = 0x8689,
-        IT8695E = 0x8695, // name unclear. May be also IT8795E
+        IT8695E = 0x8695,
         IT8705F = 0x8705,
         IT8712F = 0x8712,
         IT8716F = 0x8716,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
@@ -35,6 +35,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
         IT8686E = 0x8686,
         IT8688E = 0x8688,
         IT8689E = 0x8689,
+        IT8695E = 0x8695, // name unclear. May be also IT8795E
         IT8705F = 0x8705,
         IT8712F = 0x8712,
         IT8716F = 0x8716,
@@ -100,6 +101,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                 case Chip.IT8686E: return "ITE IT8686E";
                 case Chip.IT8688E: return "ITE IT8688E";
                 case Chip.IT8689E: return "ITE IT8689E";
+                case Chip.IT8695E: return "ITE IT8695E";
                 case Chip.IT8705F: return "ITE IT8705F";
                 case Chip.IT8712F: return "ITE IT8712F";
                 case Chip.IT8716F: return "ITE IT8716F";

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -16,13 +16,13 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
     {
         private readonly ushort _address;
         private readonly ushort _addressReg;
+        private readonly int _bankCount;
         private readonly ushort _dataReg;
         private readonly bool[] _fansDisabled = new bool[0];
         private readonly ushort _gpioAddress;
         private readonly int _gpioCount;
         private readonly bool _has16BitFanCounter;
         private readonly bool _hasExtReg;
-        private readonly int _bankCount;
         private readonly bool[] _initialFanOutputModeEnabled = new bool[3]; // Initial Fan Controller Main Control Register value. 
         private readonly byte[] _initialFanPwmControl = new byte[5]; // This will also store the 2nd control register value.
         private readonly byte[] _initialFanPwmControlExt = new byte[5];

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -22,12 +22,15 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
         private readonly int _gpioCount;
         private readonly bool _has16BitFanCounter;
         private readonly bool _hasExtReg;
+        private readonly int _countBanks;
         private readonly bool[] _initialFanOutputModeEnabled = new bool[3]; // Initial Fan Controller Main Control Register value. 
         private readonly byte[] _initialFanPwmControl = new byte[5]; // This will also store the 2nd control register value.
         private readonly byte[] _initialFanPwmControlExt = new byte[5];
         private readonly bool[] _restoreDefaultFanPwmControlRequired = new bool[5];
         private readonly byte _version;
         private readonly float _voltageGain;
+
+        private bool SupportsMultipleBanks => _countBanks > 1;
 
         public IT87XX(Chip chip, ushort address, ushort gpioAddress, byte version)
         {
@@ -67,7 +70,13 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
 
             FAN_PWM_CTRL_REG = chip == Chip.IT8665E
                 ? new byte[] { 0x15, 0x16, 0x17, 0x1e, 0x1f }
-                : new byte[] { 0x15, 0x16, 0x17, 0x7f, 0xa7 };
+                : new byte[] { 0x15, 0x16, 0x17, 0x7f, 0xa7, 0xaf };
+
+            _countBanks = chip switch
+            {
+                Chip.IT8689E => 4,
+                _ => 1
+            };
 
             _hasExtReg = chip == Chip.IT8721F ||
                          chip == Chip.IT8728F ||
@@ -75,6 +84,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                          chip == Chip.IT8686E ||
                          chip == Chip.IT8688E ||
                          chip == Chip.IT8689E ||
+                         chip == Chip.IT8695E ||
                          chip == Chip.IT8628E ||
                          chip == Chip.IT8620E ||
                          chip == Chip.IT879XE ||
@@ -122,6 +132,14 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                     Temperatures = new float?[6];
                     Fans = new float?[5];
                     Controls = new float?[5];
+                    break;
+                }
+                case Chip.IT8695E:
+                {
+                    Voltages = new float?[6];
+                    Temperatures = new float?[3];
+                    Fans = new float?[3];
+                    Controls = new float?[3];
                     break;
                 }
                 case Chip.IT8655E:
@@ -176,6 +194,11 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                 case Chip.IT8689E:
                 {
                     _voltageGain = 0.012f;
+                    break;
+                }
+                case Chip.IT8695E:
+                {
+                    _voltageGain = 11f / 1000f;
                     break;
                 }
                 case Chip.IT8655E:
@@ -321,25 +344,40 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
             if (!Ring0.WaitIsaBusMutex(100))
                 return r.ToString();
 
-
-            r.AppendLine("Environment Controller Registers");
-            r.AppendLine();
-            r.AppendLine("      00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F");
-            r.AppendLine();
-            for (int i = 0; i <= 0xA; i++)
+            // dump memory of all banks if supported by chip
+            for (byte b = 0; b < _countBanks; b++)
             {
-                r.Append(" ");
-                r.Append((i << 4).ToString("X2", CultureInfo.InvariantCulture));
-                r.Append("  ");
-                for (int j = 0; j <= 0xF; j++)
+                if (SupportsMultipleBanks && b > 0)
+                {
+                    SelectBank(b);    
+                }
+                r.AppendLine($"Environment Controller Registers Bank {b}");
+                r.AppendLine();
+                r.AppendLine("      00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F");
+                r.AppendLine();
+                for (int i = 0; i <= 0xA; i++)
                 {
                     r.Append(" ");
-                    byte value = ReadByte((byte)((i << 4) | j), out bool valid);
-                    r.Append(valid ? value.ToString("X2", CultureInfo.InvariantCulture) : "??");
-                }
+                    r.Append((i << 4).ToString("X2", CultureInfo.InvariantCulture));
+                    r.Append("  ");
+                    for (int j = 0; j <= 0xF; j++)
+                    {
+                        r.Append(" ");
+                        byte value = ReadByte((byte)((i << 4) | j), out bool valid);
+                        r.Append(valid ? value.ToString("X2", CultureInfo.InvariantCulture) : "??");
+                    }
 
+                    r.AppendLine();
+                }
+                
                 r.AppendLine();
             }
+
+            if (SupportsMultipleBanks)
+            {
+                SelectBank(0);                
+            }
+            
 
             r.AppendLine();
 
@@ -355,6 +393,49 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
             r.AppendLine();
             Ring0.ReleaseIsaBusMutex();
             return r.ToString();
+        }
+    
+        /// <summary>
+        /// Return the currently active bank index.
+        /// </summary>
+        /// <returns></returns>
+        private int GetCurrentBank()
+        {
+            if (_countBanks <= 1)
+                return 0; // current chip does not support multi bank registers
+            
+            var value = ReadByte(BANK_REGISTER, out bool valid);
+            if (valid)
+            {
+                return (value & 0x60) >> 5;
+            }
+            else
+            {
+                return -1;
+            }
+        }
+
+        /// <summary>
+        /// Selects another bank. Memory from 0x10-0xAF swaps to data from new bank.
+        /// Beware to select the default bank 0 after changing.
+        /// Bank selection is reset after power cycle.
+        /// </summary>
+        /// <param name="bankIndex">New bank index. Can be a value of 0-3.</param>
+        private void SelectBank(byte bankIndex)
+        {
+            if (bankIndex >= _countBanks)
+                return; // current chip does not support that many banks
+
+            // hard cap SelectBank to 2 bit values. If we ever have chips with more bank bits rewrite this method.
+            bankIndex &= 0x3;
+
+            var value = ReadByte(BANK_REGISTER, out bool valid);
+            if (valid)
+            {
+                value &= 0x9F;
+                value |= (byte)(bankIndex << 5);
+                WriteByte(BANK_REGISTER, value );
+            }
         }
 
         public void Update()
@@ -535,6 +616,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
 
         private const byte CONFIGURATION_REGISTER = 0x00;
         private const byte DATA_REGISTER_OFFSET = 0x06;
+        private const byte BANK_REGISTER = 0x06; // bit 5-6 define selected bank
         private const byte FAN_TACHOMETER_16BIT_REGISTER = 0x0C;
         private const byte FAN_TACHOMETER_DIVISOR_REGISTER = 0x0B;
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -22,7 +22,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
         private readonly int _gpioCount;
         private readonly bool _has16BitFanCounter;
         private readonly bool _hasExtReg;
-        private readonly int _countBanks;
+        private readonly int _bankCount;
         private readonly bool[] _initialFanOutputModeEnabled = new bool[3]; // Initial Fan Controller Main Control Register value. 
         private readonly byte[] _initialFanPwmControl = new byte[5]; // This will also store the 2nd control register value.
         private readonly byte[] _initialFanPwmControlExt = new byte[5];
@@ -30,7 +30,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
         private readonly byte _version;
         private readonly float _voltageGain;
 
-        private bool SupportsMultipleBanks => _countBanks > 1;
+        private bool SupportsMultipleBanks => _bankCount > 1;
 
         public IT87XX(Chip chip, ushort address, ushort gpioAddress, byte version)
         {
@@ -72,7 +72,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                 ? new byte[] { 0x15, 0x16, 0x17, 0x1e, 0x1f }
                 : new byte[] { 0x15, 0x16, 0x17, 0x7f, 0xa7, 0xaf };
 
-            _countBanks = chip switch
+            _bankCount = chip switch
             {
                 Chip.IT8689E => 4,
                 _ => 1
@@ -352,7 +352,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                 return r.ToString();
 
             // dump memory of all banks if supported by chip
-            for (byte b = 0; b < _countBanks; b++)
+            for (byte b = 0; b < _bankCount; b++)
             {
                 if (SupportsMultipleBanks && b > 0)
                 {
@@ -384,7 +384,6 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
             {
                 SelectBank(0);                
             }
-            
 
             r.AppendLine();
 
@@ -408,7 +407,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
         /// <returns></returns>
         private int GetCurrentBank()
         {
-            if (_countBanks <= 1)
+            if (_bankCount <= 1)
                 return 0; // current chip does not support multi bank registers
             
             var value = ReadByte(BANK_REGISTER, out bool valid);
@@ -430,7 +429,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
         /// <param name="bankIndex">New bank index. Can be a value of 0-3.</param>
         private void SelectBank(byte bankIndex)
         {
-            if (bankIndex >= _countBanks)
+            if (bankIndex >= _bankCount)
                 return; // current chip does not support that many banks
 
             // hard cap SelectBank to 2 bit values. If we ever have chips with more bank bits rewrite this method.

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -309,7 +309,14 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
 
                 if (_hasExtReg)
                 {
-                    WriteByte(FAN_PWM_CTRL_REG[index], (byte)(_initialFanPwmControl[index] & 0x7F));
+                    if (Chip == Chip.IT8689E)
+                    {
+                        WriteByte(FAN_PWM_CTRL_REG[index], 0x7F);
+                    }
+                    else
+                    {
+                        WriteByte(FAN_PWM_CTRL_REG[index], (byte)(_initialFanPwmControl[index] & 0x7F));    
+                    }
                     WriteByte(FAN_PWM_CTRL_EXT_REG[index], value.Value);
                 }
                 else

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
@@ -693,6 +693,9 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                 case 0x8689:
                     chip = Chip.IT8689E;
                     break;
+                case 0x8695:
+                    chip = Chip.IT8695E;
+                    break;
                 case 0x8705:
                     chip = Chip.IT8705F;
                     break;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -139,6 +139,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
         Z68X_UD3H_B3,
         Z68X_UD7_B3,
         Z68XP_UD3R,
+        Z690_AORUS_PRO,
         Z170N_WIFI,
         X470_AORUS_GAMING_7_WIFI,
         X570_AORUS_MASTER,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -251,6 +251,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
 
                     break;
                 }
+                case Chip.IT8695E:
                 case Chip.IT879XE:
                 {
                     GetIteConfigurationsC(superIO, manufacturer, model, v, t, f, c);
@@ -1516,6 +1517,25 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
 
                             break;
                         }
+                        case Model.Z690_AORUS_PRO:
+                        {
+                            t.Add(new Temperature("System #1", 0));
+                            t.Add(new Temperature("System #2", 1));
+                            t.Add(new Temperature("CPU", 2));
+                            t.Add(new Temperature("PCIe x16", 3));
+                            t.Add(new Temperature("VRM MOS", 4));
+                            f.Add(new Fan("CPU Fan", 0));
+                            f.Add(new Fan("System Fan #1", 1));
+                            f.Add(new Fan("System Fan #2", 2));
+                            f.Add(new Fan("System Fan #3", 3));
+                            f.Add(new Fan("CPU OPT Fan", 4));
+                            c.Add(new Ctrl("CPU Fan", 0));
+                            c.Add(new Ctrl("System Fan #1", 1));
+                            c.Add(new Ctrl("System Fan #2", 2));
+                            c.Add(new Ctrl("System Fan #3", 3));
+                            c.Add(new Ctrl("CPU OPT Fan", 4));
+                            break;
+                        }
                         case Model.Z68A_D3H_B3: // IT8728F
                         {
                             v.Add(new Voltage("VTT", 0));
@@ -1771,6 +1791,18 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             c.Add(new Ctrl("Fan Control #6", 1));
                             c.Add(new Ctrl("Fan Control #4", 2));
 
+                            break;
+                        }
+                        case Model.Z690_AORUS_PRO:
+                        {
+                            t.Add(new Temperature("System #3", 0));
+                            t.Add(new Temperature("System #4", 2));
+                            f.Add(new Fan("System Fan #5", 0));
+                            f.Add(new Fan("System Fan #6", 1));
+                            f.Add(new Fan("System Fan #4", 2));
+                            c.Add(new Ctrl("Fan Control #5", 0));
+                            c.Add(new Ctrl("Fan Control #6", 1));
+                            c.Add(new Ctrl("Fan Control #4", 2));
                             break;
                         }
                         default:

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1528,12 +1528,12 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             f.Add(new Fan("System Fan #1", 1));
                             f.Add(new Fan("System Fan #2", 2));
                             f.Add(new Fan("System Fan #3", 3));
-                            f.Add(new Fan("CPU OPT Fan", 4));
+                            f.Add(new Fan("CPU Optional Fan", 4));
                             c.Add(new Ctrl("CPU Fan", 0));
                             c.Add(new Ctrl("System Fan #1", 1));
                             c.Add(new Ctrl("System Fan #2", 2));
                             c.Add(new Ctrl("System Fan #3", 3));
-                            c.Add(new Ctrl("CPU OPT Fan", 4));
+                            c.Add(new Ctrl("CPU Optional Fan", 4));
                             break;
                         }
                         case Model.Z68A_D3H_B3: // IT8728F


### PR DESCRIPTION
- Improved IT8689E 
- Added IT8695E
- Added Mainboard Gigabyte Z690 Aorus Pro (DDR5)

Introduced Multi Bank support of chip IT8689E.
To control fans of IT8689E we may need to handle the multi banks.

- [x] Support control of fans of IT8689E
- [ ] Support control of fans of IT8695E