### PR TITLE
Fix ASUS X470-I uncontrollable fans due to the wrong fan offset (fixes #802)

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1004,9 +1004,8 @@ internal sealed class SuperIOHardware : Hardware
                         f.Add(new Fan("Chassis Fan #1", 1));
                         f.Add(new Fan("Chassis Fan #2", 2));
 
-                        //offset: 2, because the first two always show zero
-                        for (int i = 2; i < superIO.Controls.Length; i++)
-                            c.Add(new Ctrl("Fan #" + (i - 1), i));
+                        for (int i = 0; i < superIO.Controls.Length; i++)
+                            c.Add(new Ctrl("Fan #" + i, i));
 
                         break;
 


### PR DESCRIPTION
I had correct fan readings for the fan on the MB, but could not control it. Found in the code there is an offset of 2; the comment states that the first 2 fans always show zero. I removed the offset - now I have 5 fan controls (which is not correct, since the MB only has 3 fan headers), but the first one actually control the fans. I assume that the offset is either outdated and no longer needed, or it should offset 2 fans from the end of the array, not the start of it. I don't have all the headers populated, so cannot fully test whether the offset from the end is fine.

I built the LHM library and added it to both LHM and FanCtrl v1.5.6, in both cases I could control the fans.
Should also close #802, since it describes the same issue.