### PR TITLE
Added fan control support for the EVGA X58 3X SLI motherboard

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -200,6 +200,8 @@ internal class Identification
                 return Model.A890GXM_A;
             case var _ when name.Equals("X58 SLI Classified", StringComparison.OrdinalIgnoreCase):
                 return Model.X58_SLI_Classified;
+            case var _ when name.Equals("132-BL-E758", StringComparison.OrdinalIgnoreCase):
+                return Model.X58_3X_SLI;
             case var _ when name.Equals("965P-S3", StringComparison.OrdinalIgnoreCase):
                 return Model._965P_S3;
             case var _ when name.Equals("EP45-DS3R", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/F718XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/F718XX.cs
@@ -26,7 +26,7 @@ internal class F718XX : ISuperIO
         Voltages = new float?[chip == Chip.F71858 ? 3 : 9];
         Temperatures = new float?[chip == Chip.F71808E ? 2 : 3];
         Fans = new float?[chip is Chip.F71882 or Chip.F71858 ? 4 : 3];
-        Controls = new float?[chip == Chip.F71878AD ? 3 : 0];
+        Controls = new float?[chip == Chip.F71878AD ? 3 : (chip == Chip.F71882 ? 4 : 0)];
     }
 
     public Chip Chip { get; }
@@ -191,7 +191,14 @@ internal class F718XX : ISuperIO
 
         for (int i = 0; i < Controls.Length; i++)
         {
-            Controls[i] = ReadByte((byte)(PWM_VALUES_OFFSET + i)) * 100.0f / 0xFF;
+            if (Chip == Chip.F71882)
+            {
+                Controls[i] = ReadByte((byte)(FAN_PWM_REG[i])) * 100.0f / 0xFF;
+            }
+            else
+            {
+                Controls[i] = ReadByte((byte)(PWM_VALUES_OFFSET + i)) * 100.0f / 0xFF;
+            }
         }
 
         Ring0.ReleaseIsaBusMutex();

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -102,6 +102,7 @@ public enum Model
 
     // EVGA
     X58_SLI_Classified,
+    X58_3X_SLI,
 
     // Gigabyte
     _965P_S3,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1950,6 +1950,30 @@ internal sealed class SuperIOHardware : Hardware
 
                         break;
 
+                    case Model.X58_3X_SLI: // F71882
+                        v.Add(new Voltage("VCC3V", 0, 150, 150));
+                        v.Add(new Voltage("Vcore", 1, 47, 100));
+                        v.Add(new Voltage("DIMM", 2, 47, 100));
+                        v.Add(new Voltage("CPU VTT", 3, 24, 100));
+                        v.Add(new Voltage("IOH Vcore", 4, 24, 100));
+                        v.Add(new Voltage("+5V", 5, 51, 12));
+                        v.Add(new Voltage("+12V", 6, 56, 6.8f));
+                        v.Add(new Voltage("3VSB", 7, 150, 150));
+                        v.Add(new Voltage("VBat", 8, 150, 150));
+                        t.Add(new Temperature("CPU", 0));
+                        t.Add(new Temperature("VREG", 1));
+                        t.Add(new Temperature("System", 2));
+                        f.Add(new Fan("CPU Fan", 0));
+                        f.Add(new Fan("Power Fan", 1));
+                        f.Add(new Fan("Chassis Fan", 2));
+                        f.Add(new Fan("Chipset Fan", 3));
+                        c.Add(new Control("CPU Fan", 0));
+                        c.Add(new Control("Power Fan", 1));
+                        c.Add(new Control("Chassis Fan", 2));
+                        c.Add(new Control("Chipset Fan", 3));
+
+                        break;
+
                     default:
                         v.Add(new Voltage("VCC3V", 0, 150, 150));
                         v.Add(new Voltage("Vcore", 1));


### PR DESCRIPTION
I've added support for the EVGA X58 3X SLI motherboard.  Here is what the stats look like:
![image](https://user-images.githubusercontent.com/130199855/230745543-47482dff-c744-45d8-af6e-c5c46172dd81.png)

The fans are controlled by a version of FanControl using this build:
![image](https://user-images.githubusercontent.com/130199855/230745545-d0c5fb07-e982-4ddd-a0b5-0b0a304e7440.png)

HWInfo status screen:
![image](https://user-images.githubusercontent.com/130199855/230745555-3c909dbc-8e20-4fd0-80ca-e4e3b48bb0de.png)
