### PR TITLE
Add support for IPMI sensors and Supermicro IPMI fan control

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
@@ -74,7 +74,9 @@ internal enum Chip : ushort
     W83627THF = 0x8280,
     W83667HG = 0xA510,
     W83667HGB = 0xB350,
-    W83687THF = 0x8541
+    W83687THF = 0x8541,
+
+    IPMI = 0x4764,
 }
 
 internal class ChipName
@@ -143,6 +145,8 @@ internal class ChipName
             case Chip.W83667HG: return "Winbond W83667HG";
             case Chip.W83667HGB: return "Winbond W83667HG-B";
             case Chip.W83687THF: return "Winbond W83687THF";
+
+            case Chip.IPMI: return "IPMI";
 
             default: return "Unknown";
         }

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Ipmi.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Ipmi.cs
@@ -5,10 +5,101 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Management;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc;
+
+// Ported from ipmiutil
+[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi, Pack = 1)]
+unsafe struct IpmiSdr
+{
+    [MarshalAs(UnmanagedType.U2)]
+    public ushort recid;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte sdrver;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte rectype;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte reclen;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte sens_ownid;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte sens_ownlun;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte sens_num;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte entity_id;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte entity_inst;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte sens_init;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte sens_capab;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte sens_type;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte ev_type;
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 6)]
+    public string data1;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte sens_units;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte sens_base;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte sens_mod;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte linear;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte m;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte m_t;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte b;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte b_a;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte a_ax;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte rx_bx;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte flags;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte nom_reading;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte norm_max;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte norm_min;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte sens_max_reading;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte sens_min_reading;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte unr_threshold;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte ucr_threshold;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte unc_threshold;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte lnr_threshold;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte lcr_threshold;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte lnc_threshold;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte pos_hysteresis;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte neg_hysteresis;
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 3)]
+    public string data3;
+    [MarshalAs(UnmanagedType.U1)]
+    public byte id_strlen;
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 16)]
+    public string id_string;
+}
+
 internal class Ipmi : ISuperIO
 {
     public Chip Chip { get; }
@@ -33,7 +124,12 @@ internal class Ipmi : ISuperIO
     private ManagementObject _ipmi;
 
     const byte COMMAND_GET_SDR_REPOSITORY_INFO = 0x20;
+    const byte COMMAND_RESERVE_SDR_REPOSITORY = 0x22;
     const byte COMMAND_GET_SDR = 0x23;
+    const byte COMMAND_GET_SENSOR_READING = 0x2d;
+
+    const byte NETWORK_FUNCTION_SENSOR_EVENT = 0x4;
+    const byte NETWORK_FUNCTION_STORAGE = 0xa;
 
     public Ipmi()
     {
@@ -46,7 +142,7 @@ internal class Ipmi : ISuperIO
             _ipmi = ipmi;
         }
 
-        // Have to perform an early update to count the number of sensors and get their names
+        // Perform an early update to count the number of sensors and get their names
         Update();
 
         Controls = new float?[_controls.Count];
@@ -55,53 +151,103 @@ internal class Ipmi : ISuperIO
         Voltages = new float?[_voltages.Count];
     }
 
-    public string GetReport() => throw new NotImplementedException();
+    public string GetReport()
+    {
+        StringBuilder sb = new();
+        Update(sb);
+        return sb.ToString();
+    }
+
     public void SetControl(int index, byte? value) => throw new NotImplementedException();
