### PR TITLE
- Fix for Windows 11 22H2 (22621) incorrect CPU load issue.

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Cpu/CpuLoad.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/CpuLoad.cs
@@ -41,27 +41,35 @@ namespace LibreHardwareMonitor.Hardware.CPU
 
         private static bool GetTimes(out long[] idle, out long[] total)
         {
-            Interop.NtDll.SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION[] information = new Interop.NtDll.SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION[64];
-            int size = Marshal.SizeOf(typeof(Interop.NtDll.SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION));
-
             idle = null;
             total = null;
 
-            if (Interop.NtDll.NtQuerySystemInformation(Interop.NtDll.SYSTEM_INFORMATION_CLASS.SystemProcessorPerformanceInformation,
-                                                       information,
-                                                       information.Length * size,
-                                                       out IntPtr returnLength) != 0)
+            //Query processor idle information
+            Interop.NtDll.SYSTEM_PROCESSOR_IDLE_INFORMATION[] idleInformation = new Interop.NtDll.SYSTEM_PROCESSOR_IDLE_INFORMATION[64];
+            int idleSize = Marshal.SizeOf(typeof(Interop.NtDll.SYSTEM_PROCESSOR_IDLE_INFORMATION));
+            if (Interop.NtDll.NtQuerySystemInformation(Interop.NtDll.SYSTEM_INFORMATION_CLASS.SystemProcessorIdleInformation, idleInformation, idleInformation.Length * idleSize, out int idleReturn) != 0)
             {
                 return false;
             }
 
-            idle = new long[(int)returnLength / size];
-            total = new long[(int)returnLength / size];
+            //Query processor performance information
+            Interop.NtDll.SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION[] perfInformation = new Interop.NtDll.SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION[64];
+            int perfSize = Marshal.SizeOf(typeof(Interop.NtDll.SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION));
+            if (Interop.NtDll.NtQuerySystemInformation(Interop.NtDll.SYSTEM_INFORMATION_CLASS.SystemProcessorPerformanceInformation, perfInformation, perfInformation.Length * perfSize, out int perfReturn) != 0)
+            {
+                return false;
+            }
 
+            idle = new long[idleReturn / idleSize];
             for (int i = 0; i < idle.Length; i++)
             {
-                idle[i] = information[i].IdleTime;
-                total[i] = information[i].KernelTime + information[i].UserTime;
+                idle[i] = idleInformation[i].IdleTime;
+            }
+
+            total = new long[perfReturn / perfSize];
+            for (int i = 0; i < total.Length; i++)
+            {
+                total[i] = perfInformation[i].KernelTime + perfInformation[i].UserTime;
             }
 
             return true;
@@ -114,7 +122,7 @@ namespace LibreHardwareMonitor.Hardware.CPU
                 total = 0;
             }
 
-            _totalLoad = total * 100;
+            _totalLoad = total * 100f;
             _totalTimes = newTotalTimes;
             _idleTimes = newIdleTimes;
         }

--- a/LibreHardwareMonitorLib/Interop/NtDll.cs
+++ b/LibreHardwareMonitorLib/Interop/NtDll.cs
@@ -3,7 +3,6 @@
 // Copyright (C) LibreHardwareMonitor and Contributors.
 // All Rights Reserved.
 
-using System;
 using System.Runtime.InteropServices;
 
 // ReSharper disable InconsistentNaming
@@ -12,71 +11,42 @@ namespace LibreHardwareMonitor.Interop
 {
     internal class NtDll
     {
-        private const string DllName = "ntdll";
-
         [StructLayout(LayoutKind.Sequential)]
         internal struct SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION
         {
             public long IdleTime;
             public long KernelTime;
             public long UserTime;
-            public long Reserved0;
-            public long Reserved1;
-            public ulong Reserved2;
+            public long DpcTime;
+            public long InterruptTime;
+            public uint InterruptCount;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct SYSTEM_PROCESSOR_IDLE_INFORMATION
+        {
+            public long IdleTime;
+            public long C1Time;
+            public long C2Time;
+            public long C3Time;
+            public uint C1Transitions;
+            public uint C2Transitions;
+            public uint C3Transitions;
+            public uint Padding;
         }
 
         internal enum SYSTEM_INFORMATION_CLASS
         {
-            SystemBasicInformation,
-            SystemProcessorInformation,
-            SystemPerformanceInformation,
-            SystemTimeOfDayInformation,
-            SystemPathInformation,
-            SystemProcessInformation,
-            SystemCallCountInformation,
-            SystemDeviceInformation,
-            SystemProcessorPerformanceInformation,
-            SystemFlagsInformation,
-            SystemCallTimeInformation,
-            SystemModuleInformation,
-            SystemLocksInformation,
-            SystemStackTraceInformation,
-            SystemPagedPoolInformation,
-            SystemNonPagedPoolInformation,
-            SystemHandleInformation,
-            SystemObjectInformation,
-            SystemPageFileInformation,
-            SystemVdmInstemulInformation,
-            SystemVdmBopInformation,
-            SystemFileCacheInformation,
-            SystemPoolTagInformation,
-            SystemInterruptInformation,
-            SystemDpcBehaviorInformation,
-            SystemFullMemoryInformation,
-            SystemLoadGdiDriverInformation,
-            SystemUnloadGdiDriverInformation,
-            SystemTimeAdjustmentInformation,
-            SystemSummaryMemoryInformation,
-            SystemNextEventIdInformation,
-            SystemEventIdsInformation,
-            SystemCrashDumpInformation,
-            SystemExceptionInformation,
-            SystemCrashDumpStateInformation,
-            SystemKernelDebuggerInformation,
-            SystemContextSwitchInformation,
-            SystemRegistryQuotaInformation,
-            SystemExtendServiceTableInformation,
-            SystemPrioritySeperation,
-            SystemPlugPlayBusInformation,
-            SystemDockInformation,
-            SystemPowerInformation,
-            SystemProcessorSpeedInformation,
-            SystemCurrentTimeZoneInformation,
-            SystemLookasideInformation
+            SystemProcessorPerformanceInformation = 8,
+            SystemProcessorIdleInformation = 42
         }
 
-        [DllImport(DllName)]
+        [DllImport("ntdll.dll")]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-        internal static extern int NtQuerySystemInformation(SYSTEM_INFORMATION_CLASS SystemInformationClass, [Out] SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION[] SystemInformation, int SystemInformationLength, out IntPtr ReturnLength);
+        internal static extern int NtQuerySystemInformation(SYSTEM_INFORMATION_CLASS SystemInformationClass, [Out] SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION[] SystemInformation, int SystemInformationLength, out int ReturnLength);
+
+        [DllImport("ntdll.dll")]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        internal static extern int NtQuerySystemInformation(SYSTEM_INFORMATION_CLASS SystemInformationClass, [Out] SYSTEM_PROCESSOR_IDLE_INFORMATION[] SystemInformation, int SystemInformationLength, out int ReturnLength);
     }
 }


### PR DESCRIPTION
On Windows 11 22H2 (22621) SystemProcessorPerformanceInformation returns invalid IdleTime leading to wrong CPU load readings, to bypass this issue we can still read the correct IdleTime from SystemProcessorIdleInformation.