### PR TITLE
New feature: Adds mdns network discovery for http server and implements automatic server restart when changes are made

### DIFF
--- a/LibreHardwareMonitor/LibreHardwareMonitor.csproj
+++ b/LibreHardwareMonitor/LibreHardwareMonitor.csproj
@@ -21,6 +21,7 @@
     <DebugType>none</DebugType>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Makaretu.Dns.Multicast" Version="0.27.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="TaskScheduler" Version="2.10.1" />
     <PackageReference Include="OxyPlot.Core" Version="2.1.0" />

--- a/LibreHardwareMonitor/UI/AuthForm.Designer.cs
+++ b/LibreHardwareMonitor/UI/AuthForm.Designer.cs
@@ -59,24 +59,25 @@
             this.httpAuthUsernameTextBox.MaxLength = 255;
             this.httpAuthUsernameTextBox.Name = "httpAuthUsernameTextBox";
             this.httpAuthUsernameTextBox.Size = new System.Drawing.Size(171, 20);
-            this.httpAuthUsernameTextBox.TabIndex = 1;
+            this.httpAuthUsernameTextBox.TabIndex = 2;
+            this.httpAuthUsernameTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.httpAuthUsernameTextBox_KeyDown);
             // 
             // httpAuthPasswordTextBox
             // 
             this.httpAuthPasswordTextBox.Location = new System.Drawing.Point(102, 60);
             this.httpAuthPasswordTextBox.MaxLength = 255;
             this.httpAuthPasswordTextBox.Name = "httpAuthPasswordTextBox";
-            this.httpAuthPasswordTextBox.PasswordChar = '*';
             this.httpAuthPasswordTextBox.Size = new System.Drawing.Size(171, 20);
-            this.httpAuthPasswordTextBox.TabIndex = 2;
+            this.httpAuthPasswordTextBox.TabIndex = 3;
             this.httpAuthPasswordTextBox.UseSystemPasswordChar = true;
+            this.httpAuthPasswordTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.httpAuthPasswordTextBox_KeyDown);
             // 
             // httpUsernameLabel
             // 
             this.httpUsernameLabel.AutoSize = true;
             this.httpUsernameLabel.Location = new System.Drawing.Point(6, 26);
             this.httpUsernameLabel.Name = "httpUsernameLabel";
-            this.httpUsernameLabel.Size = new System.Drawing.Size(90, 13);
+            this.httpUsernameLabel.Size = new System.Drawing.Size(92, 13);
             this.httpUsernameLabel.TabIndex = 6;
             this.httpUsernameLabel.Text = "HTTP UserName:";
             // 
@@ -98,7 +99,7 @@
             this.credentialsGroupBox.Location = new System.Drawing.Point(12, 35);
             this.credentialsGroupBox.Name = "credentialsGroupBox";
             this.credentialsGroupBox.Size = new System.Drawing.Size(279, 100);
-            this.credentialsGroupBox.TabIndex = 5;
+            this.credentialsGroupBox.TabIndex = 1;
             this.credentialsGroupBox.TabStop = false;
             this.credentialsGroupBox.Text = "Credentials";
             // 
@@ -108,7 +109,7 @@
             this.httpAuthCancelButton.Location = new System.Drawing.Point(76, 206);
             this.httpAuthCancelButton.Name = "httpAuthCancelButton";
             this.httpAuthCancelButton.Size = new System.Drawing.Size(75, 23);
-            this.httpAuthCancelButton.TabIndex = 3;
+            this.httpAuthCancelButton.TabIndex = 5;
             this.httpAuthCancelButton.Text = "Cancel";
             this.httpAuthCancelButton.UseVisualStyleBackColor = true;
             this.httpAuthCancelButton.Click += new System.EventHandler(this.HttpAuthCancelButton_Click);
@@ -137,10 +138,10 @@
             this.label2.AutoSize = true;
             this.label2.Location = new System.Drawing.Point(12, 174);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(284, 26);
+            this.label2.Size = new System.Drawing.Size(265, 26);
             this.label2.TabIndex = 9;
