### PR TITLE
EC: add sensors for ProArt X570-CREATOR WIFI

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -305,6 +305,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     return Model.PRIME_X470_PRO;
                 case var _ when name.Equals("PRIME X570-PRO", StringComparison.OrdinalIgnoreCase):
                     return Model.PRIME_X570_PRO;
+                case var _ when name.Equals("ProArt X570-CREATOR WIFI", StringComparison.OrdinalIgnoreCase):
+                    return Model.PROART_X570_CREATOR_WIFI;
                 case var _ when name.Equals("Pro WS X570-ACE", StringComparison.OrdinalIgnoreCase):
                     return Model.PRO_WS_X570_ACE;
                 case var _ when name.Equals("ROG MAXIMUS X APEX", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
@@ -149,6 +149,11 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc.EC
                 ECSensor.TempChipset, ECSensor.TempCPU, ECSensor.TempMB,
                 ECSensor.TempVrm, ECSensor.TempTSensor, ECSensor.FanChipset
             ),
+            new(Model.PROART_X570_CREATOR_WIFI, BoardFamily.Amd500,
+                ECSensor.TempChipset, ECSensor.TempCPU, ECSensor.TempMB,
+                ECSensor.TempVrm, ECSensor.TempTSensor, ECSensor.FanCPUOpt, 
+                ECSensor.CurrCPU, ECSensor.VoltageCPU
+            ),
             new(Model.PRO_WS_X570_ACE, BoardFamily.Amd500,
                 ECSensor.TempChipset, ECSensor.TempCPU, ECSensor.TempMB,
                 ECSensor.TempVrm, ECSensor.FanChipset, ECSensor.CurrCPU, ECSensor.VoltageCPU

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -64,6 +64,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
         PRIME_X370_PRO,
         PRIME_X470_PRO,
         PRIME_X570_PRO,
+        PROART_X570_CREATOR_WIFI,
         PRO_WS_X570_ACE,
         RAMPAGE_EXTREME,
         RAMPAGE_II_GENE,


### PR DESCRIPTION
Copied from the Linux driver and tested there by user.

https://github.com/zeule/asus-ec-sensors/issues/17