### PR TITLE
Add support for Gigabyte's custom fan controller

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Cpu/CpuId.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/CpuId.cs
@@ -49,6 +49,7 @@ public class CpuId
             AppendRegister(vendorBuilder, ebx);
             AppendRegister(vendorBuilder, edx);
             AppendRegister(vendorBuilder, ecx);
+
             Vendor = vendorBuilder.ToString() switch
             {
                 "GenuineIntel" => Vendor.Intel,
@@ -146,7 +147,6 @@ public class CpuId
                 threadMaskWith = NextLog2(maxCoreAndThreadIdPerPackage / maxCoreIdPerPackage);
                 coreMaskWith = NextLog2(maxCoreIdPerPackage);
                 break;
-
             case Vendor.AMD:
                 uint corePerPackage;
                 if (maxCpuidExt >= 8)
@@ -173,7 +173,6 @@ public class CpuId
                 }
 
                 break;
-
             default:
                 threadMaskWith = 0;
                 coreMaskWith = 0;

--- a/LibreHardwareMonitorLib/Hardware/InpOut.cs
+++ b/LibreHardwareMonitorLib/Hardware/InpOut.cs
@@ -82,6 +82,40 @@ internal static class InpOut
         return null;
     }
 
+    public static bool WriteMemory(IntPtr baseAddress, byte value)
+    {
+        if (_mapPhysToLin == null || _unmapPhysicalMemory == null)
+            return false;
+
+        IntPtr pdwLinAddr = _mapPhysToLin(baseAddress, 1, out IntPtr pPhysicalMemoryHandle);
+        if (pdwLinAddr == IntPtr.Zero)
+            return false;
+
+        Marshal.WriteByte(pdwLinAddr, value);
+        _unmapPhysicalMemory(pPhysicalMemoryHandle, pdwLinAddr);
+
+        return true;
+    }
+
+    public static IntPtr MapMemory(IntPtr baseAddress, uint size, out IntPtr handle)
+    {
+        if (_mapPhysToLin == null)
+        {
+            handle = IntPtr.Zero;
+            return IntPtr.Zero;
+        }
+
+        return _mapPhysToLin(baseAddress, size, out handle);
+    }
+
+    public static bool UnmapMemory(IntPtr handle, IntPtr address)
+    {
+        if (_unmapPhysicalMemory == null)
+            return false;
+
+        return _unmapPhysicalMemory(handle, address);
+    }
+
     private static void Delete()
     {
         try

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -351,6 +351,8 @@ internal class Identification
                 return Model.TUF_GAMING_B550M_PLUS_WIFI;
             case var _ when name.Equals("B360 AORUS GAMING 3 WIFI-CF", StringComparison.OrdinalIgnoreCase):
                 return Model.B360_AORUS_GAMING_3_WIFI_CF;
+            case var _ when name.Equals("B550 AORUS PRO", StringComparison.OrdinalIgnoreCase):
+                return Model.B550_AORUS_PRO;
             case var _ when name.Equals("B560M AORUS ELITE", StringComparison.OrdinalIgnoreCase):
                 return Model.B560M_AORUS_ELITE;
             case var _ when name.Equals("B560M AORUS PRO", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
@@ -37,7 +37,6 @@ internal enum Chip : ushort
     IT8686E = 0x8686,
     IT8688E = 0x8688,
     IT8689E = 0x8689,
-    IT8695E = 0x8695,
     IT8705F = 0x8705,
     IT8712F = 0x8712,
     IT8716F = 0x8716,
@@ -48,7 +47,9 @@ internal enum Chip : ushort
     IT8728F = 0x8728,
     IT8771E = 0x8771,
     IT8772E = 0x8772,
-    IT879XE = 0x8733,
+    IT8790E = 0x8790,
+    IT8792E = 0x8733, // Could also be IT8791E
+    IT8795E = 0x8695,
 
     NCT610XD = 0xC452,
     NCT6771F = 0xB470,
@@ -106,7 +107,6 @@ internal class ChipName
             case Chip.IT8686E: return "ITE IT8686E";
             case Chip.IT8688E: return "ITE IT8688E";
             case Chip.IT8689E: return "ITE IT8689E";
-            case Chip.IT8695E: return "ITE IT8695E";
             case Chip.IT8705F: return "ITE IT8705F";
             case Chip.IT8712F: return "ITE IT8712F";
             case Chip.IT8716F: return "ITE IT8716F";
@@ -117,7 +117,9 @@ internal class ChipName
             case Chip.IT8728F: return "ITE IT8728F";
             case Chip.IT8771E: return "ITE IT8771E";
             case Chip.IT8772E: return "ITE IT8772E";
-            case Chip.IT879XE: return "ITE IT8792E/IT8795E";
+            case Chip.IT8790E: return "ITE IT8790E";
+            case Chip.IT8792E: return "ITE IT8791E/IT8792E";
+            case Chip.IT8795E: return "ITE IT8795E";
 
             case Chip.NCT610XD: return "Nuvoton NCT6102D/NCT6104D/NCT6106D";
             case Chip.NCT6771F: return "Nuvoton NCT6771F";

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/GigabyteController.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/GigabyteController.cs
@@ -7,145 +7,136 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
+using LibreHardwareMonitor.Hardware.CPU;
 
-namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
+namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc;
+
+/// <summary>
+/// This is a controller present on some Gigabyte motherboards for both Intel and AMD, that is in custom firmware
+/// loaded onto the 2nd ITE EC.
+/// It can be accessed by using memory mapped IO, mapping its internal RAM onto main RAM via the ISA Bridge.
+/// This class can disable it so that the regular IT87XX code can drive the fans.
+/// </summary>
+internal class GigabyteController
 {
+    private const uint ControllerAddressRange = 0xFF;
+    private const int ControllerEnableRegister = 0x47;
+    private const uint ControllerFanControlArea = 0x900;
 
     /// <summary>
-    /// This is a controller present on some Gigabyte motherboards for both Intel and AMD, that is in custom firmware
-    /// loaded onto the 2nd ITE EC.
-    ///
-    /// It can be accessed by using memory mapped IO, mapping its internal RAM onto main RAM via the ISA Bridge.
-    /// 
-    /// This class can disable it so that the regular IT87XX code can drive the fans.
+    /// Base address in PCI RAM that maps to the EC's RAM
     /// </summary>
-    internal class GigabyteController
+    private readonly uint _controllerBaseAddress;
+
+    private readonly Vendor _vendor;
+
+    private bool? _initialState;
+
+    public GigabyteController(uint address, Vendor vendor)
     {
-        private bool? _initialState;
-        private ProcessorFamily _processorFamily;
+        _controllerBaseAddress = address;
+        _vendor = vendor;
+    }
 
-        /// <summary>
-        /// Base address in PCI RAM that maps to the EC's RAM
-        /// </summary>
-        private uint _controllerBaseAddress;
-
-        public GigabyteController(uint address, ProcessorFamily family)
+    /// <summary>
+    /// Enable/Disable Fan Control
+    /// </summary>
+    /// <param name="enabled"></param>
+    /// <returns>true on success</returns>
+    public bool Enable(bool enabled)
+    {
+        // TODO: Intel
+        return _vendor switch
         {
-            _controllerBaseAddress = address;
-            _processorFamily = family;
+            Vendor.AMD => AmdEnable(enabled),
+            _ => false
+        };
+    }
+
+    private bool AmdEnable(bool enabled)
+    {
+        if (!Ring0.WaitPciBusMutex(10))
+            return false;
+
+        // see D14F3x https://www.amd.com/system/files/TechDocs/55072_AMD_Family_15h_Models_70h-7Fh_BKDG.pdf 
+        uint amdIsaBridgeAddress = Ring0.GetPciAddress(0x0, 0x14, 0x3);
+
+        const uint ioOrMemoryPortDecodeEnableRegister = 0x48;
+        const uint memoryRangePortEnableMask = 0x1 << 5;
+        const uint pciMemoryAddressForLpcTargetCyclesRegister = 0x60;
+        const uint romAddressRange2Register = 0x6C;
+
+        uint controllerFanControlAddress = _controllerBaseAddress + ControllerFanControlArea;
+
+        uint pciAddressStart = _controllerBaseAddress >> 0x10;
+        uint pciAddressEnd = pciAddressStart + 1;
+
+        uint enabledPciMemoryAddressRegister = pciAddressEnd << 0x10 | pciAddressStart;
+        uint enabledRomAddressRegister = 0xFFFFU << 0x10 | pciAddressEnd;
+
+        Ring0.ReadPciConfig(amdIsaBridgeAddress, ioOrMemoryPortDecodeEnableRegister, out uint originalDecodeEnableRegister);
+        Ring0.ReadPciConfig(amdIsaBridgeAddress, pciMemoryAddressForLpcTargetCyclesRegister, out uint originalPciMemoryAddressRegister);
+        Ring0.ReadPciConfig(amdIsaBridgeAddress, romAddressRange2Register, out uint originalRomAddressRegister);
+
+        bool originalMmIoEnabled = (originalDecodeEnableRegister & memoryRangePortEnableMask) != 0 &&
+                                   originalPciMemoryAddressRegister == enabledPciMemoryAddressRegister &&
+                                   originalRomAddressRegister == enabledRomAddressRegister;
+
+        if (!originalMmIoEnabled)
+        {
+            Ring0.WritePciConfig(amdIsaBridgeAddress, ioOrMemoryPortDecodeEnableRegister, originalDecodeEnableRegister | memoryRangePortEnableMask);
+            Ring0.WritePciConfig(amdIsaBridgeAddress, pciMemoryAddressForLpcTargetCyclesRegister, enabledPciMemoryAddressRegister);
+            Ring0.WritePciConfig(amdIsaBridgeAddress, romAddressRange2Register, enabledRomAddressRegister);
         }
 
+        bool result = Enable(enabled, new IntPtr(controllerFanControlAddress));
 
-        /// <summary>
-        /// Enable/Disable Fan Control
-        /// </summary>
-        /// <param name="enabled"></param>
-        /// <returns>true on success</returns>
-        public bool Enable(bool enabled)
+        // Restore previous values
+        if (!originalMmIoEnabled)
         {
-            switch (_processorFamily)
-            {
-                case ProcessorFamily.AmdZen:
-                    return AMDEnable(enabled);
-                // TODO: Intel
-                default:
-                    return false;
-            }
+            Ring0.WritePciConfig(amdIsaBridgeAddress, ioOrMemoryPortDecodeEnableRegister, originalDecodeEnableRegister);
+            Ring0.WritePciConfig(amdIsaBridgeAddress, pciMemoryAddressForLpcTargetCyclesRegister, originalRomAddressRegister);
+            Ring0.WritePciConfig(amdIsaBridgeAddress, romAddressRange2Register, originalRomAddressRegister);
         }
 
-        private bool AMDEnable(bool enabled)
+        Ring0.ReleasePciBusMutex();
+
+        return result;
+    }
+
+    private bool Enable(bool enabled, IntPtr pciMmIoBaseAddress)
+    {
+        // Map PCI memory to this process memory
+        if (!InpOut.Open())
+            return false;
+
+        IntPtr mapped = InpOut.MapMemory(pciMmIoBaseAddress, ControllerAddressRange, out IntPtr handle);
+
+        if (mapped == IntPtr.Zero)
+            return false;
+
+        bool current = Convert.ToBoolean(Marshal.ReadByte(mapped, ControllerEnableRegister));
+
+        _initialState ??= current;
+
+        // Update Controller State
+        if (current != enabled)
         {
-            Ring0.Open();
-
-            if (!Ring0.WaitPciBusMutex(10))
-                return false;
-
-            // see D14F3x https://www.amd.com/system/files/TechDocs/55072_AMD_Family_15h_Models_70h-7Fh_BKDG.pdf 
-            uint AmdIsaBridgeAddress = Ring0.GetPciAddress(0x0, 0x14, 0x3);
-
-            const uint IOorMemoryPortDecodeEnableRegister = 0x48;
-            const uint MemoryRangePortEnableMask = 0x1 << 5;
-            const uint PCIMemoryAddressforLPCTargetCyclesRegister = 0x60;
-            const uint ROMAddressRange2Register = 0x6C;
-            uint ControllerFanControlAddress = _controllerBaseAddress + ControllerFanControlArea;
-
-            uint pciAddressStart = _controllerBaseAddress >> 0x10;
-            uint pciAddressEnd = pciAddressStart + 1;
-
-            uint enabledPCIMemoryAddressRegister = pciAddressEnd << 0x10 | pciAddressStart;
-            uint enabledROMAddressRegister = 0xFFFFU << 0x10 | pciAddressEnd;
-
-            Ring0.ReadPciConfig(AmdIsaBridgeAddress, IOorMemoryPortDecodeEnableRegister, out uint originalDecodeEnableRegister);
-            Ring0.ReadPciConfig(AmdIsaBridgeAddress, PCIMemoryAddressforLPCTargetCyclesRegister, out uint originalPCIMemoryAddressRegister);
-            Ring0.ReadPciConfig(AmdIsaBridgeAddress, ROMAddressRange2Register, out uint originalROMAddressRegister);
-
-            bool originalMMIOEnabled =
-                (originalDecodeEnableRegister & MemoryRangePortEnableMask) != 0
-                && originalPCIMemoryAddressRegister == enabledPCIMemoryAddressRegister
-                && originalROMAddressRegister == enabledROMAddressRegister;
-
-            if (!originalMMIOEnabled)
-            {
-                Ring0.WritePciConfig(AmdIsaBridgeAddress, IOorMemoryPortDecodeEnableRegister, originalDecodeEnableRegister | MemoryRangePortEnableMask);
-                Ring0.WritePciConfig(AmdIsaBridgeAddress, PCIMemoryAddressforLPCTargetCyclesRegister, enabledPCIMemoryAddressRegister);
-                Ring0.WritePciConfig(AmdIsaBridgeAddress, ROMAddressRange2Register, enabledROMAddressRegister);
-            }
-
-            var result = _Enable(enabled, new IntPtr(ControllerFanControlAddress));
-
-            // Restore previous values
-            if (!originalMMIOEnabled)
-            {
-                Ring0.WritePciConfig(AmdIsaBridgeAddress, IOorMemoryPortDecodeEnableRegister, originalDecodeEnableRegister);
-                Ring0.WritePciConfig(AmdIsaBridgeAddress, PCIMemoryAddressforLPCTargetCyclesRegister, originalROMAddressRegister);
-                Ring0.WritePciConfig(AmdIsaBridgeAddress, ROMAddressRange2Register, originalROMAddressRegister);
-            }
-
-            Ring0.ReleasePciBusMutex();
-
-            return result;
+            Marshal.WriteByte(mapped, ControllerEnableRegister, Convert.ToByte(enabled));
+            // Give it some time to see the change
+            Thread.Sleep(200);
         }
 
-        private bool _Enable(bool enabled, IntPtr PCIMMIOBaseAddress)
-        {
-            // Map PCI memory to this process memory
-            if (!InpOut.Open())
-                return false;
+        InpOut.UnmapMemory(handle, mapped);
+        return true;
+    }
 
-            IntPtr mapped = InpOut.MapMemory(PCIMMIOBaseAddress, ControllerAddressRange, out IntPtr handle);
-
-            if (mapped == IntPtr.Zero)
-                return false;
-
-            var current = Convert.ToBoolean(Marshal.ReadByte(mapped, ControllerEnableRegister));
-
-            if (!_initialState.HasValue)
-                _initialState = current;
-
-            // Update Controller State
-            if (current != enabled)
-            {
-                Marshal.WriteByte(mapped, ControllerEnableRegister, Convert.ToByte(enabled));
-                // Give it some time to see the change
-                Thread.Sleep(200);
-            }
-
-            InpOut.UnmapMemory(handle, mapped);
-
-            return true;
-        }
-
-        /// <summary>
-        /// Restore settings back to initial values
-        /// </summary>
-        public void Restore()
-        {
-            if (_initialState.HasValue)
-                Enable(_initialState.Value);
-        }
-
-        const int ControllerEnableRegister = 0x47;
-        const uint ControllerAddressRange = 0xFF;
-        const uint ControllerFanControlArea = 0x900;
+    /// <summary>
+    /// Restore settings back to initial values
+    /// </summary>
+    public void Restore()
+    {
+        if (_initialState.HasValue)
+            Enable(_initialState.Value);
     }
 }

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/GigabyteController.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/GigabyteController.cs
@@ -1,0 +1,151 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (C) LibreHardwareMonitor and Contributors.
+// Partial Copyright (C) Michael Möller <mmoeller@openhardwaremonitor.org> and Contributors.
+// All Rights Reserved.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc
+{
+
+    /// <summary>
+    /// This is a controller present on some Gigabyte motherboards for both Intel and AMD, that is in custom firmware
+    /// loaded onto the 2nd ITE EC.
+    ///
+    /// It can be accessed by using memory mapped IO, mapping its internal RAM onto main RAM via the ISA Bridge.
+    /// 
+    /// This class can disable it so that the regular IT87XX code can drive the fans.
+    /// </summary>
+    internal class GigabyteController
+    {
+        private bool? _initialState;
+        private ProcessorFamily _processorFamily;
+
+        /// <summary>
+        /// Base address in PCI RAM that maps to the EC's RAM
+        /// </summary>
+        private uint _controllerBaseAddress;
+
+        public GigabyteController(uint address, ProcessorFamily family)
+        {
+            _controllerBaseAddress = address;
+            _processorFamily = family;
+        }
+
+
+        /// <summary>
+        /// Enable/Disable Fan Control
+        /// </summary>
+        /// <param name="enabled"></param>
+        /// <returns>true on success</returns>
+        public bool Enable(bool enabled)
+        {
+            switch (_processorFamily)
+            {
+                case ProcessorFamily.AmdZen:
+                    return AMDEnable(enabled);
+                // TODO: Intel
+                default:
+                    return false;
+            }
+        }
+
+        private bool AMDEnable(bool enabled)
+        {
+            Ring0.Open();
+
+            if (!Ring0.WaitPciBusMutex(10))
+                return false;
+
+            // see D14F3x https://www.amd.com/system/files/TechDocs/55072_AMD_Family_15h_Models_70h-7Fh_BKDG.pdf 
+            uint AmdIsaBridgeAddress = Ring0.GetPciAddress(0x0, 0x14, 0x3);
+
+            const uint IOorMemoryPortDecodeEnableRegister = 0x48;
+            const uint MemoryRangePortEnableMask = 0x1 << 5;
+            const uint PCIMemoryAddressforLPCTargetCyclesRegister = 0x60;
+            const uint ROMAddressRange2Register = 0x6C;
+            uint ControllerFanControlAddress = _controllerBaseAddress + ControllerFanControlArea;
+
+            uint pciAddressStart = _controllerBaseAddress >> 0x10;
+            uint pciAddressEnd = pciAddressStart + 1;
+
+            uint enabledPCIMemoryAddressRegister = pciAddressEnd << 0x10 | pciAddressStart;
+            uint enabledROMAddressRegister = 0xFFFFU << 0x10 | pciAddressEnd;
+
+            Ring0.ReadPciConfig(AmdIsaBridgeAddress, IOorMemoryPortDecodeEnableRegister, out uint originalDecodeEnableRegister);
+            Ring0.ReadPciConfig(AmdIsaBridgeAddress, PCIMemoryAddressforLPCTargetCyclesRegister, out uint originalPCIMemoryAddressRegister);
+            Ring0.ReadPciConfig(AmdIsaBridgeAddress, ROMAddressRange2Register, out uint originalROMAddressRegister);
+
+            bool originalMMIOEnabled =
+                (originalDecodeEnableRegister & MemoryRangePortEnableMask) != 0
+                && originalPCIMemoryAddressRegister == enabledPCIMemoryAddressRegister
+                && originalROMAddressRegister == enabledROMAddressRegister;
+
+            if (!originalMMIOEnabled)
+            {
+                Ring0.WritePciConfig(AmdIsaBridgeAddress, IOorMemoryPortDecodeEnableRegister, originalDecodeEnableRegister | MemoryRangePortEnableMask);
+                Ring0.WritePciConfig(AmdIsaBridgeAddress, PCIMemoryAddressforLPCTargetCyclesRegister, enabledPCIMemoryAddressRegister);
+                Ring0.WritePciConfig(AmdIsaBridgeAddress, ROMAddressRange2Register, enabledROMAddressRegister);
+            }
+
+            var result = _Enable(enabled, new IntPtr(ControllerFanControlAddress));
+
+            // Restore previous values
+            if (!originalMMIOEnabled)
+            {
+                Ring0.WritePciConfig(AmdIsaBridgeAddress, IOorMemoryPortDecodeEnableRegister, originalDecodeEnableRegister);
+                Ring0.WritePciConfig(AmdIsaBridgeAddress, PCIMemoryAddressforLPCTargetCyclesRegister, originalROMAddressRegister);
+                Ring0.WritePciConfig(AmdIsaBridgeAddress, ROMAddressRange2Register, originalROMAddressRegister);
+            }
+
+            Ring0.ReleasePciBusMutex();
+
+            return result;
+        }
+
+        private bool _Enable(bool enabled, IntPtr PCIMMIOBaseAddress)
+        {
+            // Map PCI memory to this process memory
+            if (!InpOut.Open())
+                return false;
+
+            IntPtr mapped = InpOut.MapMemory(PCIMMIOBaseAddress, ControllerAddressRange, out IntPtr handle);
+
+            if (mapped == IntPtr.Zero)
+                return false;
+
+            var current = Convert.ToBoolean(Marshal.ReadByte(mapped, ControllerEnableRegister));
+
+            if (!_initialState.HasValue)
+                _initialState = current;
+
+            // Update Controller State
+            if (current != enabled)
+            {
+                Marshal.WriteByte(mapped, ControllerEnableRegister, Convert.ToByte(enabled));
+                // Give it some time to see the change
+                Thread.Sleep(200);
+            }
+
+            InpOut.UnmapMemory(handle, mapped);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Restore settings back to initial values
+        /// </summary>
+        public void Restore()
+        {
+            if (_initialState.HasValue)
+                Enable(_initialState.Value);
+        }
+
+        const int ControllerEnableRegister = 0x47;
+        const uint ControllerAddressRange = 0xFF;
+        const uint ControllerFanControlArea = 0x900;
+    }
+}

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -6,7 +6,9 @@
 
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Text;
+using System.Threading;
 
 // ReSharper disable once InconsistentNaming
 
@@ -30,16 +32,18 @@ internal class IT87XX : ISuperIO
     private readonly bool[] _restoreDefaultFanPwmControlRequired = new bool[MaxFanHeaders];
     private readonly byte _version;
     private readonly float _voltageGain;
+    private GigabyteController _gigabyteController;
 
     private bool SupportsMultipleBanks => _bankCount > 1;
 
-    public IT87XX(Chip chip, ushort address, ushort gpioAddress, byte version)
+    public IT87XX(Chip chip, ushort address, ushort gpioAddress, byte version, Motherboard motherboard, GigabyteController gigabyteController)
     {
         _address = address;
         _version = version;
         _addressReg = (ushort)(address + ADDRESS_REGISTER_OFFSET);
         _dataReg = (ushort)(address + DATA_REGISTER_OFFSET);
         _gpioAddress = gpioAddress;
+        _gigabyteController = gigabyteController;
 
         Chip = chip;
 
@@ -84,12 +88,12 @@ internal class IT87XX : ISuperIO
             Chip.IT8686E or
             Chip.IT8688E or
             Chip.IT8689E or
-            Chip.IT8695E or
+            Chip.IT8795E or
             Chip.IT8628E or
             Chip.IT8625E or
             Chip.IT8620E or
             Chip.IT8613E or
-            Chip.IT879XE or
+            Chip.IT8792E or
             Chip.IT8655E or
             Chip.IT8631E;
 
@@ -144,7 +148,7 @@ internal class IT87XX : ISuperIO
                 Controls = new float?[6];
                 break;
 
-            case Chip.IT8695E:
+            case Chip.IT8795E:
                 Voltages = new float?[6];
                 Temperatures = new float?[3];
                 Fans = new float?[3];
@@ -158,7 +162,7 @@ internal class IT87XX : ISuperIO
                 Controls = new float?[3];
                 break;
 
-            case Chip.IT879XE:
+            case Chip.IT8792E:
                 Voltages = new float?[9];
                 Temperatures = new float?[3];
                 Fans = new float?[3];
@@ -187,8 +191,8 @@ internal class IT87XX : ISuperIO
         _voltageGain = chip switch
         {
             Chip.IT8613E or Chip.IT8620E or Chip.IT8628E or Chip.IT8631E or Chip.IT8721F or Chip.IT8728F or Chip.IT8771E or Chip.IT8772E or Chip.IT8686E or Chip.IT8688E or Chip.IT8689E => 0.012f,
-            Chip.IT8625E or Chip.IT8695E => 0.011f,
-            Chip.IT8655E or Chip.IT8665E or Chip.IT879XE => 0.0109f,
+            Chip.IT8625E or Chip.IT8795E => 0.011f,
+            Chip.IT8655E or Chip.IT8665E or Chip.IT8792E => 0.0109f,
             _ => 0.016f
         };
 
@@ -259,6 +263,10 @@ internal class IT87XX : ISuperIO
         if (value.HasValue)
         {
             SaveDefaultFanPwmControl(index);
+
+            // Disable the controller when setting values to prevent it from overriding them
+            if (_gigabyteController != null)
+                _gigabyteController.Enable(false);
 
             if (index < 3 && !_initialFanOutputModeEnabled[index])
                 WriteByte(FAN_MAIN_CTRL_REG, (byte)(ReadByte(FAN_MAIN_CTRL_REG, out _) | (1 << index)));
@@ -539,6 +547,10 @@ internal class IT87XX : ISuperIO
                 WriteByte(FAN_PWM_CTRL_EXT_REG[index], _initialFanPwmControlExt[index]);
 
             _restoreDefaultFanPwmControlRequired[index] = false;
+
+            // restore the GB controller when all fans become restored
+            if (_gigabyteController != null && _restoreDefaultFanPwmControlRequired.All(e => e == false))
+                _gigabyteController.Restore();
         }
     }
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
@@ -669,10 +669,10 @@ internal class LpcIO
         Vendor DetectVendor()
         {
             string manufacturer = motherboard.SMBios.Processors[0].ManufacturerName;
-            if (manufacturer.Contains("Intel", StringComparison.OrdinalIgnoreCase))
+            if (manufacturer.IndexOf("Intel", StringComparison.OrdinalIgnoreCase) != -1)
                 return Vendor.Intel;
 
-            if (manufacturer.Contains("Advanced Micro Devices", StringComparison.OrdinalIgnoreCase) || manufacturer.StartsWith("AMD", StringComparison.OrdinalIgnoreCase))
+            if (manufacturer.IndexOf("Advanced Micro Devices", StringComparison.OrdinalIgnoreCase) != -1 || manufacturer.StartsWith("AMD", StringComparison.OrdinalIgnoreCase))
                 return Vendor.AMD;
 
             return Vendor.Unknown;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Manufacturer.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Manufacturer.cs
@@ -11,7 +11,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard;
 [SuppressMessage("ReSharper", "IdentifierTypo")]
 [SuppressMessage("ReSharper", "CommentTypo")]
 [SuppressMessage("ReSharper", "InconsistentNaming")]
-internal enum Manufacturer
+public enum Manufacturer
 {
     Abit,
     Acer,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -12,7 +12,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard;
 
 [SuppressMessage("ReSharper", "IdentifierTypo")]
 [SuppressMessage("ReSharper", "CommentTypo")]
-internal enum Model
+public enum Model
 {
     // ASRock
     _880GMH_USB3,
@@ -109,6 +109,7 @@ internal enum Model
     AX370_Gaming_5,
     AX370_Gaming_K7,
     B360_AORUS_GAMING_3_WIFI_CF,
+    B550_AORUS_PRO,
     B560M_AORUS_ELITE,
     B560M_AORUS_PRO,
     B560M_AORUS_PRO_AX,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Motherboard.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Motherboard.cs
@@ -14,7 +14,7 @@ using OperatingSystem = LibreHardwareMonitor.Software.OperatingSystem;
 namespace LibreHardwareMonitor.Hardware.Motherboard;
 
 /// <summary>
-/// Represents the motherboard of a computer with its <see cref="LpcIO"/> and <see cref="EmbeddedController"/> as <see cref="SubHardware"/>.
+/// Represents the motherboard of a computer with its <see cref="LpcIO" /> and <see cref="EmbeddedController" /> as <see cref="SubHardware" />.
 /// </summary>
 public class Motherboard : IHardware
 {
@@ -25,10 +25,11 @@ public class Motherboard : IHardware
     private string _customName;
 
     /// <summary>
-    /// Creates motherboard instance by retrieving information from <see cref="LibreHardwareMonitor.Hardware.SMBios"/> and creates a new <see cref="SubHardware"/> based on data from <see cref="LpcIO"/> and <see cref="EmbeddedController"/>.
+    /// Creates motherboard instance by retrieving information from <see cref="LibreHardwareMonitor.Hardware.SMBios" /> and creates a new <see cref="SubHardware" /> based on data from <see cref="LpcIO" />
+    /// and <see cref="EmbeddedController" />.
     /// </summary>
-    /// <param name="smBios"><see cref="LibreHardwareMonitor.Hardware.SMBios"/> table containing motherboard data.</param>
-    /// <param name="settings">Additional settings passed by <see cref="IComputer"/>.</param>
+    /// <param name="smBios"><see cref="LibreHardwareMonitor.Hardware.SMBios" /> table containing motherboard data.</param>
+    /// <param name="settings">Additional settings passed by <see cref="IComputer" />.</param>
     public Motherboard(SMBios smBios, ISettings settings)
     {
         IReadOnlyList<ISuperIO> superIO;
@@ -80,26 +81,30 @@ public class Motherboard : IHardware
             SubHardware[superIO.Count] = embeddedController;
     }
 
-    /// <inheritdoc/>
+    /// <inheritdoc />
     public event SensorEventHandler SensorAdded;
 
-    /// <inheritdoc/>
+    /// <inheritdoc />
     public event SensorEventHandler SensorRemoved;
 
-    /// <returns><see cref="HardwareType.Motherboard"/></returns>
-    public HardwareType HardwareType
-    {
-        get { return HardwareType.Motherboard; }
-    }
+    /// <inheritdoc />
+    public HardwareType HardwareType => HardwareType.Motherboard;
 
-    /// <inheritdoc/>
-    public Identifier Identifier
-    {
-        get { return new Identifier("motherboard"); }
-    }
+    /// <inheritdoc />
+    public Identifier Identifier => new("motherboard");
 
     /// <summary>
-    /// Gets the name obtained from <see cref="LibreHardwareMonitor.Hardware.SMBios"/>.
+    /// Gets the <see cref="LibreHardwareMonitor.Hardware.Motherboard.Manufacturer" />.
+    /// </summary>
+    public Manufacturer Manufacturer { get; }
+
+    /// <summary>
+    /// Gets the <see cref="LibreHardwareMonitor.Hardware.Motherboard.Model" />.
+    /// </summary>
+    public Model Model { get; }
+
+    /// <summary>
+    /// Gets the name obtained from <see cref="LibreHardwareMonitor.Hardware.SMBios" />.
     /// </summary>
     public string Name
     {
@@ -112,41 +117,31 @@ public class Motherboard : IHardware
         }
     }
 
-    /// <inheritdoc/>
-    /// <returns>Always <see langword="null"/></returns>
+    /// <inheritdoc />
+    /// <returns>Always <see langword="null" /></returns>
     public virtual IHardware Parent
     {
         get { return null; }
     }
 
-    /// <inheritdoc/>
+    /// <inheritdoc />
     public virtual IDictionary<string, string> Properties => new SortedDictionary<string, string>();
 
-    /// <inheritdoc/>
+    /// <inheritdoc />
     public ISensor[] Sensors
     {
         get { return Array.Empty<ISensor>(); }
     }
 
     /// <summary>
-    /// Gets the <see cref="LibreHardwareMonitor.Hardware.SMBios"/> information.
+    /// Gets the <see cref="LibreHardwareMonitor.Hardware.SMBios" /> information.
     /// </summary>
     public SMBios SMBios { get; }
 
-    /// <inheritdoc/>
+    /// <inheritdoc />
     public IHardware[] SubHardware { get; }
 
-    /// <summary>
-    /// Gets the <see cref="LibreHardwareMonitor.Hardware.Motherboard.Manufacturer"/>.
-    /// </summary>
-    public Manufacturer Manufacturer { get; private set; }
-
-    /// <summary>
-    /// Gets the <see cref="LibreHardwareMonitor.Hardware.Motherboard.Model"/>.
-    /// </summary>
-    public Model Model { get; private set; }
-
-    /// <inheritdoc/>
+    /// <inheritdoc />
     public string GetReport()
     {
         StringBuilder r = new();
@@ -162,12 +157,12 @@ public class Motherboard : IHardware
     }
 
     /// <summary>
-    /// Motherboard itself cannot be updated. Update <see cref="SubHardware"/> instead.
+    /// Motherboard itself cannot be updated. Update <see cref="SubHardware" /> instead.
     /// </summary>
     public void Update()
-    {}
+    { }
 
-    /// <inheritdoc/>
+    /// <inheritdoc />
     public void Accept(IVisitor visitor)
     {
         if (visitor == null)
@@ -176,7 +171,7 @@ public class Motherboard : IHardware
         visitor.VisitHardware(this);
     }
 
-    /// <inheritdoc/>
+    /// <inheritdoc />
     public void Traverse(IVisitor visitor)
     {
         foreach (IHardware hardware in SubHardware)
@@ -184,7 +179,7 @@ public class Motherboard : IHardware
     }
 
     /// <summary>
-    /// Closes <see cref="SubHardware"/> using <see cref="Hardware.Close"/>.
+    /// Closes <see cref="SubHardware" /> using <see cref="Hardware.Close" />.
     /// </summary>
     public void Close()
     {

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Motherboard.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Motherboard.cs
@@ -35,21 +35,21 @@ public class Motherboard : IHardware
         _settings = settings;
         SMBios = smBios;
 
-        Manufacturer manufacturer = smBios.Board == null ? Manufacturer.Unknown : Identification.GetManufacturer(smBios.Board.ManufacturerName);
-        Model model = smBios.Board == null ? Model.Unknown : Identification.GetModel(smBios.Board.ProductName);
+        Manufacturer = smBios.Board == null ? Manufacturer.Unknown : Identification.GetManufacturer(smBios.Board.ManufacturerName);
+        Model = smBios.Board == null ? Model.Unknown : Identification.GetModel(smBios.Board.ProductName);
 
         if (smBios.Board != null)
         {
             if (!string.IsNullOrEmpty(smBios.Board.ProductName))
             {
-                if (manufacturer == Manufacturer.Unknown)
+                if (Manufacturer == Manufacturer.Unknown)
                     _name = smBios.Board.ProductName;
                 else
-                    _name = manufacturer + " " + smBios.Board.ProductName;
+                    _name = Manufacturer + " " + smBios.Board.ProductName;
             }
             else
             {
-                _name = manufacturer.ToString();
+                _name = Manufacturer.ToString();
             }
         }
         else
@@ -66,15 +66,15 @@ public class Motherboard : IHardware
         }
         else
         {
-            _lpcIO = new LpcIO();
+            _lpcIO = new LpcIO(this);
             superIO = _lpcIO.SuperIO;
         }
 
-        EmbeddedController embeddedController = EmbeddedController.Create(model, settings);
+        EmbeddedController embeddedController = EmbeddedController.Create(Model, settings);
 
         SubHardware = new IHardware[superIO.Count + (embeddedController != null ? 1 : 0)];
         for (int i = 0; i < superIO.Count; i++)
-            SubHardware[i] = new SuperIOHardware(this, superIO[i], manufacturer, model, settings);
+            SubHardware[i] = new SuperIOHardware(this, superIO[i], Manufacturer, Model, settings);
 
         if (embeddedController != null)
             SubHardware[superIO.Count] = embeddedController;
@@ -135,6 +135,16 @@ public class Motherboard : IHardware
 
     /// <inheritdoc/>
     public IHardware[] SubHardware { get; }
+
+    /// <summary>
+    /// Gets the <see cref="LibreHardwareMonitor.Hardware.Motherboard.Manufacturer"/>.
+    /// </summary>
+    public Manufacturer Manufacturer { get; private set; }
+
+    /// <summary>
+    /// Gets the <see cref="LibreHardwareMonitor.Hardware.Motherboard.Model"/>.
+    /// </summary>
+    public Model Model { get; private set; }
 
     /// <inheritdoc/>
     public string GetReport()

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -233,8 +233,8 @@ internal sealed class SuperIOHardware : Hardware
                 GetIteConfigurationsB(superIO, manufacturer, model, v, t, f, c);
                 break;
 
-            case Chip.IT8695E:
-            case Chip.IT879XE:
+            case Chip.IT8795E:
+            case Chip.IT8792E:
                 GetIteConfigurationsC(superIO, manufacturer, model, v, t, f, c);
                 break;
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -235,6 +235,7 @@ internal sealed class SuperIOHardware : Hardware
 
             case Chip.IT8795E:
             case Chip.IT8792E:
+            case Chip.IT8790E:
                 GetIteConfigurationsC(superIO, manufacturer, model, v, t, f, c);
                 break;
 


### PR DESCRIPTION
* This is a custom firmware loaded into ITE ECs that adds automatic control of fans, and possibly LEDs and other functions as well.
* It has only been seen so far in the 2nd EC of some MBs, and requires the ITE chip to support reading its "scratch ram".
* The controller fan control module is disabled when attempting to change the fan speed for the known affected fans.
* Also clean up the discovery and name of some of the ITE chips based on known info.
* Only AMD MBs are supported with this commit, further work required for Intel boards.
* Fixes #251 for potentially many AMD boards.