-            this.label2.Text = "If the web server is running then it will need to be restarted \r\nfor the change t" +
-    "o take effect.";
+            this.label2.Text = "If the web server is running then it must to be restarted \r\nfor the change to tak" +
+    "e effect.";
             // 
             // AuthForm
             // 

--- a/LibreHardwareMonitor/UI/MainForm.Designer.cs
+++ b/LibreHardwareMonitor/UI/MainForm.Designer.cs
@@ -60,6 +60,7 @@ namespace LibreHardwareMonitor.UI
             this.hddMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.nicMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.psuMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.batteryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuItem6 = new System.Windows.Forms.ToolStripSeparator();
             this.exitMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.viewMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -127,6 +128,7 @@ namespace LibreHardwareMonitor.UI
             this.runWebServerMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.serverPortMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.authWebServerMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.networkDiscoveryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.treeContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
@@ -134,7 +136,6 @@ namespace LibreHardwareMonitor.UI
             this.timer = new System.Windows.Forms.Timer(this.components);
             this.splitContainer = new LibreHardwareMonitor.UI.SplitContainerAdv();
             this.treeView = new Aga.Controls.Tree.TreeViewAdv();
-            this.batteryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.backgroundUpdater = new System.ComponentModel.BackgroundWorker();
             this.mainMenu.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer)).BeginInit();
@@ -249,19 +250,19 @@ namespace LibreHardwareMonitor.UI
             // saveReportMenuItem
             // 
             this.saveReportMenuItem.Name = "saveReportMenuItem";
-            this.saveReportMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.saveReportMenuItem.Size = new System.Drawing.Size(145, 22);
             this.saveReportMenuItem.Text = "Save Report...";
             this.saveReportMenuItem.Click += new System.EventHandler(this.SaveReportMenuItem_Click);
             // 
             // MenuItem2
             // 
             this.MenuItem2.Name = "MenuItem2";
-            this.MenuItem2.Size = new System.Drawing.Size(177, 6);
+            this.MenuItem2.Size = new System.Drawing.Size(142, 6);
             // 
             // resetMenuItem
             // 
             this.resetMenuItem.Name = "resetMenuItem";
-            this.resetMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.resetMenuItem.Size = new System.Drawing.Size(145, 22);
             this.resetMenuItem.Text = "Reset";
             this.resetMenuItem.Click += new System.EventHandler(this.ResetClick);
             // 
@@ -278,66 +279,72 @@ namespace LibreHardwareMonitor.UI
             this.psuMenuItem,
             this.batteryMenuItem});
             this.menuItem5.Name = "menuItem5";
-            this.menuItem5.Size = new System.Drawing.Size(180, 22);
+            this.menuItem5.Size = new System.Drawing.Size(145, 22);
             this.menuItem5.Text = "Hardware";
             // 
             // mainboardMenuItem
             // 
             this.mainboardMenuItem.Name = "mainboardMenuItem";
-            this.mainboardMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.mainboardMenuItem.Size = new System.Drawing.Size(160, 22);
             this.mainboardMenuItem.Text = "Motherboard";
             // 
             // cpuMenuItem
             // 
             this.cpuMenuItem.Name = "cpuMenuItem";
-            this.cpuMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.cpuMenuItem.Size = new System.Drawing.Size(160, 22);
             this.cpuMenuItem.Text = "CPU";
             // 
             // ramMenuItem
             // 
             this.ramMenuItem.Name = "ramMenuItem";
-            this.ramMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.ramMenuItem.Size = new System.Drawing.Size(160, 22);
             this.ramMenuItem.Text = "RAM";
             // 
             // gpuMenuItem
             // 
             this.gpuMenuItem.Name = "gpuMenuItem";
-            this.gpuMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.gpuMenuItem.Size = new System.Drawing.Size(160, 22);
             this.gpuMenuItem.Text = "GPU";
             // 
             // fanControllerMenuItem
             // 
             this.fanControllerMenuItem.Name = "fanControllerMenuItem";
