### PR TITLE
Change "Hard Disk Drives" menu option to read "Storage Devices"

### DIFF
--- a/LibreHardwareMonitor/UI/MainForm.Designer.cs
+++ b/LibreHardwareMonitor/UI/MainForm.Designer.cs
@@ -316,7 +316,7 @@ namespace LibreHardwareMonitor.UI
             // 
             this.hddMenuItem.Name = "hddMenuItem";
             this.hddMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.hddMenuItem.Text = "Storage Drives";
+            this.hddMenuItem.Text = "Storage Devices";
             // 
             // nicMenuItem
             // 

--- a/LibreHardwareMonitor/UI/MainForm.Designer.cs
+++ b/LibreHardwareMonitor/UI/MainForm.Designer.cs
@@ -316,7 +316,7 @@ namespace LibreHardwareMonitor.UI
             // 
             this.hddMenuItem.Name = "hddMenuItem";
             this.hddMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.hddMenuItem.Text = "Hard Disk Drives";
+            this.hddMenuItem.Text = "Internal Storage Drives";
             // 
             // nicMenuItem
             // 

--- a/LibreHardwareMonitor/UI/MainForm.Designer.cs
+++ b/LibreHardwareMonitor/UI/MainForm.Designer.cs
@@ -316,7 +316,7 @@ namespace LibreHardwareMonitor.UI
             // 
             this.hddMenuItem.Name = "hddMenuItem";
             this.hddMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.hddMenuItem.Text = "Internal Storage Drives";
+            this.hddMenuItem.Text = "Storage Drives";
             // 
             // nicMenuItem
             // 


### PR DESCRIPTION
Change the text of the "File > Hardware > Hard Disk Drives" menu option to read "Storage Drives" (so that it is now "File > Hardware > Storage Drives").

The motivation for this change is that the option affects Solid State Drives in addition to Hard Disk Drives.