### PR TITLE
Add view menu item to clear the plot

### DIFF
--- a/LibreHardwareMonitor/UI/MainForm.Designer.cs
+++ b/LibreHardwareMonitor/UI/MainForm.Designer.cs
@@ -64,6 +64,7 @@ namespace LibreHardwareMonitor.UI
             this.exitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.viewMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resetMinMaxMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resetPlotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.MenuItem3 = new System.Windows.Forms.ToolStripSeparator();
             this.hiddenMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.plotMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -345,6 +346,7 @@ namespace LibreHardwareMonitor.UI
             // 
             this.viewMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.resetMinMaxMenuItem,
+            this.resetPlotMenuItem,
             this.MenuItem3,
             this.hiddenMenuItem,
             this.plotMenuItem,
@@ -361,6 +363,13 @@ namespace LibreHardwareMonitor.UI
             this.resetMinMaxMenuItem.Size = new System.Drawing.Size(188, 22);
             this.resetMinMaxMenuItem.Text = "Reset Min/Max";
             this.resetMinMaxMenuItem.Click += new System.EventHandler(this.ResetMinMaxMenuItem_Click);
+            // 
+            // resetPlotMenuItem
+            // 
+            this.resetPlotMenuItem.Name = "resetPlotMenuItem";
+            this.resetPlotMenuItem.Size = new System.Drawing.Size(188, 22);
+            this.resetPlotMenuItem.Text = "Reset Plot";
+            this.resetPlotMenuItem.Click += new System.EventHandler(this.resetPlotMenuItem_Click);
             // 
             // MenuItem3
             // 
@@ -993,6 +1002,7 @@ namespace LibreHardwareMonitor.UI
         private ToolStripRadioButtonMenuItem fahrenheitMenuItem;
         private System.Windows.Forms.ToolStripSeparator MenuItem2;
         private System.Windows.Forms.ToolStripMenuItem resetMinMaxMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem resetPlotMenuItem;
         private System.Windows.Forms.ToolStripSeparator MenuItem3;
         private System.Windows.Forms.ToolStripMenuItem gadgetMenuItem;
         private System.Windows.Forms.ToolStripMenuItem minCloseMenuItem;

--- a/LibreHardwareMonitor/UI/MainForm.cs
+++ b/LibreHardwareMonitor/UI/MainForm.cs
@@ -1100,6 +1100,14 @@ public sealed partial class MainForm : Form
         }));
     }
 
+    private void resetPlotMenuItem_Click(object sender, EventArgs e)
+    {
+        _computer.Accept(new SensorVisitor(delegate (ISensor sensorClick)
+        {
+            sensorClick.ResetPlot();
+        }));
+    }
+
     private void MainForm_MoveOrResize(object sender, EventArgs e)
     {
         if (WindowState != FormWindowState.Minimized)

--- a/LibreHardwareMonitor/UI/MainForm.cs
+++ b/LibreHardwareMonitor/UI/MainForm.cs
@@ -1104,7 +1104,7 @@ public sealed partial class MainForm : Form
     {
         _computer.Accept(new SensorVisitor(delegate (ISensor sensorClick)
         {
-            sensorClick.ResetPlot();
+            sensorClick.ClearValues();
         }));
     }
 

--- a/LibreHardwareMonitorLib/Hardware/ISensor.cs
+++ b/LibreHardwareMonitorLib/Hardware/ISensor.cs
@@ -125,7 +125,7 @@ public interface ISensor : IElement
     void ResetMax();
 
     /// <summary>
-    /// Resets the plot graph.
+    /// Clears the values stored in <see cref="Values"/>.
     /// </summary>
-    void ResetPlot();
+    void ClearValues();
 }

--- a/LibreHardwareMonitorLib/Hardware/ISensor.cs
+++ b/LibreHardwareMonitorLib/Hardware/ISensor.cs
@@ -123,4 +123,9 @@ public interface ISensor : IElement
     /// Resets a value stored in <see cref="Max"/>.
     /// </summary>
     void ResetMax();
+
+    /// <summary>
+    /// Resets the plot graph.
+    /// </summary>
+    void ResetPlot();
 }

--- a/LibreHardwareMonitorLib/Hardware/Sensor.cs
+++ b/LibreHardwareMonitorLib/Hardware/Sensor.cs
@@ -169,7 +169,7 @@ internal class Sensor : ISensor
         Max = null;
     }
 
-    public void ResetPlot()
+    public void ClearValues()
     {
         _values.Clear();
     }

--- a/LibreHardwareMonitorLib/Hardware/Sensor.cs
+++ b/LibreHardwareMonitorLib/Hardware/Sensor.cs
@@ -169,6 +169,11 @@ internal class Sensor : ISensor
         Max = null;
     }
 
+    public void ResetPlot()
+    {
+        _values.Clear();
+    }
+
     public void Accept(IVisitor visitor)
     {
         if (visitor == null)


### PR DESCRIPTION
Adds a view menu -> "Reset Plot" item to clear the plotted value data.

![image](https://user-images.githubusercontent.com/9030085/202876923-a35558b4-5ab2-4bce-935a-c5046f6c3cbd.png)

I've had this feature in my own custom build for a while now, and I added it as a separate entry rather than just "Reset min/max/plot" on one button because there have been times where I only want to reset the min / max values but keep the plot, and likewise reset the plot but keep the maximum / minimum values intact.

(satisfies #859)