### PR TITLE
Add EC sensors and fan names for ASUS Z170-A

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
@@ -31,6 +31,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc.EC
             FanVrmHS,
             /// <summary>Chipset fan [RPM]</summary>
             FanChipset,
+            /// <summary>Water Pump (W_PUMP header) [RPM]</summary>
+            FanWPump,
             /// <summary>Water flow sensor reading [RPM]</summary>
             FanWaterFlow,
             /// <summary>CPU current [A]</summary>
@@ -52,6 +54,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc.EC
             { ECSensor.FanCPUOpt, new EmbeddedControllerSource("CPU Optional Fan", SensorType.Fan, 0x00b0, 2) },
             { ECSensor.FanVrmHS, new EmbeddedControllerSource("VRM Heat Sink Fan", SensorType.Fan, 0x00b2, 2) },
             { ECSensor.FanChipset, new EmbeddedControllerSource("Chipset Fan", SensorType.Fan, 0x00b4, 2) },
+            { ECSensor.FanWPump, new EmbeddedControllerSource("Water Pump", SensorType.Fan, 0x00bc, 2) },
             // TODO: "why 42?" is a silly question, I know, but still, why? On the serious side, it might be 41.6(6)
             { ECSensor.FanWaterFlow, new EmbeddedControllerSource("Water flow", SensorType.Flow, 0x00bc, 2, factor: 1.0f / 42f * 60f) },
             { ECSensor.CurrCPU, new EmbeddedControllerSource("CPU", SensorType.Current, 0x00f4) },
@@ -133,6 +136,11 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc.EC
                 Model.ROG_STRIX_Z690_A_GAMING_WIFI_D4,
                 new ECSensor[] {
                     ECSensor.TempTSensor, ECSensor.TempVrm }
+            },
+            {
+                Model.Z170_A,
+                new ECSensor[] {
+                    ECSensor.TempTSensor, ECSensor.TempChipset, ECSensor.FanWPump, ECSensor.CurrCPU }
             }
         };
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2548,11 +2548,20 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             t.Add(new Temperature("Temperature #4", 5));
                             t.Add(new Temperature("Temperature #5", 6));
 
-                            for (int i = 0; i < superIO.Fans.Length; i++)
-                                f.Add(new Fan("Fan #" + (i + 1), i));
+                            //CPU Fan Optional uses the same fancontrol as CPU Fan
+                            //Water Pump speed can only be read from the EC
+                            string[] fanNames = { "Chassis Fan 1", "CPU Fan", "Chassis Fan 2", "Chassis Fan 3", "Chassis Fan 4", "CPU Fan Optional" };
+                            string[] fanControlNames = { "Chassis Fan 1", "CPU Fan", "Chassis Fan 2", "Chassis Fan 3", "Chassis Fan 4", "Water Pump" };
+                            System.Diagnostics.Debug.Assert(fanNames.Length == superIO.Fans.Length,
+                                string.Format("Expected {0} fan registers in the SuperIO chip", fanNames.Length));
+                            System.Diagnostics.Debug.Assert(fanControlNames.Length == superIO.Controls.Length,
+                                string.Format("Expected {0} fan controls in the SuperIO chip", fanControlNames.Length));
 
-                            for (int i = 0; i < superIO.Controls.Length; i++)
-                                c.Add(new Ctrl("Fan Control #" + (i + 1), i));
+                            for (int i = 0; i < fanNames.Length; i++)
+                                f.Add(new Fan(fanNames[i], i));
+
+                            for (int i = 0; i < fanControlNames.Length; i++)
+                                c.Add(new Ctrl(fanControlNames[i] + " Control", i));
 
                             break;
                         }


### PR DESCRIPTION
Added the fan speed and fan control names (checked all values against ASUS AI Suite 3) and EC sensors (checked with AI Suite as well).
As noted in the comment, the 6th fan speed and 6th fan control do not match because the CPU_OPT-header has no independent control and the W_PUMP-header speed is only found in the EC.