### PR TITLE
Add support for ROG MAXIMUS Z690 EXTREME GLACIAL

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -357,6 +357,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     return Model.B560M_AORUS_PRO_AX;
                 case var _ when name.Equals("ROG STRIX Z690-A GAMING WIFI D4", StringComparison.OrdinalIgnoreCase):
                     return Model.ROG_STRIX_Z690_A_GAMING_WIFI_D4;
+                case var _ when name.Equals("ROG MAXIMUS Z690 EXTREME GLACIAL", StringComparison.OrdinalIgnoreCase):
+                    return Model.ROG_MAXIMUS_Z690_EXTREME_GLACIAL;
                 case var _ when name.Equals("B660GTN", StringComparison.OrdinalIgnoreCase):
                     return Model.B660GTN;
                 case var _ when name.Equals("Base Board Product Name", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
@@ -43,6 +43,8 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc.EC
             TempWaterIn,
             /// <summary>"Water_Out" temperature sensor reading [℃]</summary>
             TempWaterOut,
+            /// <summary>Water block temperature sensor reading [℃]</summary>
+            TempWaterBlockIn,
             Max
         };
 
@@ -131,6 +133,10 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc.EC
                 {
                     { ECSensor.TempTSensor, new EmbeddedControllerSource("T Sensor", SensorType.Temperature, 0x003d, blank: -40) },
                     { ECSensor.TempVrm, new EmbeddedControllerSource("VRM", SensorType.Temperature, 0x003e) },
+                    { ECSensor.TempWaterIn, new EmbeddedControllerSource("Water In", SensorType.Temperature, 0x0100, blank: -40) },
+                    { ECSensor.TempWaterOut, new EmbeddedControllerSource("Water Out", SensorType.Temperature, 0x0101, blank: -40) },
+                    { ECSensor.TempWaterBlockIn, new EmbeddedControllerSource("Water Block In", SensorType.Temperature, 0x0102, blank: -40) },
+                    { ECSensor.FanWaterFlow, new EmbeddedControllerSource("Water Flow", SensorType.Flow, 0x00be, 2, factor: 1.0f / 42f * 60f) }, // todo: need validation for this calculation
                 }
             },
         };
@@ -198,6 +204,9 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc.EC
             ),
             new(Model.ROG_STRIX_Z690_A_GAMING_WIFI_D4, BoardFamily.Intel600,
                 ECSensor.TempTSensor, ECSensor.TempVrm
+            ),
+            new(Model.ROG_MAXIMUS_Z690_EXTREME_GLACIAL, BoardFamily.Intel600,
+                ECSensor.TempVrm, ECSensor.TempWaterIn, ECSensor.TempWaterOut, ECSensor.TempWaterBlockIn, ECSensor.FanWaterFlow
             ),
             new(Model.Z170_A, BoardFamily.Intel100,
                 ECSensor.TempTSensor, ECSensor.TempChipset, ECSensor.FanWaterPump, 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -50,6 +50,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
         ROG_STRIX_B550_F_GAMING_WIFI,
         ROG_STRIX_B550_I_GAMING,
         ROG_STRIX_Z690_A_GAMING_WIFI_D4,
+        ROG_MAXIMUS_Z690_EXTREME_GLACIAL,
         M2N_SLI_Deluxe,
         M4A79XTD_EVO,
         P5W_DH_Deluxe,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2696,6 +2696,62 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
 
                             break;
                         }
