### PR TITLE
Exclude 980 Pro from samsung NVMe protocol

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Storage/NVMeSamsung.cs
+++ b/LibreHardwareMonitorLib/Hardware/Storage/NVMeSamsung.cs
@@ -80,7 +80,7 @@ namespace LibreHardwareMonitor.Hardware.Storage
                 Marshal.StructureToPtr(buffers, buffer, false);
 
                 validTransfer = Kernel32.DeviceIoControl(hDevice, Kernel32.IOCTL.IOCTL_SCSI_PASS_THROUGH, buffer, length, buffer, length, out _, IntPtr.Zero);
-                if (validTransfer)
+                if (validTransfer && buffers.DataBuf.Any((x) => x != 0))
                 {
                     IntPtr offset = Marshal.OffsetOf<Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS>(nameof(Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS.DataBuf));
                     IntPtr newPtr = IntPtr.Add(buffer, offset.ToInt32());
@@ -240,7 +240,7 @@ namespace LibreHardwareMonitor.Hardware.Storage
                 {
                     var result = Marshal.PtrToStructure<Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS>(buffer);
 
-                    if (result.DataBuf.Sum(x => (long)x) == 0)
+                    if (result.DataBuf.All((x) => x == 0))
                     {
                         handle.Close();
                         handle = null;

--- a/LibreHardwareMonitorLib/Hardware/Storage/NVMeSamsung.cs
+++ b/LibreHardwareMonitorLib/Hardware/Storage/NVMeSamsung.cs
@@ -80,7 +80,7 @@ namespace LibreHardwareMonitor.Hardware.Storage
                 Marshal.StructureToPtr(buffers, buffer, false);
 
                 validTransfer = Kernel32.DeviceIoControl(hDevice, Kernel32.IOCTL.IOCTL_SCSI_PASS_THROUGH, buffer, length, buffer, length, out _, IntPtr.Zero);
-                if (validTransfer && buffers.DataBuf.Any((x) => x != 0))
+                if (validTransfer && buffers.DataBuf.Any(x => x != 0))
                 {
                     IntPtr offset = Marshal.OffsetOf<Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS>(nameof(Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS.DataBuf));
                     IntPtr newPtr = IntPtr.Add(buffer, offset.ToInt32());
@@ -240,7 +240,7 @@ namespace LibreHardwareMonitor.Hardware.Storage
                 {
                     var result = Marshal.PtrToStructure<Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS>(buffer);
 
-                    if (result.DataBuf.All((x) => x == 0))
+                    if (result.DataBuf.All(x => x == 0))
                     {
                         handle.Close();
                         handle = null;

--- a/LibreHardwareMonitorLib/Hardware/Storage/NVMeSmart.cs
+++ b/LibreHardwareMonitorLib/Hardware/Storage/NVMeSmart.cs
@@ -28,6 +28,10 @@ namespace LibreHardwareMonitor.Hardware.Storage
                 if (_handle != null)
                 {
                     NVMeDrive = new NVMeSamsung();
+                    if (!NVMeDrive.IdentifyController(_handle, out _))
+                    {
+                        NVMeDrive = null;
+                    }
                 }
             }
 


### PR DESCRIPTION
As someone who possesses a 980 Pro, I've been seeing incorrect SMART
readings since #674 (like power cycle count is always detected as 0). I
noticed that #388 purposely excludes the 980 Pro from the samsung
protocol in favor of the generic one, so I have reverted back to that
behavior. I then confirmed that the readings were correct.