-            this.fanControllerMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.fanControllerMenuItem.Size = new System.Drawing.Size(160, 22);
             this.fanControllerMenuItem.Text = "Fan Controllers";
             // 
             // hddMenuItem
             // 
             this.hddMenuItem.Name = "hddMenuItem";
-            this.hddMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.hddMenuItem.Size = new System.Drawing.Size(160, 22);
             this.hddMenuItem.Text = "Hard Disk Drives";
             // 
             // nicMenuItem
             // 
             this.nicMenuItem.Name = "nicMenuItem";
-            this.nicMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.nicMenuItem.Size = new System.Drawing.Size(160, 22);
             this.nicMenuItem.Text = "Network";
             // 
             // psuMenuItem
             // 
             this.psuMenuItem.Name = "psuMenuItem";
-            this.psuMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.psuMenuItem.Size = new System.Drawing.Size(160, 22);
             this.psuMenuItem.Text = "Power supplies";
+            // 
+            // batteryMenuItem
+            // 
+            this.batteryMenuItem.Name = "batteryMenuItem";
+            this.batteryMenuItem.Size = new System.Drawing.Size(160, 22);
+            this.batteryMenuItem.Text = "Batteries";
             // 
             // menuItem6
             // 
             this.menuItem6.Name = "menuItem6";
-            this.menuItem6.Size = new System.Drawing.Size(177, 6);
+            this.menuItem6.Size = new System.Drawing.Size(142, 6);
             // 
             // exitMenuItem
             // 
             this.exitMenuItem.Name = "exitMenuItem";
-            this.exitMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.exitMenuItem.Size = new System.Drawing.Size(145, 22);
             this.exitMenuItem.Text = "Exit";
             this.exitMenuItem.Click += new System.EventHandler(this.ExitClick);
             // 
@@ -411,19 +418,19 @@ namespace LibreHardwareMonitor.UI
             // valueMenuItem
             // 
             this.valueMenuItem.Name = "valueMenuItem";
-            this.valueMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.valueMenuItem.Size = new System.Drawing.Size(102, 22);
             this.valueMenuItem.Text = "Value";
             // 
             // minMenuItem
             // 
             this.minMenuItem.Name = "minMenuItem";
-            this.minMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.minMenuItem.Size = new System.Drawing.Size(102, 22);
             this.minMenuItem.Text = "Min";
             // 
             // maxMenuItem
             // 
             this.maxMenuItem.Name = "maxMenuItem";
-            this.maxMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.maxMenuItem.Size = new System.Drawing.Size(102, 22);
             this.maxMenuItem.Text = "Max";
             // 
             // optionsMenuItem
@@ -653,7 +660,7 @@ namespace LibreHardwareMonitor.UI
             this.log6hMenuItem.Name = "log6hMenuItem";
             this.log6hMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log6hMenuItem.Text = "6h";
-            //
+            // 
             // updateIntervalMenuItem
             // 
             this.updateIntervalMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -671,42 +678,42 @@ namespace LibreHardwareMonitor.UI
             // 
             this.updateInterval250msMenuItem.CheckOnClick = true;
             this.updateInterval250msMenuItem.Name = "updateInterval250msMenuItem";
-            this.updateInterval250msMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.updateInterval250msMenuItem.Size = new System.Drawing.Size(108, 22);
             this.updateInterval250msMenuItem.Text = "250ms";
             // 
             // updateInterval500msMenuItem
             // 
             this.updateInterval500msMenuItem.CheckOnClick = true;
             this.updateInterval500msMenuItem.Name = "updateInterval500msMenuItem";
-            this.updateInterval500msMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.updateInterval500msMenuItem.Size = new System.Drawing.Size(108, 22);
             this.updateInterval500msMenuItem.Text = "500ms";
             // 
             // updateInterval1sMenuItem
             // 
             this.updateInterval1sMenuItem.CheckOnClick = true;
             this.updateInterval1sMenuItem.Name = "updateInterval1sMenuItem";
