### PR TITLE
Update the minimum framework to net472

### DIFF
--- a/Aga.Controls/Aga.Controls.csproj
+++ b/Aga.Controls/Aga.Controls.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProductVersion>9.0.30729</ProductVersion>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <AssemblyTitle>Aga.Controls</AssemblyTitle>
     <Description>http://sourceforge.net/projects/treeviewadv/</Description>
     <Copyright>Copyright © Andrey Gliznetsov 2006 - 2009</Copyright>

--- a/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
+++ b/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net47;netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>LibreHardwareMonitorLib</AssemblyName>
     <RootNamespace>LibreHardwareMonitor</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
+++ b/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net47;netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>LibreHardwareMonitorLib</AssemblyName>
     <RootNamespace>LibreHardwareMonitor</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Libre Hardware Monitor, a fork of Open Hardware Monitor, is free software that c
 | Name| .NET | Build Status |
 | --- | --- | --- | 
 | **LibreHardwareMonitor** <br /> Windows Forms based application that presents all data in a graphical interface | .NET Framework 4.7.2 | [![Build status](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/workflows/CI/badge.svg)](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/actions) | 
-| **LibreHardwareMonitorLib** <br /> Library that allows you to use all features in your own application | .NET Framework 4.7.2,<br />.NET Standard 2.0,<br />.NET 5.0,<br />.NET 6.0 | [![Build status](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/workflows/CI/badge.svg)](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/actions) | 
+| **LibreHardwareMonitorLib** <br /> Library that allows you to use all features in your own application | .NET Framework 4.7,<br />.NET Standard 2.0,<br />.NET 5.0,<br />.NET 6.0 | [![Build status](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/workflows/CI/badge.svg)](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/actions) | 
 
 ## What can you do?
 With the help of LibreHardwareMonitor you can read information from devices such as:
@@ -26,9 +26,8 @@ The LibreHardwareMonitor team welcomes feedback and contributions!<br/>
 You can check if it works properly on your motherboard. For many manufacturers, the way of reading data differs a bit, so if you notice any inaccuracies, please send us a pull request. If you have any suggestions or improvements, don't hesitate to create an issue.
 
 ## What's the easiest way to start?
+**LibreHardwareMonitor application:** - [How to compile the application](https://docs.microsoft.com/en-us/visualstudio/ide/compiling-and-building-in-visual-studio)  
 *Compiling LibreHardwareMonitor requires [Visual Studio 2022](https://docs.microsoft.com/en-us/visualstudio/ide/whats-new-visual-studio-2022?view=vs-2022).*
-
-**LibreHardwareMonitor application:** - [How to compile the application](https://docs.microsoft.com/en-us/visualstudio/ide/compiling-and-building-in-visual-studio) 
 1. Download the repository and compile 'LibreHardwareMonitor'.
 2. You can start the **net452\LibreHardwareMonitor.exe** application immediately.
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Libre Hardware Monitor, a fork of Open Hardware Monitor, is free software that c
 ## What's included?
 | Name| .NET | Build Status |
 | --- | --- | --- | 
-| **LibreHardwareMonitor** <br /> Windows Forms based application that presents all data in a graphical interface | .NET Framework 4.5.2 | [![Build status](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/workflows/CI/badge.svg)](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/actions) | 
-| **LibreHardwareMonitorLib** <br /> Library that allows you to use all features in your own application | .NET Framework 4.5.2,<br />.NET Standard 2.0,<br />.NET 5.0,<br />.NET 6.0 | [![Build status](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/workflows/CI/badge.svg)](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/actions) | 
+| **LibreHardwareMonitor** <br /> Windows Forms based application that presents all data in a graphical interface | .NET Framework 4.7.2 | [![Build status](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/workflows/CI/badge.svg)](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/actions) | 
+| **LibreHardwareMonitorLib** <br /> Library that allows you to use all features in your own application | .NET Framework 4.7.2,<br />.NET Standard 2.0,<br />.NET 5.0,<br />.NET 6.0 | [![Build status](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/workflows/CI/badge.svg)](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/actions) | 
 
 ## What can you do?
 With the help of LibreHardwareMonitor you can read information from devices such as:
@@ -26,7 +26,9 @@ The LibreHardwareMonitor team welcomes feedback and contributions!<br/>
 You can check if it works properly on your motherboard. For many manufacturers, the way of reading data differs a bit, so if you notice any inaccuracies, please send us a pull request. If you have any suggestions or improvements, don't hesitate to create an issue.
 
 ## What's the easiest way to start?
-**LibreHardwareMonitor application:** - [How to compile the application](https://docs.microsoft.com/en-us/visualstudio/ide/compiling-and-building-in-visual-studio)
+*Compiling LibreHardwareMonitor requires [Visual Studio 2022](https://docs.microsoft.com/en-us/visualstudio/ide/whats-new-visual-studio-2022?view=vs-2022).*
+
+**LibreHardwareMonitor application:** - [How to compile the application](https://docs.microsoft.com/en-us/visualstudio/ide/compiling-and-building-in-visual-studio) 
 1. Download the repository and compile 'LibreHardwareMonitor'.
 2. You can start the **net452\LibreHardwareMonitor.exe** application immediately.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can check if it works properly on your motherboard. For many manufacturers, 
 **LibreHardwareMonitor application:** - [How to compile the application](https://docs.microsoft.com/en-us/visualstudio/ide/compiling-and-building-in-visual-studio)  
 *Compiling LibreHardwareMonitor requires [Visual Studio 2022](https://docs.microsoft.com/en-us/visualstudio/ide/whats-new-visual-studio-2022?view=vs-2022).*
 1. Download the repository and compile 'LibreHardwareMonitor'.
-2. You can start the **net452\LibreHardwareMonitor.exe** application immediately.
+2. You can start the **net472\LibreHardwareMonitor.exe** application immediately.
 
 **NuGet Package** - [How to use NuGet](https://docs.microsoft.com/en-us/nuget/quickstart/install-and-use-a-package-in-visual-studio)
 1. Add the [LibreHardwareMonitorLib package](https://www.nuget.org/packages/LibreHardwareMonitorLib/) to your application.


### PR DESCRIPTION
This PR sets the minimum targeted framework to .NET 4.7.2 in all of the projects in the solution. This PR achieves the intent of the discussion in issue #650. This PR also updates the README to match these updated requirements.

This PR is helpful because Visual Studio 2022 natively includes .NET 4.7.2, but support for 4.6.2 - 4.7.1 requires additional installation.

Additionally, due to the use of C#10 File Scoped Namespaces in the lib project, the solution [no longer compiles in VS2019](https://dotnetcoretutorials.com/2021/09/20/file-scoped-namespaces-in-c-10/). Because of this, I added a line in the README stating that "Compiling LibreHardwareMonitor requires Visual Studio 2022." 

If we would like to change this verbiage, or if someone knows a workaround to retain VS2019 support, please let me know and I'll make those updates to this PR.

Fixes #650 