+                        case Model.ROG_MAXIMUS_Z690_EXTREME_GLACIAL: //NCT6798D
+                        {
+                            v.Add(new Voltage("Vcore", 0));
+                            v.Add(new Voltage("+5V", 1, 4, 1));
+                            v.Add(new Voltage("AVSB", 2, 34, 34));
+                            v.Add(new Voltage("3VCC", 3, 34, 34));
+                            v.Add(new Voltage("+12V", 4, 11, 1));
+                            v.Add(new Voltage("IVR Atom L2 Cluster1", 5));
+                            v.Add(new Voltage("Voltage #7", 6));
+                            v.Add(new Voltage("3VSB_ATX", 7, 34, 34));
+                            v.Add(new Voltage("BAT_3V", 8, 34, 34));
+                            v.Add(new Voltage("VTT", 9, 1, 1));
+                            v.Add(new Voltage("Voltage #11", 10));
+                            v.Add(new Voltage("IVR Atom L2 Cluster0", 11, 1, 1));
+                            v.Add(new Voltage("PCH", 12));
+                            v.Add(new Voltage("Voltage #14", 13));
+                            v.Add(new Voltage("Voltage #15", 14));
+
+                            t.Add(new Temperature("Temperature #1", 0));
+                            t.Add(new Temperature("CPU", 1));
+                            t.Add(new Temperature("Motherboard", 2));
+                            //t.Add(new Temperature("Temperature 03", 3));
+                            t.Add(new Temperature("Temperature #4", 4));
+                            t.Add(new Temperature("Temperature #5", 5));
+                            t.Add(new Temperature("Temperature #6", 6));
+                            t.Add(new Temperature("Temperature #7", 7));
+                            //t.Add(new Temperature("Temperature 08", 8));
+                            //t.Add(new Temperature("Temperature 09", 9));
+                            //t.Add(new Temperature("Temperature 10", 10));
+                            //t.Add(new Temperature("Temperature 11", 11));
+                            t.Add(new Temperature("PCH", 12));
+                            //t.Add(new Temperature("Temperature 13", 13));
+                            //t.Add(new Temperature("Temperature 14", 14));
+                            //t.Add(new Temperature("Temperature 15", 15));
+                            //t.Add(new Temperature("Temperature 16", 16));
+                            //t.Add(new Temperature("Temperature 17", 17));
+                            //t.Add(new Temperature("Temperature 18", 18));
+                            //t.Add(new Temperature("Temperature 19", 19));
+                            //t.Add(new Temperature("Temperature 20", 20));
+                            t.Add(new Temperature("Temperature #9", 21));
+
+                            string[] fanControlNames = {"Chassis Fan 1", "CPU Fan", "Radiator Fan 1",
+                                "Radiator Fan 2", "Chassis Fan 2", "Water Pump 1", "Water Pump 2"};
+                            System.Diagnostics.Debug.Assert(fanControlNames.Length == superIO.Fans.Length,
+                                string.Format("Expected {0} fan register in the SuperIO chip", fanControlNames.Length));
+                            System.Diagnostics.Debug.Assert(superIO.Fans.Length == superIO.Controls.Length,
+                                "Expected counts of fan controls and fan speed registers to be equal");
+
+                            for (int i = 0; i < fanControlNames.Length; i++)
+                                f.Add(new Fan(fanControlNames[i], i));
+
+                            for (int i = 0; i < fanControlNames.Length; i++)
+                                c.Add(new Ctrl(fanControlNames[i], i));
+
+                            break;
+                        }
                         case Model.ROG_STRIX_B550_I_GAMING: //NCT6798D
                         {
                             v.Add(new Voltage("Vcore", 0, 10, 10));
@@ -2800,6 +2856,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
 
                             break;
                         }
+
                         default:
                         {
                             v.Add(new Voltage("Vcore", 0));

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2703,13 +2703,13 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                             v.Add(new Voltage("AVSB", 2, 34, 34));
                             v.Add(new Voltage("3VCC", 3, 34, 34));
                             v.Add(new Voltage("+12V", 4, 11, 1));
-                            v.Add(new Voltage("IVR Atom L2 Cluster1", 5));
+                            v.Add(new Voltage("IVR Atom L2 Cluster #1", 5));
                             v.Add(new Voltage("Voltage #7", 6));
-                            v.Add(new Voltage("3VSB_ATX", 7, 34, 34));
-                            v.Add(new Voltage("BAT_3V", 8, 34, 34));
+                            v.Add(new Voltage("3VSB", 7, 34, 34));
+                            v.Add(new Voltage("VBat", 8, 34, 34));
                             v.Add(new Voltage("VTT", 9, 1, 1));
                             v.Add(new Voltage("Voltage #11", 10));
-                            v.Add(new Voltage("IVR Atom L2 Cluster0", 11, 1, 1));
+                            v.Add(new Voltage("IVR Atom L2 Cluster #0", 11, 1, 1));
                             v.Add(new Voltage("PCH", 12));
                             v.Add(new Voltage("Voltage #14", 13));
                             v.Add(new Voltage("Voltage #15", 14));
@@ -2856,7 +2856,6 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
 
                             break;
                         }
-
                         default:
                         {
                             v.Add(new Voltage("Vcore", 0));


### PR DESCRIPTION
This adds support for the ROG MAXIMUS Z690 EXTREME GLACIAL, as this motherboard comes out of the box with a monoblock the ASUS EC has additional readings/values that are unique for this motherboard, in particular:

- built-in water flow sensor (inside the monoblock)
- built-in water temperature (inside the monoblock)
- optional temperature sensor (header on the motherboard) for water in
- optional temperature sensor (header on the motherboard) for water out
- optional water flow sensor (header on the motherboard)

I had to add an additional `enum` type called `TempWaterBlockIn` --- which is probably unlikely going to ever be found useful for most motherboards, but there are a few rare ones out there that come with this sensor.

Otherwise, the rest of the code conforms to the rest of the code-base.