### PR TITLE
Do not modify enumerated tree 

### DIFF
--- a/LibreHardwareMonitor/UI/TreeModel.cs
+++ b/LibreHardwareMonitor/UI/TreeModel.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using Aga.Controls.Tree;
 
 namespace LibreHardwareMonitor.UI;
@@ -59,12 +60,10 @@ public class TreeModel : ITreeModel
         Node node = GetNode(treePath);
         if (node != null)
         {
-            foreach (Node n in node.Nodes)
-                if (_forceVisible || n.IsVisible)
-                    yield return n;
+            return node.Nodes.Where(n => _forceVisible || n.IsVisible).ToList();
         }
-        else
-        { }
+
+        return Enumerable.Empty<Node>();
     }
 
     public bool IsLeaf(TreePath treePath)


### PR DESCRIPTION
When going to sleep when plot is shown some node are removed on my PC and it crash with InvalidOperationException because the collection is modified during enumeration.

 So return a copy of the filtered list instead of yield return.