### PR TITLE
Hotfix: Correct incorrect code on hash 0a65107

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1632,14 +1632,14 @@ internal sealed class SuperIOHardware : Hardware
                         t.Add(new Temperature("System #1",3));
                         t.Add(new Temperature("System #2",4));
                         t.Add(new Temperature("VRAM MOS",5));
-                        f.Add(new Fan("CPU Fan"),0);
-                        f.Add(new Fan("System Fan #1"),2);
-                        f.Add(new Fan("System Fan #2"),3);
-                        f.Add(new Fan("System Fan #3"),4);
-                        c.Add(new Control("CPU Fan"),0);
-                        c.Add(new Control("System Fan #1"),2);
-                        c.Add(new Control("System Fan #2"),3);
-                        c.Add(new Control("System Fan #3"),4);
+                        f.Add(new Fan("CPU Fan",0));
+                        f.Add(new Fan("System Fan #1",2));
+                        f.Add(new Fan("System Fan #2",3));
+                        f.Add(new Fan("System Fan #3",4));
+                        c.Add(new Control("CPU Fan",0));
+                        c.Add(new Control("System Fan #1",2));
+                        c.Add(new Control("System Fan #2",3));
+                        c.Add(new Control("System Fan #3",4));
                         break;
 
                     default:


### PR DESCRIPTION
PR https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/pull/1076 incorrectly introduced a build break due to wrong placement of parenthesis. Contributor doesn't appear to have compiled the code.