-            this.updateInterval1sMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.updateInterval1sMenuItem.Size = new System.Drawing.Size(108, 22);
             this.updateInterval1sMenuItem.Text = "1s";
             // 
             // updateInterval2sMenuItem
             // 
             this.updateInterval2sMenuItem.CheckOnClick = true;
             this.updateInterval2sMenuItem.Name = "updateInterval2sMenuItem";
-            this.updateInterval2sMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.updateInterval2sMenuItem.Size = new System.Drawing.Size(108, 22);
             this.updateInterval2sMenuItem.Text = "2s";
             // 
             // updateInterval5sMenuItem
             // 
             this.updateInterval5sMenuItem.CheckOnClick = true;
             this.updateInterval5sMenuItem.Name = "updateInterval5sMenuItem";
-            this.updateInterval5sMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.updateInterval5sMenuItem.Size = new System.Drawing.Size(108, 22);
             this.updateInterval5sMenuItem.Text = "5s";
             // 
             // updateInterval10sMenuItem
             // 
             this.updateInterval10sMenuItem.CheckOnClick = true;
             this.updateInterval10sMenuItem.Name = "updateInterval10sMenuItem";
-            this.updateInterval10sMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.updateInterval10sMenuItem.Size = new System.Drawing.Size(108, 22);
             this.updateInterval10sMenuItem.Text = "10s";
             // 
             // sensorValuesTimeWindowMenuItem
@@ -814,7 +821,8 @@ namespace LibreHardwareMonitor.UI
             this.webMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.runWebServerMenuItem,
             this.serverPortMenuItem,
-            this.authWebServerMenuItem});
+            this.authWebServerMenuItem,
+            this.networkDiscoveryToolStripMenuItem});
             this.webMenuItem.Name = "webMenuItem";
             this.webMenuItem.Size = new System.Drawing.Size(221, 22);
             this.webMenuItem.Text = "Remote Web Server";
@@ -822,22 +830,28 @@ namespace LibreHardwareMonitor.UI
             // runWebServerMenuItem
             // 
             this.runWebServerMenuItem.Name = "runWebServerMenuItem";
-            this.runWebServerMenuItem.Size = new System.Drawing.Size(153, 22);
+            this.runWebServerMenuItem.Size = new System.Drawing.Size(180, 22);
             this.runWebServerMenuItem.Text = "Run";
             // 
             // serverPortMenuItem
             // 
             this.serverPortMenuItem.Name = "serverPortMenuItem";
-            this.serverPortMenuItem.Size = new System.Drawing.Size(153, 22);
+            this.serverPortMenuItem.Size = new System.Drawing.Size(180, 22);
             this.serverPortMenuItem.Text = "Port";
             this.serverPortMenuItem.Click += new System.EventHandler(this.ServerPortMenuItem_Click);
             // 
             // authWebServerMenuItem
             // 
             this.authWebServerMenuItem.Name = "authWebServerMenuItem";
-            this.authWebServerMenuItem.Size = new System.Drawing.Size(153, 22);
+            this.authWebServerMenuItem.Size = new System.Drawing.Size(180, 22);
             this.authWebServerMenuItem.Text = "Authentication";
             this.authWebServerMenuItem.Click += new System.EventHandler(this.AuthWebServerMenuItem_Click);
+            // 
+            // networkDiscoveryToolStripMenuItem
+            // 
+            this.networkDiscoveryToolStripMenuItem.Name = "networkDiscoveryToolStripMenuItem";
+            this.networkDiscoveryToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.networkDiscoveryToolStripMenuItem.Text = "Network Discovery";
             // 
             // helpMenuItem
             // 
@@ -850,7 +864,7 @@ namespace LibreHardwareMonitor.UI
             // aboutMenuItem
             // 
             this.aboutMenuItem.Name = "aboutMenuItem";
-            this.aboutMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.aboutMenuItem.Size = new System.Drawing.Size(180, 22);
             this.aboutMenuItem.Text = "About";
             this.aboutMenuItem.Click += new System.EventHandler(this.AboutMenuItem_Click);
             // 
