### PR TITLE
RyzenSMU: add some more metrics for Zen3

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/RyzenSMU.cs
+++ b/LibreHardwareMonitorLib/Hardware/RyzenSMU.cs
@@ -76,20 +76,30 @@ namespace LibreHardwareMonitor.Hardware
                 // Zen 3.
                 0x00380805, new Dictionary<uint, SmuSensorType>
                 {
-                    // TDC and EDC don't match the HWiNFO values
-                    //{ 15, new SmuSensorType { Name = "TDC", Type = SensorType.Current, Scale = 1 } },
-                    //{ 21, new SmuSensorType { Name = "EDC", Type = SensorType.Current, Scale = 1 } },
+                    { 3, new SmuSensorType { Name = "TDC", Type = SensorType.Current, Scale = 1 } },
+                    // TODO: requires some post-processing
+                    // see: https://gitlab.com/leogx9r/ryzen_smu/-/blob/master/userspace/monitor_cpu.c#L577
+                    // { 9, new SmuSensorType { Name = "EDC", Type = SensorType.Current, Scale = 1 } },
                     { 48, new SmuSensorType { Name = "Fabric", Type = SensorType.Clock, Scale = 1 } },
                     { 50, new SmuSensorType { Name = "Uncore", Type = SensorType.Clock, Scale = 1 } },
                     { 51, new SmuSensorType { Name = "Memory", Type = SensorType.Clock, Scale = 1 } },
-                    //{ 115, new SmuSensorType { Name = "SoC", Type = SensorType.Temperature, Scale = 1 } },
-                    //{ 66, new SmuSensorType { Name = "Bus Speed", Type = SensorType.Clock, Scale = 1 } },
-                    //{ 188, new SmuSensorType { Name = "Core #1", Type = SensorType.Clock, Scale = 1000 } },
-                    //{ 189, new SmuSensorType { Name = "Core #2", Type = SensorType.Clock, Scale = 1000 } },
-                    //{ 190, new SmuSensorType { Name = "Core #3", Type = SensorType.Clock, Scale = 1000 } },
-                    //{ 191, new SmuSensorType { Name = "Core #4", Type = SensorType.Clock, Scale = 1000 } },
-                    //{ 192, new SmuSensorType { Name = "Core #5", Type = SensorType.Clock, Scale = 1000 } },
-                    //{ 193, new SmuSensorType { Name = "Core #6", Type = SensorType.Clock, Scale = 1000 } },
+                    { 127, new SmuSensorType { Name = "SoC", Type = SensorType.Temperature, Scale = 1 } },
+                    { 268, new SmuSensorType { Name = "Core #1 (Effective)", Type = SensorType.Clock, Scale = 1000 } },
+                    { 269, new SmuSensorType { Name = "Core #2 (Effective)", Type = SensorType.Clock, Scale = 1000 } },
+                    { 270, new SmuSensorType { Name = "Core #3 (Effective)", Type = SensorType.Clock, Scale = 1000 } },
+                    { 271, new SmuSensorType { Name = "Core #4 (Effective)", Type = SensorType.Clock, Scale = 1000 } },
+                    { 272, new SmuSensorType { Name = "Core #5 (Effective)", Type = SensorType.Clock, Scale = 1000 } },
+                    { 273, new SmuSensorType { Name = "Core #6 (Effective)", Type = SensorType.Clock, Scale = 1000 } },
+                    { 274, new SmuSensorType { Name = "Core #7 (Effective)", Type = SensorType.Clock, Scale = 1000 } },
+                    { 275, new SmuSensorType { Name = "Core #8 (Effective)", Type = SensorType.Clock, Scale = 1000 } },
+                    { 276, new SmuSensorType { Name = "Core #9 (Effective)", Type = SensorType.Clock, Scale = 1000 } },
+                    { 277, new SmuSensorType { Name = "Core #10 (Effective)", Type = SensorType.Clock, Scale = 1000 } },
+                    { 278, new SmuSensorType { Name = "Core #11 (Effective)", Type = SensorType.Clock, Scale = 1000 } },
+                    { 279, new SmuSensorType { Name = "Core #12 (Effective)", Type = SensorType.Clock, Scale = 1000 } },
+                    { 280, new SmuSensorType { Name = "Core #13 (Effective)", Type = SensorType.Clock, Scale = 1000 } },
+                    { 281, new SmuSensorType { Name = "Core #14 (Effective)", Type = SensorType.Clock, Scale = 1000 } },
+                    { 282, new SmuSensorType { Name = "Core #15 (Effective)", Type = SensorType.Clock, Scale = 1000 } },
+                    { 283, new SmuSensorType { Name = "Core #16 (Effective)", Type = SensorType.Clock, Scale = 1000 } },
                 }
             }
         };


### PR DESCRIPTION
Partially based on information from https://github.com/hattedsquirrel/ryzen_monitor. There's a lot more stuff in there that people have figured out the mappings for, but this is a decent start towards #657.