### PR TITLE
Skip checking the conditions, because Actions support it by default [-skip ci]

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,8 +7,6 @@ on:
 jobs:
   build:
     runs-on: windows-2022
-    if: contains(github.event.head_commit.message, 'ci skip') == false
-
     steps:
       - uses: actions/checkout@v2
       - uses: nuget/setup-nuget@v1

--- a/.github/workflows/pull requests.yml
+++ b/.github/workflows/pull requests.yml
@@ -7,8 +7,6 @@ on:
 jobs:
   build:
     runs-on: windows-2022
-    if: contains(github.event.head_commit.message, 'ci skip') == false
-
     steps:
       - uses: actions/checkout@v2
       - uses: nuget/setup-nuget@v1


### PR DESCRIPTION
According to @timheuer, you don't need the "if" conditions in your Actions workflows anymore as [skip ci] and others work natively now on GitHub Actions: https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/