### PR TITLE
IT8613E and Biostar B660GTN support

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -349,6 +349,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     return Model.B560M_AORUS_PRO_AX;
                 case var _ when name.Equals("ROG STRIX Z690-A GAMING WIFI D4", StringComparison.OrdinalIgnoreCase):
                     return Model.ROG_STRIX_Z690_A_GAMING_WIFI_D4;
+                case var _ when name.Equals("B660GTN", StringComparison.OrdinalIgnoreCase):
+                    return Model.B660GTN;
                 case var _ when name.Equals("Base Board Product Name", StringComparison.OrdinalIgnoreCase):
                 case var _ when name.Equals("To be filled by O.E.M.", StringComparison.OrdinalIgnoreCase):
                     return Model.Unknown;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
@@ -27,6 +27,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
         F71889ED = 0x0909,
         F71889F = 0x0723,
 
+        IT8613E = 0x8613,
         IT8620E = 0x8620,
         IT8628E = 0x8628,
         IT8631E = 0x8631,
@@ -92,7 +93,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                 case Chip.F71889ED: return "Fintek F71889ED";
                 case Chip.F71889F: return "Fintek F71889F";
                 case Chip.F71808E: return "Fintek F71808E";
-
+                case Chip.IT8613E: return "ITE IT8613E";
                 case Chip.IT8620E: return "ITE IT8620E";
                 case Chip.IT8628E: return "ITE IT8628E";
                 case Chip.IT8631E: return "ITE IT8631E";

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -87,12 +87,21 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                          chip == Chip.IT8695E ||
                          chip == Chip.IT8628E ||
                          chip == Chip.IT8620E ||