-    public void Update()
+
+    public void Update() { Update(null); }
+    private void Update(StringBuilder? debugSB = null)
     {
         _controls.Clear();
         _fans.Clear();
         _temperatures.Clear();
         _voltages.Clear();
 
-        byte[] sdrInfo = RunIPMICommand(COMMAND_GET_SDR_REPOSITORY_INFO, new byte[] { });
+        byte[] sdrInfo = RunIPMICommand(COMMAND_GET_SDR_REPOSITORY_INFO, NETWORK_FUNCTION_STORAGE, new byte[] { });
         int recordCount = sdrInfo[3] * 256 + sdrInfo[2];
 
         byte recordLower = 0;
         byte recordUpper = 0;
         for (int i = 0; i < recordCount; ++i)
         {
-            byte[] sdr = RunIPMICommand(COMMAND_GET_SDR, new byte[] { 0, 0, recordLower, recordUpper, 0, 0xff });
-            recordLower = sdr[1];
-            recordUpper = sdr[2];
+            byte[] sdrRaw = RunIPMICommand(COMMAND_GET_SDR, NETWORK_FUNCTION_STORAGE, new byte[] { 0, 0, recordLower, recordUpper, 0, 0xff });
 
-            if (sdr[6] == 1)
+            recordLower = sdrRaw[1];
+            recordUpper = sdrRaw[2];
+
+            // Long records unsupported
+            if (sdrRaw[0] == 0)
             {
-                byte sensorType = sdr[15];
-                string sensorName = Encoding.UTF8.GetString(sdr, 51, sdr.Length - 51);
-                if (sensorName.IndexOf((char)0) >= 0)
+                IpmiSdr sdr;
+                unsafe
                 {
-                    sensorName = sensorName.Remove(sensorName.IndexOf((char)0));
+                    fixed (byte* pSdr = sdrRaw)
+                    {
+                        sdr = (IpmiSdr)Marshal.PtrToStructure((IntPtr)pSdr + 3, typeof(IpmiSdr));
+                    }
                 }
 
-                switch (sensorType)
+                if (sdr.rectype == 1)
                 {
-                    case 1:
-                        _temperatures.Add(1.0f);
-                        if (Temperatures.Length == 0)
+                    byte[] reading = RunIPMICommand(COMMAND_GET_SENSOR_READING, NETWORK_FUNCTION_SENSOR_EVENT, new byte[] { sdr.sens_num });
+
+                    if (reading[0] == 0)
+                    {
+                        switch (sdr.sens_type)
                         {
-                            TemperatureNames.Add(sensorName);
+                            case 1:
+                                _temperatures.Add(RawToFloat(reading[1], sdr));
+                                if (Temperatures.Length == 0)
+                                {
+                                    TemperatureNames.Add(sdr.id_string.Replace(" Temp", ""));
+                                }
+                                break;
+
+                            case 2:
+                                _voltages.Add(RawToFloat(reading[1], sdr));
+                                if (Voltages.Length == 0)
+                                {
+                                    VoltageNames.Add(sdr.id_string);
+                                }
+                                break;
+
+                            case 4:
+                                _fans.Add(RawToFloat(reading[1], sdr));
+                                if (Fans.Length == 0)
+                                {
+                                    FanNames.Add(sdr.id_string);
+                                }
+                                break;
+
+                            default:
+                                break;
                         }
-                        break;
+                    }
+
+                    if (debugSB != null)
+                    {
+                        debugSB.AppendLine("IPMI sensor " + i + " reading: " + BitConverter.ToString(reading).Replace("-", "") + " info: " + BitConverter.ToString(sdrRaw).Replace("-", ""));
+                    }
                 }
             }
-
-            //System.Diagnostics.Debug.WriteLine(BitConverter.ToString(getSDRResult).Replace("-", ""));
         }
 
         for (int i = 0; i < Math.Min(_temperatures.Count, Temperatures.Length); ++i)
         {
             Temperatures[i] = _temperatures[i];
+        }
+        for (int i = 0; i < Math.Min(_voltages.Count, Voltages.Length); ++i)
+        {
+            Voltages[i] = _voltages[i];
+        }
+        for (int i = 0; i < Math.Min(_fans.Count, Fans.Length); ++i)
+        {
+            Fans[i] = _fans[i];
         }
     }
     public static bool IsBmcPresent()
@@ -119,10 +265,10 @@ internal class Ipmi : ISuperIO
     {
     }
 
-    private byte[] RunIPMICommand(int command, byte[] requestData)
+    private byte[] RunIPMICommand(byte command, byte networkFunction, byte[] requestData)
     {
         ManagementBaseObject inParams = _ipmi.GetMethodParameters("RequestResponse");
-        inParams["NetworkFunction"] = 0xa;
+        inParams["NetworkFunction"] = networkFunction;
         inParams["Lun"] = 0;
         inParams["ResponderAddress"] = 0x20;
         inParams["Command"] = command;
@@ -131,4 +277,44 @@ internal class Ipmi : ISuperIO
         ManagementBaseObject outParams = _ipmi.InvokeMethod("RequestResponse", inParams, null);
         return (byte[])outParams["ResponseData"];
     }
