### PR TITLE
Add support for VID sensors per core on Intel CPUs

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Cpu/IntelCpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/IntelCpu.cs
@@ -432,11 +432,9 @@ namespace LibreHardwareMonitor.Hardware.CPU
             }
 
             _coreVIDs = new Sensor[_coreCount];
-            coreSensorId = 1;
             for (int i = 0; i < _coreVIDs.Length; i++)
             {
                 _coreVIDs[i] = new Sensor(CoreString(i), i + 1, SensorType.Voltage, this, settings);
-                coreSensorId++;
                 ActivateSensor(_coreVIDs[i]);
             }
 

--- a/LibreHardwareMonitorLib/Hardware/Cpu/IntelCpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/IntelCpu.cs
@@ -19,9 +19,10 @@ namespace LibreHardwareMonitor.Hardware.CPU
         private readonly Sensor _coreMax;
         private readonly Sensor[] _coreTemperatures;
         private readonly Sensor _coreVoltage;
+        private readonly Sensor[] _coreVIDs;
         private readonly Sensor[] _distToTjMaxTemperatures;
 
-        private readonly uint[] _energyStatusMsrs = { MSR_PKG_ENERY_STATUS, MSR_PP0_ENERY_STATUS, MSR_PP1_ENERY_STATUS, MSR_DRAM_ENERGY_STATUS };
+        private readonly uint[] _energyStatusMsrs = { MSR_PKG_ENERGY_STATUS, MSR_PP0_ENERGY_STATUS, MSR_PP1_ENERGY_STATUS, MSR_DRAM_ENERGY_STATUS };
         private readonly float _energyUnitMultiplier;
         private readonly uint[] _lastEnergyConsumed;
         private readonly DateTime[] _lastEnergyTime;
@@ -36,6 +37,7 @@ namespace LibreHardwareMonitor.Hardware.CPU
         public IntelCpu(int processorIndex, CpuId[][] cpuId, ISettings settings) : base(processorIndex, cpuId, settings)
         {
             uint eax;
+            uint edx;
 
             // set tjMax
             float[] tjMax;
@@ -240,7 +242,7 @@ namespace LibreHardwareMonitor.Hardware.CPU
                 case MicroArchitecture.Core:
                 case MicroArchitecture.NetBurst:
                 {
-                    if (Ring0.ReadMsr(IA32_PERF_STATUS, out uint _, out uint edx))
+                    if (Ring0.ReadMsr(IA32_PERF_STATUS, out uint _, out edx))
                     {
                         _timeStampCounterMultiplier = ((edx >> 8) & 0x1f) + 0.5 * ((edx >> 14) & 1);
                     }
@@ -429,6 +431,15 @@ namespace LibreHardwareMonitor.Hardware.CPU
                 ActivateSensor(_coreVoltage);
             }
 
+            _coreVIDs = new Sensor[_coreCount];
+            coreSensorId = 1;
+            for (int i = 0; i < _coreVIDs.Length; i++)
+            {
+                _coreVIDs[i] = new Sensor(CoreString(i), i + 1, SensorType.Voltage, this, settings);
+                coreSensorId++;
+                ActivateSensor(_coreVIDs[i]);
+            }
+
             Update();
         }
 
@@ -465,10 +476,10 @@ namespace LibreHardwareMonitor.Hardware.CPU
                 IA32_TEMPERATURE_TARGET,
                 IA32_PACKAGE_THERM_STATUS,
                 MSR_RAPL_POWER_UNIT,
-                MSR_PKG_ENERY_STATUS,
+                MSR_PKG_ENERGY_STATUS,
                 MSR_DRAM_ENERGY_STATUS,
-                MSR_PP0_ENERY_STATUS,
-                MSR_PP1_ENERY_STATUS
+                MSR_PP0_ENERGY_STATUS,
+                MSR_PP1_ENERGY_STATUS
             };
         }
 
@@ -491,6 +502,7 @@ namespace LibreHardwareMonitor.Hardware.CPU
             float coreMax = float.MinValue;
             float coreAvg = 0;
             uint eax = 0;
+            uint edx;
 
             for (int i = 0; i < _coreTemperatures.Length; i++)
             {
@@ -627,9 +639,22 @@ namespace LibreHardwareMonitor.Hardware.CPU
                 }
             }
 
-            if (_coreVoltage != null && Ring0.ReadMsr(IA32_PERF_STATUS, out eax, out uint _))
+            if (_coreVoltage != null && Ring0.ReadMsr(IA32_PERF_STATUS, out _, out edx))
             {
-                _coreVoltage.Value = ((eax >> 32) & 0xFFFF) / (float)(1 << 13);
+                _coreVoltage.Value = ((edx >> 32) & 0xFFFF) / (float)(1 << 13);
+            }
+
+            for (int i = 0; i < _coreVIDs.Length; i++)
+            {
+                if (Ring0.ReadMsr(IA32_PERF_STATUS, out _, out edx, _cpuId[i][0].Affinity) && ((edx >> 32) & 0xFFFF) > 0)
+                {
+                    _coreVIDs[i].Value = ((edx >> 32) & 0xFFFF) / (float)(1 << 13);
+                    ActivateSensor(_coreVIDs[i]);
+                }
+                else
+                {
+                    DeactivateSensor(_coreVIDs[i]);
+                }
             }
         }
 
@@ -668,10 +693,10 @@ namespace LibreHardwareMonitor.Hardware.CPU
         private const uint IA32_THERM_STATUS_MSR = 0x019C;
 
         private const uint MSR_DRAM_ENERGY_STATUS = 0x619;
-        private const uint MSR_PKG_ENERY_STATUS = 0x611;
+        private const uint MSR_PKG_ENERGY_STATUS = 0x611;
         private const uint MSR_PLATFORM_INFO = 0xCE;
-        private const uint MSR_PP0_ENERY_STATUS = 0x639;
-        private const uint MSR_PP1_ENERY_STATUS = 0x641;
+        private const uint MSR_PP0_ENERGY_STATUS = 0x639;
+        private const uint MSR_PP1_ENERGY_STATUS = 0x641;
 
         private const uint MSR_RAPL_POWER_UNIT = 0x606;
         // ReSharper restore InconsistentNaming


### PR DESCRIPTION
This PR adds support for reading the VID on each core on Intel CPUs. Also, I've improved the sensors accuracy by getting the values from EDX rather than EAX.

Here's a comparison between LHM getting VID from EAX, LHM getting VIDs from EDX and the VIDs provided by HWMonitor:
LHM getting VID from EAX:
![LHM_EAX](https://user-images.githubusercontent.com/84488929/167770223-8d195658-41f1-4164-ac1e-d00c536157ed.PNG)
LHM getting VIDs from EDX:
![LHM_EDX](https://user-images.githubusercontent.com/84488929/167770335-46e2cbda-4c85-44cb-bfbb-1b349e4ed872.PNG)
VIDs provided by HWMonitor:
![HWM](https://user-images.githubusercontent.com/84488929/167770385-9754c58a-7564-4cad-b0ce-52c2a3c2f93c.PNG)