### PR TITLE
Add Support IT8625E and X670E Valkyrie

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -363,6 +363,8 @@ internal class Identification
                 return Model.ROG_MAXIMUS_Z690_EXTREME_GLACIAL;
             case var _ when name.Equals("B660GTN", StringComparison.OrdinalIgnoreCase):
                 return Model.B660GTN;
+            case var _ when name.Equals("X670E VALKYRIE", StringComparison.OrdinalIgnoreCase):
+                return Model.X670E_Valkyrie;
             case var _ when name.Equals("ROG MAXIMUS Z790 HERO", StringComparison.OrdinalIgnoreCase):
                 return Model.ROG_MAXIMUS_Z790_HERO;
             case var _ when name.Equals("Base Board Product Name", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
@@ -29,6 +29,7 @@ internal enum Chip : ushort
 
     IT8613E = 0x8613,
     IT8620E = 0x8620,
+    IT8625E = 0x8625,
     IT8628E = 0x8628,
     IT8631E = 0x8631,
     IT8655E = 0x8655,
@@ -97,6 +98,7 @@ internal class ChipName
             case Chip.F71808E: return "Fintek F71808E";
             case Chip.IT8613E: return "ITE IT8613E";
             case Chip.IT8620E: return "ITE IT8620E";
+            case Chip.IT8625E: return "ITE IT8625E";
             case Chip.IT8628E: return "ITE IT8628E";
             case Chip.IT8631E: return "ITE IT8631E";
             case Chip.IT8655E: return "ITE IT8655E";

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -66,9 +66,13 @@ internal class IT87XX : ISuperIO
         if (!valid || ((configuration & 0x10) == 0 && chip != Chip.IT8655E && chip != Chip.IT8665E))
             return;
 
-        FAN_PWM_CTRL_REG = chip == Chip.IT8665E
-            ? new byte[] { 0x15, 0x16, 0x17, 0x1e, 0x1f }
-            : new byte[] { 0x15, 0x16, 0x17, 0x7f, 0xa7, 0xaf };
+        FAN_PWM_CTRL_REG = chip switch
+        {
+            // IT8625E Register is estimated from Biostar's Valkyrie Aurora Config file
+            Chip.IT8625E =>new byte[] { 0x81, 0x83, 0x85, 0x87, 0x96, 0x94 },
+            Chip.IT8665E =>new byte[] { 0x15, 0x16, 0x17, 0x1e, 0x1f },
+            _ => new byte[] { 0x15, 0x16, 0x17, 0x7f, 0xa7, 0xaf }
+        };
 
         _bankCount = chip switch
         {
@@ -101,7 +105,7 @@ internal class IT87XX : ISuperIO
                 break;
 
             case Chip.IT8625E:
-                Voltages = new float?[6];
+                Voltages = new float?[7];
                 Temperatures = new float?[3];
                 Fans = new float?[6];
                 Controls = new float?[6];

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -84,6 +84,7 @@ internal class IT87XX : ISuperIO
             Chip.IT8689E or
             Chip.IT8695E or
             Chip.IT8628E or
+            Chip.IT8625E or
             Chip.IT8620E or
             Chip.IT8613E or
             Chip.IT879XE or
@@ -99,6 +100,12 @@ internal class IT87XX : ISuperIO
                 Controls = new float?[4];
                 break;
 
+            case Chip.IT8625E:
+                Voltages = new float?[6];
+                Temperatures = new float?[3];
+                Fans = new float?[6];
+                Controls = new float?[6];
+                break;
             case Chip.IT8628E:
                 Voltages = new float?[10];
                 Temperatures = new float?[6];
@@ -178,7 +185,7 @@ internal class IT87XX : ISuperIO
         _voltageGain = chip switch
         {
             Chip.IT8613E or Chip.IT8620E or Chip.IT8628E or Chip.IT8631E or Chip.IT8721F or Chip.IT8728F or Chip.IT8771E or Chip.IT8772E or Chip.IT8686E or Chip.IT8688E or Chip.IT8689E => 0.012f,
-            Chip.IT8695E => 11f / 1000f,
+            Chip.IT8625E or Chip.IT8695E => 0.011f,
             Chip.IT8655E or Chip.IT8665E or Chip.IT879XE => 0.0109f,
             _ => 0.016f
         };

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
@@ -542,6 +542,7 @@ internal class LpcIO
         {
             0x8613 => Chip.IT8613E,
             0x8620 => Chip.IT8620E,
+            0x8625 => Chip.IT8625E,
             0x8628 => Chip.IT8628E,
             0x8631 => Chip.IT8631E,
             0x8665 => Chip.IT8665E,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -79,6 +79,7 @@ internal enum Model
 
     //BIOSTAR
     B660GTN,
+    X670E_Valkyrie,
 
     // DFI
     LP_BI_P45_T2RS_Elite,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1604,20 +1604,27 @@ internal sealed class SuperIOHardware : Hardware
                     case Model.X670E_Valkyrie: //IT8625E
                         v.Add(new Voltage("CPU Core Voltage", 0));
                         v.Add(new Voltage("CPU DDR IMC Voltage", 1));
-                        v.Add(new Voltage("+12.0V", 2, 5, 1));
-                        v.Add(new Voltage("CPU_SOC Voltage", 3));
+                        v.Add(new Voltage("+12.0V", 2, 10, 2));
+                        // Voltage of unknown use
+                        v.Add(new Voltage("Voltage #4", 3, true));
                         v.Add(new Voltage("CPU_MISC Voltage", 4));
                         v.Add(new Voltage("CPU_VDD Voltage", 5));
+                        v.Add(new Voltage("CPU_SOC Voltage", 6));
 
                         t.Add(new Temperature("CPU Temperature", 0));
                         t.Add(new Temperature("MOS Temperature", 1));
                         t.Add(new Temperature("System Temperature", 2));
 
-                        for (int i = 0; i < superIO.Fans.Length; i++)
-                            f.Add(new Fan("Fan #" + (i + 1), i));
+                        f.Add(new Fan("CPU Fan Speed", 0));
+                        f.Add(new Fan("CPU OPT Speed", 1));
+                        for (int i = 2; i < superIO.Fans.Length; i++)
+                            f.Add(new Fan($"System Fan{i - 1} Speed ", i));
 
-                        for (int i = 0; i < superIO.Controls.Length; i++)
-                            c.Add(new Ctrl("Fan #" + (i + 1), i));
+                        c.Add(new Ctrl("CPU Fan", 0));
+                        c.Add(new Ctrl("CPU OPT", 1));
+                        for (int i = 2; i < superIO.Controls.Length; i++)
+                            c.Add(new Ctrl($"System Fan{i - 1}", i));
+
                         break;
 
                     default:

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -218,6 +218,7 @@ internal sealed class SuperIOHardware : Hardware
 
             case Chip.IT8613E:
             case Chip.IT8620E:
+            case Chip.IT8625E:
             case Chip.IT8628E:
             case Chip.IT8631E:
             case Chip.IT8655E:
@@ -1598,6 +1599,25 @@ internal sealed class SuperIOHardware : Hardware
                         c.Add(new Ctrl("CPU Optional Fan", 2));
                         c.Add(new Ctrl("System Fan", 4));
 
+                        break;
+
+                    case Model.X670E_Valkyrie: //IT8625E
+                        v.Add(new Voltage("CPU Core Voltage", 0));
+                        v.Add(new Voltage("CPU DDR IMC Voltage", 1));
+                        v.Add(new Voltage("+12.0V", 2, 5, 1));
+                        v.Add(new Voltage("CPU_SOC Voltage", 3));
+                        v.Add(new Voltage("CPU_MISC Voltage", 4));
+                        v.Add(new Voltage("CPU_VDD Voltage", 5));
+
+                        t.Add(new Temperature("CPU Temperature", 0));
+                        t.Add(new Temperature("MOS Temperature", 1));
+                        t.Add(new Temperature("System Temperature", 2));
+
+                        for (int i = 0; i < superIO.Fans.Length; i++)
+                            f.Add(new Fan("Fan #" + (i + 1), i));
+
+                        for (int i = 0; i < superIO.Controls.Length; i++)
+                            c.Add(new Ctrl("Fan #" + (i + 1), i));
                         break;
 
                     default:


### PR DESCRIPTION
Support for this board and chip.

The value of FAN_PWM_CTRL_REG is on the Config file in Biostar's UtilitySoftware.
https://gist.github.com/masaki9b/ed0d53fb293af9eb1673417d63ede252#file-biostarvalkyrieauroraconfig-ini-L627-L668

It works mostly fine in my environment, the only problem I could not solve is that System Fan4 is always disabled.