### PR TITLE
Adds EC T_Sensor for ROG Strix Z690-A DDR4

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -347,6 +347,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     return Model.B560M_AORUS_PRO;
                 case var _ when name.Equals("B560M AORUS PRO AX", StringComparison.OrdinalIgnoreCase):
                     return Model.B560M_AORUS_PRO_AX;
+                case var _ when name.Equals("ROG STRIX Z690-A GAMING WIFI D4", StringComparison.OrdinalIgnoreCase):
+                    return Model.ROG_STRIX_Z690_A_GAMING_WIFI_D4;
                 case var _ when name.Equals("Base Board Product Name", StringComparison.OrdinalIgnoreCase):
                 case var _ when name.Equals("To be filled by O.E.M.", StringComparison.OrdinalIgnoreCase):
                     return Model.Unknown;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
@@ -128,6 +128,11 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc.EC
                 Model.ROG_STRIX_X570_I_GAMING,
                 new ECSensor[] {
                     ECSensor.TempTSensor, ECSensor.FanVrmHS, ECSensor.FanChipset, ECSensor.CurrCPU }
+            },
+            {
+                Model.ROG_STRIX_Z690_A_GAMING_WIFI_D4,
+                new ECSensor[] {
+                    ECSensor.TempTSensor, ECSensor.TempVrm }
             }
         };
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -49,6 +49,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
         ROG_STRIX_B550_E_GAMING,
         ROG_STRIX_B550_F_GAMING_WIFI,
         ROG_STRIX_B550_I_GAMING,
+        ROG_STRIX_Z690_A_GAMING_WIFI_D4,
         M2N_SLI_Deluxe,
         M4A79XTD_EVO,
         P5W_DH_Deluxe,


### PR DESCRIPTION
Adds the T_sensor and VRM Temp from the EC controller on the ROG Strix Z690-A Wifi DDR4