### PR TITLE
Fix usage of wrong mutex for access to Embedded Controllers

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/WindowsEmbeddedControllerIO.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/WindowsEmbeddedControllerIO.cs
@@ -30,7 +30,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc.EC
 
         public WindowsEmbeddedControllerIO()
         {
-            if (!Ring0.WaitIsaBusMutex(10))
+            if (!Ring0.WaitEcMutex(10))
             {
                 throw new BusMutexLockingFailedException();
             }
@@ -79,7 +79,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc.EC
             if (!_disposed)
             {
                 _disposed = true;
-                Ring0.ReleaseIsaBusMutex();
+                Ring0.ReleaseEcMutex();
             }
         }
 


### PR DESCRIPTION
This PR adds `Global\Access_EC` as new mutex to synchronize access to Embedded Controllers.