@@ -926,12 +940,6 @@ namespace LibreHardwareMonitor.UI
             this.treeView.MouseDown += new System.Windows.Forms.MouseEventHandler(this.TreeView_MouseDown);
             this.treeView.MouseMove += new System.Windows.Forms.MouseEventHandler(this.TreeView_MouseMove);
             this.treeView.MouseUp += new System.Windows.Forms.MouseEventHandler(this.TreeView_MouseUp);
-            // 
-            // batteryMenuItem
-            // 
-            this.batteryMenuItem.Name = "batteryMenuItem";
-            this.batteryMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.batteryMenuItem.Text = "Batteries";
             // 
             // MainForm
             // 
@@ -1060,6 +1068,7 @@ namespace LibreHardwareMonitor.UI
         private System.Windows.Forms.ToolStripMenuItem psuMenuItem;
         private System.Windows.Forms.ToolStripMenuItem batteryMenuItem;
         private System.ComponentModel.BackgroundWorker backgroundUpdater;
+        private System.Windows.Forms.ToolStripMenuItem networkDiscoveryToolStripMenuItem;
     }
 }
 

--- a/LibreHardwareMonitor/UI/MainForm.Designer.cs
+++ b/LibreHardwareMonitor/UI/MainForm.Designer.cs
@@ -135,7 +135,6 @@ namespace LibreHardwareMonitor.UI
             this.splitContainer = new LibreHardwareMonitor.UI.SplitContainerAdv();
             this.treeView = new Aga.Controls.Tree.TreeViewAdv();
             this.batteryMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.psuMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.backgroundUpdater = new System.ComponentModel.BackgroundWorker();
             this.mainMenu.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer)).BeginInit();

--- a/LibreHardwareMonitor/UI/MainForm.cs
+++ b/LibreHardwareMonitor/UI/MainForm.cs
@@ -43,6 +43,7 @@ public sealed partial class MainForm : Form
     private readonly UserOption _readRamSensors;
     private readonly Node _root;
     private readonly UserOption _runWebServer;
+    private readonly UserOption _advertiseWebServer;
     private readonly UserRadioGroup _sensorValuesTimeWindow;
     private readonly PersistentSettings _settings;
     private readonly UserOption _showGadget;
@@ -240,7 +241,8 @@ public sealed partial class MainForm : Form
                                 _settings.GetValue("listenerPort", 8085),
                                 _settings.GetValue("authenticationEnabled", false),
                                 _settings.GetValue("authenticationUserName", "librehm"),
-                                _settings.GetValue("authenticationPassword", "librehm"));
+                                _settings.GetValue("authenticationPassword", "librehm"),
+                                _settings.GetValue("networkDiscoveryToolStripMenuItem", false));
 
         if (Server.PlatformNotSupported)
         {
@@ -262,8 +264,17 @@ public sealed partial class MainForm : Form
                 Server.StopHttpListener();
         };
 
-        authWebServerMenuItem.Checked = Server.AuthEnabled;
+        _advertiseWebServer = new UserOption("networkDiscoveryToolStripMenuItem", false, networkDiscoveryToolStripMenuItem, _settings);
+        _advertiseWebServer.Changed += delegate
+        {
+            if (_advertiseWebServer.Value)
+                Server.StartNetworkDiscovery();
+            else
+                Server.StopNetworkDiscovery();
+            Server.NetworkDiscoveryEnabled = _advertiseWebServer.Value;
+        };
 
+        authWebServerMenuItem.Checked = Server.AuthEnabled;
 
         _logSensors = new UserOption("logSensorsMenuItem", false, logSensorsMenuItem, _settings);
 