+
+    // Ported from ipmiutil
+    float RawToFloat(byte sensorReading, IpmiSdr sdr)
+    {
+        double floatval = (double)sensorReading;
+        int m, b, a;
+        int ax;
+        int rx, b_exp;
+        int signval;
+
+        m = sdr.m + ((sdr.m_t & 0xc0) << 2);
+        b = sdr.b + ((sdr.b_a & 0xc0) << 2);
+        if (Convert.ToBoolean(b & 0x0200)) b = (b - 0x0400);  /*negative*/
+        if (Convert.ToBoolean(m & 0x0200)) m = (m - 0x0400);  /*negative*/
+        rx = (sdr.rx_bx & 0xf0) >> 4;
+        if (Convert.ToBoolean(rx & 0x08)) rx = (rx - 0x10); /*negative*/
+        a = (sdr.b_a & 0x3f) + ((sdr.a_ax & 0xf0) << 2);
+        ax = (sdr.a_ax & 0x0c) >> 2;
+        b_exp = (sdr.rx_bx & 0x0f);
+        if (Convert.ToBoolean(b_exp & 0x08)) b_exp = (b_exp - 0x10);  /*negative*/
+        
+        if ((sdr.sens_units & 0xc0) != 0)
+        {  
+            if (Convert.ToBoolean(sensorReading & 0x80)) signval = (sensorReading - 0x100);
+            else signval = sensorReading;
+            floatval = (double)signval;
+        }
+        floatval *= (double)m;
+
+        floatval += (b * Math.Pow(10, b_exp));
+        floatval *= Math.Pow(10, rx);
+
+        if (sdr.linear != 0)
+        { 
+            throw new NotImplementedException();
+        }
+
+        return (float)floatval;
+    }
+
 }

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Ipmi.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Ipmi.cs
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (C) LibreHardwareMonitor and Contributors.
+// All Rights Reserved.
+
+using System;
+using System.Management;
+
+namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc;
+internal class Ipmi : ISuperIO
+{
+    public Chip Chip { get; }
+
+    public float?[] Controls { get; } = Array.Empty<float?>();
+
+    public float?[] Fans { get; } = Array.Empty<float?>();
+
+    public float?[] Temperatures { get; } = Array.Empty<float?>();
+
+    public float?[] Voltages { get; } = Array.Empty<float?>();
+
+    private ManagementObject _ipmi;
+
+    const byte COMMAND_GET_SDR_REPOSITORY_INFO = 0x20;
+    const byte COMMAND_GET_SDR = 0x23;
+
+    public Ipmi()
+    {
+        Chip = Chip.IPMI;
+
+        ManagementClass ipmiClass = new ManagementClass("root\\WMI", "Microsoft_IPMI", null);
+
+        foreach (ManagementObject ipmi in ipmiClass.GetInstances())
+        {
+            _ipmi = ipmi;
+        }
+    }
+
+    public string GetReport() => throw new NotImplementedException();
+    public void SetControl(int index, byte? value) => throw new NotImplementedException();
+    public void Update()
+    {
+        byte[] getSDRInfoResult = RunIPMICommand(COMMAND_GET_SDR_REPOSITORY_INFO, new byte[] { });
+        int recordCount = getSDRInfoResult[3] * 256 + getSDRInfoResult[2];
+
+      /*  // Reserve SDR Repository
+        byte[] reserveSDRResult = IPMICommand(0x22, new byte[] { });
+        byte reserveLower = reserveSDRResult[1];
+        byte reserveUpper = reserveSDRResult[2];*/
+
+        byte recordLower = 0;
+        byte recordUpper = 0;
+        for (int i = 0; i < recordCount; ++i)
+        {
+            byte[] getSDRResult = RunIPMICommand(COMMAND_GET_SDR, new byte[] { 0, 0, recordLower, recordUpper, 0, 0xff });
+            recordLower = getSDRResult[1];
+            recordUpper = getSDRResult[2];
+            System.Diagnostics.Debug.WriteLine(BitConverter.ToString(getSDRResult).Replace("-", ""));
+        }
+    }
+    public static bool IsBmcPresent()
+    {
+        ManagementObjectSearcher searcher = new ManagementObjectSearcher("root\\WMI", "select * from Microsoft_IPMI where Active='True'");
+        return searcher.Get().Count > 0;
+    }
+
+    public byte? ReadGpio(int index)
+    {
+        return null;
+    }
+
+    public void WriteGpio(int index, byte value)
+    {
+    }
+
+    private byte[] RunIPMICommand(int command, byte[] requestData)
+    {
+        ManagementBaseObject inParams = _ipmi.GetMethodParameters("RequestResponse");
+        inParams["NetworkFunction"] = 0xa;
+        inParams["Lun"] = 0;
+        inParams["ResponderAddress"] = 0x20;
+        inParams["Command"] = command;
+        inParams["RequestDataSize"] = requestData.Length;
+        inParams["RequestData"] = requestData;
+        ManagementBaseObject outParams = _ipmi.InvokeMethod("RequestResponse", inParams, null);
+        return (byte[])outParams["ResponseData"];
+    }
+}

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
@@ -28,6 +28,11 @@ internal class LpcIO
         Detect();
 
         Ring0.ReleaseIsaBusMutex();