+                         chip == Chip.IT8613E ||
                          chip == Chip.IT879XE ||
                          chip == Chip.IT8655E ||
                          chip == Chip.IT8631E;
 
             switch (chip)
             {
+                case Chip.IT8613E:
+                {
+                    Voltages = new float?[10];
+                    Temperatures = new float?[4];
+                    Fans = new float?[5];
+                    Controls = new float?[4];
+                    break;
+                }
                 case Chip.IT8628E:
                 {
                     Voltages = new float?[10];
@@ -182,6 +191,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
             {
                 // IT8620E, IT8628E, IT8721F, IT8728F, IT8772E and IT8686E use a 12mV resolution.
                 // All others 16mV.
+                case Chip.IT8613E:
                 case Chip.IT8620E:
                 case Chip.IT8628E:
                 case Chip.IT8631E:

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
@@ -669,6 +669,9 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
             Chip chip;
             switch (chipId)
             {
+                case 0x8613:
+                    chip = Chip.IT8613E;
+                    break;
                 case 0x8620:
                     chip = Chip.IT8620E;
                     break;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -72,6 +72,9 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
         Z170_A,
         TUF_GAMING_B550M_PLUS_WIFI,
 
+        //BIOSTAR
+        B660GTN,
+
         // DFI
         LP_BI_P45_T2RS_Elite,
         LP_DK_P55_T3EH9,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -234,6 +234,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
 
                     break;
                 }
+                case Chip.IT8613E:
                 case Chip.IT8620E:
                 case Chip.IT8628E:
                 case Chip.IT8631E:
@@ -1618,6 +1619,65 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             f.Add(new Fan("System Fan #1", 1));
                             f.Add(new Fan("System Fan #2", 2));
                             f.Add(new Fan("System Fan #3", 3));
+
+                            break;
+                        }
+
+                        default:
+                        {
+                            v.Add(new Voltage("Voltage #1", 0, true));
+                            v.Add(new Voltage("Voltage #2", 1, true));
+                            v.Add(new Voltage("Voltage #3", 2, true));
+                            v.Add(new Voltage("Voltage #4", 3, true));
+                            v.Add(new Voltage("Voltage #5", 4, true));
+                            v.Add(new Voltage("Voltage #6", 5, true));
+                            v.Add(new Voltage("Voltage #7", 6, true));
+                            v.Add(new Voltage("3VSB", 7, 10, 10, 0, true));
+                            v.Add(new Voltage("VBat", 8, 10, 10));
+
+                            for (int i = 0; i < superIO.Temperatures.Length; i++)
+                                t.Add(new Temperature("Temperature #" + (i + 1), i));
+
+                            for (int i = 0; i < superIO.Fans.Length; i++)
+                                f.Add(new Fan("Fan #" + (i + 1), i));
+
+                            for (int i = 0; i < superIO.Controls.Length; i++)
+                                c.Add(new Ctrl("Fan Control #" + (i + 1), i));
+
+                            break;
+                        }
+                    }
+
+                    break;
+                }
+                case Manufacturer.Biostar:
+                {
+                    switch (model)
+                    {
+                        case Model.B660GTN: //IT8613E 
+                            //This board have some problems with their app Controling fans that I was able to replicate here so I guess is a Bios problem with the pins.
+                            //Biostar is aware so expect changes in the control pins with new bios.
+                            //In the meantime is possible to control CPUFAN and CPUOPT1 but not SYSFAN1. Readings are ok tho 
+                        {
+                            //the parameters are extracted from the Biostar app config file. 
+                            v.Add(new Voltage("Vcore", 0, 0, 1)); //this is right
+                            v.Add(new Voltage("DRAM", 1, 0, 1));  //This is exact
+                            v.Add(new Voltage("+12V", 2, 5, 1));  //Reads higher than it should 
+                            v.Add(new Voltage("+5V", 3, 147, 100));  //Again reads higher
+                            //Comented because I don't know if it makes sense
+                            //v.Add(new Voltage("VCC ST", 4)); // reads 4.2V
+                            //v.Add(new Voltage("VCCIN AUX", 5)); // reads 2.2V
+                            //v.Add(new Voltage("CPU GT", 6)); // reads 2.6V
+                            //v.Add(new Voltage("3VSB", 7, 10, 10)); //reads 5.8V ? 
+                            v.Add(new Voltage("VBat", 8, 10, 10)); //reads higher than it should 3.4V 
+                            t.Add(new Temperature("System1", 0));
+                            t.Add(new Temperature("System2", 1));  //not sure what sensor is this. it doesn't climb under stress 
+                            t.Add(new Temperature("CPU", 2));
+                            f.Add(new Fan("CPU Fan", 1));
+                            f.Add(new Fan("CPU OPT fan", 2));
+                            f.Add(new Fan("SYSFAN", 4));
+                            c.Add(new Ctrl("CPU Fan", 1));
+                            c.Add(new Ctrl("CPU OPT Fan", 2));
 
                             break;
                         }

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1622,7 +1622,6 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
 
                             break;
                         }
-
                         default:
                         {
                             v.Add(new Voltage("Voltage #1", 0, true));

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1656,7 +1656,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                         case Model.B660GTN: //IT8613E 
                             // This board has some problems with their app controlling fans that I was able to replicate here so I guess is a BIOS problem with the pins.
                             // Biostar is aware so expect changes in the control pins with new bios.
-                            / /In the meantime, it's possible to control CPUFAN and CPUOPT1m but not SYSFAN1.
+                            // In the meantime, it's possible to control CPUFAN and CPUOPT1m but not SYSFAN1.
                         {
                             // The parameters are extracted from the Biostar app config file. 
                             v.Add(new Voltage("Vcore", 0, 0, 1));

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1654,29 +1654,29 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     switch (model)
                     {
                         case Model.B660GTN: //IT8613E 
-                            //This board have some problems with their app Controling fans that I was able to replicate here so I guess is a Bios problem with the pins.
-                            //Biostar is aware so expect changes in the control pins with new bios.
-                            //In the meantime is possible to control CPUFAN and CPUOPT1 but not SYSFAN1. Readings are ok tho 
+                            // This board has some problems with their app controlling fans that I was able to replicate here so I guess is a BIOS problem with the pins.
+                            // Biostar is aware so expect changes in the control pins with new bios.
+                            / /In the meantime, it's possible to control CPUFAN and CPUOPT1m but not SYSFAN1.
                         {
-                            //the parameters are extracted from the Biostar app config file. 
-                            v.Add(new Voltage("Vcore", 0, 0, 1)); //this is right
-                            v.Add(new Voltage("DRAM", 1, 0, 1));  //This is exact
-                            v.Add(new Voltage("+12V", 2, 5, 1));  //Reads higher than it should 
-                            v.Add(new Voltage("+5V", 3, 147, 100));  //Again reads higher
-                            //Comented because I don't know if it makes sense
-                            //v.Add(new Voltage("VCC ST", 4)); // reads 4.2V
-                            //v.Add(new Voltage("VCCIN AUX", 5)); // reads 2.2V
-                            //v.Add(new Voltage("CPU GT", 6)); // reads 2.6V
-                            //v.Add(new Voltage("3VSB", 7, 10, 10)); //reads 5.8V ? 
-                            v.Add(new Voltage("VBat", 8, 10, 10)); //reads higher than it should 3.4V 
-                            t.Add(new Temperature("System1", 0));
-                            t.Add(new Temperature("System2", 1));  //not sure what sensor is this. it doesn't climb under stress 
+                            // The parameters are extracted from the Biostar app config file. 
+                            v.Add(new Voltage("Vcore", 0, 0, 1));
+                            v.Add(new Voltage("DIMM", 1, 0, 1));
+                            v.Add(new Voltage("+12V", 2, 5, 1)); // Reads higher than it should.
+                            v.Add(new Voltage("+5V", 3, 147, 100));  // Reads higher than it should.
+                            // Commented because I don't know if it makes sense.
+                            //v.Add(new Voltage("VCC ST", 4)); // Reads 4.2V.
+                            //v.Add(new Voltage("VCCIN AUX", 5)); // Reads 2.2V.
+                            //v.Add(new Voltage("CPU GT", 6)); // Reads 2.6V.
+                            //v.Add(new Voltage("3VSB", 7, 10, 10)); // Reads 5.8V ? 
+                            v.Add(new Voltage("VBat", 8, 10, 10)); // Reads higher than it should at 3.4V.
+                            t.Add(new Temperature("System 1", 0));
+                            t.Add(new Temperature("System 2", 1));  // Not sure what sensor is this.
                             t.Add(new Temperature("CPU", 2));
                             f.Add(new Fan("CPU Fan", 1));
-                            f.Add(new Fan("CPU OPT fan", 2));
-                            f.Add(new Fan("SYSFAN", 4));
+                            f.Add(new Fan("CPU Optional fan", 2));
+                            f.Add(new Fan("System Fan", 4));
                             c.Add(new Ctrl("CPU Fan", 1));
-                            c.Add(new Ctrl("CPU OPT Fan", 2));
+                            c.Add(new Ctrl("CPU Optional Fan", 2));
 
                             break;
                         }


### PR DESCRIPTION
Support for this board and chip.
 
Voltages are slightly  off and there's a problem controlling one fan header, SYSFAN1  (Biostar  is aware and fixing it, hopefully) But it's possible to read temps and fans rpm and control 2 fan headers (of 3), CPUFAN and CPUOPT1.

Please tell me if there's something wrong with the code or format.  

fixes #686 