--- a/LibreHardwareMonitor/UI/MainForm.cs
+++ b/LibreHardwareMonitor/UI/MainForm.cs
@@ -239,14 +239,19 @@ public sealed partial class MainForm : Form
         Server = new HttpServer(_root,
                                 _settings.GetValue("listenerPort", 8085),
                                 _settings.GetValue("authenticationEnabled", false),
-                                _settings.GetValue("authenticationUserName", ""),
-                                _settings.GetValue("authenticationPassword", ""));
+                                _settings.GetValue("authenticationUserName", "librehm"),
+                                _settings.GetValue("authenticationPassword", "librehm"));
 
         if (Server.PlatformNotSupported)
         {
             webMenuItemSeparator.Visible = false;
             webMenuItem.Visible = false;
         }
+
+        Server.RunningStateUpdated += delegate
+        {
+            runWebServerMenuItem.Checked = Server.IsRunning;
+        };
 
         _runWebServer = new UserOption("runWebServerMenuItem", false, runWebServerMenuItem, _settings);
         _runWebServer.Changed += delegate
@@ -257,7 +262,8 @@ public sealed partial class MainForm : Form
                 Server.StopHttpListener();
         };
 
-        authWebServerMenuItem.Checked = _settings.GetValue("authenticationEnabled", false);
+        authWebServerMenuItem.Checked = Server.AuthEnabled;
+
 
         _logSensors = new UserOption("logSensorsMenuItem", false, logSensorsMenuItem, _settings);
 

--- a/LibreHardwareMonitor/UI/MainForm.resx
+++ b/LibreHardwareMonitor/UI/MainForm.resx
@@ -117,17 +117,20 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="treeContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="mainMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="treeContextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>288, 17</value>
+  </metadata>
   <metadata name="saveFileDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>164, 17</value>
+    <value>435, 17</value>
   </metadata>
   <metadata name="timer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>293, 17</value>
+    <value>564, 17</value>
   </metadata>
-  <metadata name="backgroundWorker1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>483, 17</value>
+  <metadata name="backgroundUpdater.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>127, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/LibreHardwareMonitor/UI/PortForm.cs
+++ b/LibreHardwareMonitor/UI/PortForm.cs
@@ -9,6 +9,7 @@ using System.Windows.Forms;
 using System.Net;
 using System.Net.Sockets;
 using System.Diagnostics;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace LibreHardwareMonitor.UI;
 
@@ -52,6 +53,14 @@ public partial class PortForm : Form
     private void PortOKButton_Click(object sender, EventArgs e)
     {
         _parent.Server.ListenerPort = (int)portNumericUpDn.Value;
+        if(_parent.Server.RestartRequired && _parent.Server.PendingRestarts.Contains(Utilities.HttpServer.PendingRestartReason.ListenerPortChanged))
+        {
+            DialogResult result = MessageBox.Show("Server restart required for port change to take effect.\nDo you want to restart it now?", "Pending server restart", MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button1);
+            if (result == DialogResult.Yes)
+            {
+                _parent.Server.Restart();
+            }
+        }
         Close();
     }
 


### PR DESCRIPTION
I did multiple changes so here it goes:

When you run the app for first time (no present configuration) username and password are prefilled with default value:

![image](https://user-images.githubusercontent.com/6750655/204120360-d406b756-d5e7-442a-b006-c1854a9928f0.png)

When changing server settings like port or username or password or checkbox for http basic authentication after applying you will be prompted to automaticaly restart the server for the changes to take effect. 

Auth Form             |  Port Form
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/6750655/204120435-70c3a227-9633-4992-944d-45c98c7cce18.png)   |  ![image](https://user-images.githubusercontent.com/6750655/204120462-abd0a6cc-070a-4e8e-ac58-8d318b3225a3.png)

Network Discovery toggle added to Remote Web Server under options: 

![image](https://user-images.githubusercontent.com/6750655/204120570-83af7b6c-1358-4144-940e-8e61c457b058.png)

Network Discovery updates automatically to follow server changes if applied.

Here is example what is advertised. My idea is to use this for Home assistant integration.

![image](https://user-images.githubusercontent.com/6750655/204120630-4094376c-9b6a-4a9f-94e9-1c617246fe2a.png)

Running state changed event is also added so maybe someone in future can implement small icon somewhere to indicate if server is running or not. Same goes with pending changes that are not applied because server is not restarted.