+
+        if (Ipmi.IsBmcPresent())
+        {
+            _superIOs.Add(new Ipmi());
+        }
     }
 
     public ISuperIO[] SuperIO => _superIOs.ToArray();

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
@@ -17,7 +17,7 @@ internal class LpcIO
     private readonly StringBuilder _report = new();
     private readonly List<ISuperIO> _superIOs = new();
 
-    public LpcIO()
+    public LpcIO(Manufacturer motherboardManufacturer)
     {
         if (!Ring0.IsOpen)
             return;
@@ -31,7 +31,7 @@ internal class LpcIO
 
         if (Ipmi.IsBmcPresent())
         {
-            _superIOs.Add(new Ipmi());
+            _superIOs.Add(new Ipmi(motherboardManufacturer));
         }
     }
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Motherboard.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Motherboard.cs
@@ -66,7 +66,7 @@ public class Motherboard : IHardware
         }
         else
         {
-            _lpcIO = new LpcIO();
+            _lpcIO = new LpcIO(manufacturer);
             superIO = _lpcIO.SuperIO;
         }
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Xml.Linq;
 using LibreHardwareMonitor.Hardware.Motherboard.Lpc;
 
 namespace LibreHardwareMonitor.Hardware.Motherboard;
@@ -395,6 +396,30 @@ internal sealed class SuperIOHardware : Hardware
                 c.Add(new Ctrl("System Fan #4", 5));
                 c.Add(new Ctrl("System Fan #5", 6));
                 c.Add(new Ctrl("System Fan #6", 7));
+
+                break;
+
+            case Chip.IPMI:
+                Ipmi ipmi = (Ipmi)superIO;
+                for (int i = 0; i < ipmi.TemperatureNames.Count; ++i)
+                {
+                    t.Add(new Temperature(ipmi.TemperatureNames[i], i));
+                }
+                for (int i = 0; i < ipmi.FanNames.Count; ++i)
+                {
+                    f.Add(new Fan(ipmi.FanNames[i], i));
+                }
+                for (int i = 0; i < ipmi.VoltageNames.Count; ++i)
+                {
+                    v.Add(new Voltage(ipmi.VoltageNames[i], i));
+                }
+
+                // Fan control is exposed for Supermicro only as it differs between IPMI implementations
+                // Requires fans to be set to full speed in IPMI settings
+                if (manufacturer == Manufacturer.Supermicro)
+                {
+                    c.Add(new Ctrl("Fan PWM Override", 0));
+                }
 
                 break;
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
-using System.Xml.Linq;
 using LibreHardwareMonitor.Hardware.Motherboard.Lpc;
 
 namespace LibreHardwareMonitor.Hardware.Motherboard;
@@ -413,12 +412,9 @@ internal sealed class SuperIOHardware : Hardware
                 {
                     v.Add(new Voltage(ipmi.VoltageNames[i], i));
                 }
-
-                // Fan control is exposed for Supermicro only as it differs between IPMI implementations
-                // Requires fans to be set to full speed in IPMI settings
-                if (manufacturer == Manufacturer.Supermicro)
+                for (int i = 0; i < ipmi.ControlNames.Count; ++i)
                 {
-                    c.Add(new Ctrl("Fan PWM Override", 0));
+                    c.Add(new Ctrl(ipmi.ControlNames[i], i));
                 }
 
                 break;


### PR DESCRIPTION
I have added support for reading voltage/temperature/fan sensors from local IPMI, based on [IPMIUtil](https://ipmiutil.sourceforge.net/) and the [IPMI spec](https://www.intel.co.uk/content/www/uk/en/products/docs/servers/ipmi/ipmi-second-gen-interface-spec-v2-rev1-1.html)

Also added support for reading/writing Supermicro vendor-specific fan controls on X10 and newer boards

[Performance](https://imgkk.com/i/tq8x.png) is fine - slower than existing super io, but faster than Nvidia

![screenshot](https://imgkk.com/i/upna.png)
