### PR TITLE
Add motherboard: Gigabyte Z690 Gaming X DDR4 (#703)

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -293,6 +293,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     return Model.Z390_UD;
                 case var _ when name.Equals("Z690 AORUS PRO", StringComparison.OrdinalIgnoreCase):
                     return Model.Z690_AORUS_PRO;
+                case var _ when name.Equals("Z690 GAMING X DDR4", StringComparison.OrdinalIgnoreCase):
+                    return Model.Z690_GAMING_X_DDR4;
                 case var _ when name.Equals("FH67", StringComparison.OrdinalIgnoreCase):
                     return Model.FH67;
                 case var _ when name.Equals("AX370-Gaming K7", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -14,6 +14,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
 {
     internal class IT87XX : ISuperIO
     {
+        private const int MaxFanHeaders = 6;
         private readonly ushort _address;
         private readonly ushort _addressReg;
         private readonly int _bankCount;
@@ -24,9 +25,9 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
         private readonly bool _has16BitFanCounter;
         private readonly bool _hasExtReg;
         private readonly bool[] _initialFanOutputModeEnabled = new bool[3]; // Initial Fan Controller Main Control Register value. 
-        private readonly byte[] _initialFanPwmControl = new byte[5]; // This will also store the 2nd control register value.
-        private readonly byte[] _initialFanPwmControlExt = new byte[5];
-        private readonly bool[] _restoreDefaultFanPwmControlRequired = new bool[5];
+        private readonly byte[] _initialFanPwmControl = new byte[MaxFanHeaders]; // This will also store the 2nd control register value.
+        private readonly byte[] _initialFanPwmControlExt = new byte[MaxFanHeaders];
+        private readonly bool[] _restoreDefaultFanPwmControlRequired = new bool[MaxFanHeaders];
         private readonly byte _version;
         private readonly float _voltageGain;
 
@@ -139,8 +140,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
                 {
                     Voltages = new float?[10];
                     Temperatures = new float?[6];
-                    Fans = new float?[5];
-                    Controls = new float?[5];
+                    Fans = new float?[6];
+                    Controls = new float?[6];
                     break;
                 }
                 case Chip.IT8695E:
@@ -643,7 +644,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
         private const byte VOLTAGE_BASE_REG = 0x20;
 
         private readonly byte[] FAN_PWM_CTRL_REG;
-        private readonly byte[] FAN_PWM_CTRL_EXT_REG = { 0x63, 0x6b, 0x73, 0x7b, 0xa3 };
+        private readonly byte[] FAN_PWM_CTRL_EXT_REG = { 0x63, 0x6b, 0x73, 0x7b, 0xa3, 0xab};
         private readonly byte[] FAN_TACHOMETER_EXT_REG = { 0x18, 0x19, 0x1a, 0x81, 0x83, 0x4d };
         private readonly byte[] FAN_TACHOMETER_REG = { 0x0d, 0x0e, 0x0f, 0x80, 0x82, 0x4c };
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -144,6 +144,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
         Z68X_UD7_B3,
         Z68XP_UD3R,
         Z690_AORUS_PRO,
+        Z690_GAMING_X_DDR4,
         Z170N_WIFI,
         X470_AORUS_GAMING_7_WIFI,
         X570_AORUS_MASTER,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1537,6 +1537,28 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             c.Add(new Ctrl("CPU Optional Fan", 4));
                             break;
                         }
+                        case Model.Z690_GAMING_X_DDR4:
+                        {
+                            t.Add(new Temperature("System #1", 0));
+                            t.Add(new Temperature("PCH", 1));
+                            t.Add(new Temperature("CPU", 2));
+                            t.Add(new Temperature("PCIe x16", 3));
+                            t.Add(new Temperature("VRM MOS", 4));
+                            t.Add(new Temperature("System #2", 5));
+                            f.Add(new Fan("CPU Fan", 0));
+                            f.Add(new Fan("System Fan #1", 1));
+                            f.Add(new Fan("System Fan #2", 2));
+                            f.Add(new Fan("System Fan #3", 3));
+                            f.Add(new Fan("CPU Optional Fan", 4));
+                            f.Add(new Fan("System Fan #4 / Pump", 5));
+                            c.Add(new Ctrl("CPU Fan", 0));
+                            c.Add(new Ctrl("System Fan #1", 1));
+                            c.Add(new Ctrl("System Fan #2", 2));
+                            c.Add(new Ctrl("System Fan #3", 3));
+                            c.Add(new Ctrl("CPU Optional Fan", 4));
+                            c.Add(new Ctrl("System Fan #4 / Pump", 5));
+                            break;
+                        }
                         case Model.Z68A_D3H_B3: // IT8728F
                         {
                             v.Add(new Voltage("VTT", 0));


### PR DESCRIPTION
This is my first contribution to this project for issue #703, it needs checking for newbie-mistakes... I don't actually have C# on my resume. 😆 

Purpose:

- Adds support for additional `SYS_FAN4_PUMP` header control and tachometer
- Adds support for additional `PCH` temperature sensor

In draft form until:

- [X] Verify temperature probes match HWiNFO64
- [x] Verify `CPU_FAN` temp/tach matches board
- [x] Verify `CPU_OPT` temp/tach matches board
- [X] Verify `SYS_FAN1` temp/tach matches board
- [X] Verify `SYS_FAN2` temp/tach matches board
- [x] Verify `SYS_FAN3` temp/tach matches board
- [X] Verify `SYS_FAN4_PUMP` temp/tach matches board

Of particular note to reviewers:

- Sanity check change to `MAX_FAN_HEADER_COUNT` to support 6 headers, is there a better place to keep the constant?
- Not sure how to confirm new value in `FAN_PWM_CTRL_EXT_REG`, I merely picked something 8 higher and am able to control `SYS_FAN4_PUMP`.
- ~Should I use `Model.Z690_GAMING_X_DDR4` instead of `Model.Z690_GAMING_X`?~