### PR TITLE
Add support for Gigabyte B550 Aorus Pro sensors

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -186,13 +186,13 @@ internal class IT87XX : ISuperIO
 
         _fansDisabled = new bool[Fans.Length];
 
-        // IT8620E, IT8628E, IT8721F, IT8728F, IT8772E and IT8686E use a 12mV resolution.
-        // All others 16mV.
+        // Voltage gain varies by model.
+        // Conflicting reports on IT8792E: either 0.0109 in linux drivers or 0.011 comparing with Gigabyte board & SIV SW.
         _voltageGain = chip switch
         {
             Chip.IT8613E or Chip.IT8620E or Chip.IT8628E or Chip.IT8631E or Chip.IT8721F or Chip.IT8728F or Chip.IT8771E or Chip.IT8772E or Chip.IT8686E or Chip.IT8688E or Chip.IT8689E => 0.012f,
-            Chip.IT8625E or Chip.IT8795E => 0.011f,
-            Chip.IT8655E or Chip.IT8665E or Chip.IT8792E => 0.0109f,
+            Chip.IT8625E or Chip.IT8792E or Chip.IT8795E => 0.011f,
+            Chip.IT8655E or Chip.IT8665E => 0.0109f,
             _ => 0.016f
         };
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1589,6 +1589,35 @@ internal sealed class SuperIOHardware : Hardware
 
                         break;
 
+                    case Model.B550_AORUS_PRO:
+                        v.Add(new Voltage("Vcore", 0, 0, 1));
+                        v.Add(new Voltage("+3.3V", 1, 6.5F, 10));
+                        v.Add(new Voltage("+12V", 2, 5, 1));
+                        v.Add(new Voltage("+5V", 3, 1.5F, 1));
+                        v.Add(new Voltage("Vcore SoC", 4, 0, 1));
+                        v.Add(new Voltage("VDDP", 5, 0, 1));
+                        v.Add(new Voltage("DRAM", 6, 0, 1));
+                        v.Add(new Voltage("3VSB", 7, 10, 10));
+                        v.Add(new Voltage("VBat", 8, 10, 10));
+                        t.Add(new Temperature("System #1", 0));
+                        t.Add(new Temperature("Chipset", 1));
+                        t.Add(new Temperature("CPU", 2));
+                        t.Add(new Temperature("PCIe x16", 3));
+                        t.Add(new Temperature("VRM", 4));
+                        t.Add(new Temperature("PCH", 5));
+                        f.Add(new Fan("CPU Fan", 0));
+                        f.Add(new Fan("System Fan #1", 1));
+                        f.Add(new Fan("System Fan #2", 2));
+                        f.Add(new Fan("System Fan #3", 3));
+                        f.Add(new Fan("CPU Optional Fan", 4));
+                        c.Add(new Control("CPU Fan", 0));
+                        c.Add(new Control("System Fan #1", 1));
+                        c.Add(new Control("System Fan #2", 2));
+                        c.Add(new Control("System Fan #3", 3));
+                        c.Add(new Control("CPU Optional Fan", 4));
+
+                        break;
+
                     default:
                         v.Add(new Voltage("Voltage #1", 0, true));
                         v.Add(new Voltage("Voltage #2", 1, true));
@@ -1770,7 +1799,8 @@ internal sealed class SuperIOHardware : Hardware
                 {
                     case Model.X570_AORUS_MASTER: // IT879XE
                     case Model.X570_AORUS_ULTRA:
-                        v.Add(new Voltage("CPU VDD18", 0));
+                    case Model.B550_AORUS_PRO:
+                        v.Add(new Voltage("VIN0", 0));
                         v.Add(new Voltage("DDRVTT AB", 1));
                         v.Add(new Voltage("Chipset Core", 2));
                         v.Add(new Voltage("Voltage #4", 3, true));


### PR DESCRIPTION
* Also change IT8792 to use voltage gain 0.011. This matches Gigabyte software, although the value may still be wrong.