### PR TITLE
Support for Asus PRIME Z690-A T_Sensor and Temp VRM

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -365,6 +365,8 @@ internal class Identification
                 return Model.B660GTN;
             case var _ when name.Equals("ROG MAXIMUS Z790 HERO", StringComparison.OrdinalIgnoreCase):
                 return Model.ROG_MAXIMUS_Z790_HERO;
+            case var _ when name.Equals("PRIME Z690-A", StringComparison.OrdinalIgnoreCase):
+                return Model.PRIME_Z690_A;
             case var _ when name.Equals("Base Board Product Name", StringComparison.OrdinalIgnoreCase):
             case var _ when name.Equals("To be filled by O.E.M.", StringComparison.OrdinalIgnoreCase):
                 return Model.Unknown;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
@@ -159,7 +159,11 @@ public abstract class EmbeddedController : Hardware
             ECSensor.TempChipset,
             ECSensor.FanWaterPump,
             ECSensor.CurrCPU,
-            ECSensor.VoltageCPU)
+            ECSensor.VoltageCPU),
+        new(Model.PRIME_Z690_A,
+            BoardFamily.Intel600,
+            ECSensor.TempTSensor,
+            ECSensor.TempVrm)
     };
 
     private static readonly Dictionary<BoardFamily, Dictionary<ECSensor, EmbeddedControllerSource>> _knownSensors = new()

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -76,6 +76,7 @@ internal enum Model
     Z170_A,
     TUF_GAMING_B550M_PLUS_WIFI,
     ROG_MAXIMUS_Z790_HERO,
+    PRIME_Z690_A,
 
     //BIOSTAR
     B660GTN,


### PR DESCRIPTION
Added the following sensors for the [Asus Prime Z690-A Board](https://www.asus.com/motherboards-components/motherboards/prime/prime-z690-a/)
  - "T_Sensor"
  - VRM temperature

Confirmed functionality by using the modified code in [FanControl](https://github.com/Rem0o/FanControl.Releases)