### PR TITLE
Add full MS-7751 boards support (F71889AD + F753XX) and SMBus

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -282,6 +282,9 @@ internal class Identification
             case var _ when name.Equals("Z77A-GD55", StringComparison.OrdinalIgnoreCase):        // MS-7751 Rev 1.x
             case var _ when name.Equals("Z77A-GD55 (MS-7751)", StringComparison.OrdinalIgnoreCase):
                 return Model.Z77_MPower;
+            case var _ when name.Equals("Big Bang-XPower II", StringComparison.OrdinalIgnoreCase):
+            case var _ when name.Equals("Big Bang-XPower II (MS-7737)", StringComparison.OrdinalIgnoreCase):
+                return Model.X79_XPower_II;
             case var _ when name.Equals("X79-UD3", StringComparison.OrdinalIgnoreCase):
                 return Model.X79_UD3;
             case var _ when name.Equals("Z68A-D3H-B3", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -273,6 +273,15 @@ internal class Identification
             case var _ when name.Equals("Z270 PC MATE", StringComparison.OrdinalIgnoreCase):
             case var _ when name.Equals("Z270 PC MATE (MS-7A72)", StringComparison.OrdinalIgnoreCase):
                 return Model.Z270_PC_MATE;
+            case var _ when name.Equals("Z77 MPower", StringComparison.OrdinalIgnoreCase):       // MS-7751 Rev 4.x
+            case var _ when name.Equals("Z77 MPower (MS-7751)", StringComparison.OrdinalIgnoreCase):
+            case var _ when name.Equals("Z77A-GD65", StringComparison.OrdinalIgnoreCase):        // MS-7751 Rev >1.x
+            case var _ when name.Equals("Z77A-GD65 (MS-7751)", StringComparison.OrdinalIgnoreCase):
+            case var _ when name.Equals("Z77A-GD65 GAMING", StringComparison.OrdinalIgnoreCase): // MS-7751 Rev 2.x
+            case var _ when name.Equals("Z77A-GD65 GAMING (MS-7751)", StringComparison.OrdinalIgnoreCase):
+            case var _ when name.Equals("Z77A-GD55", StringComparison.OrdinalIgnoreCase):        // MS-7751 Rev 1.x
+            case var _ when name.Equals("Z77A-GD55 (MS-7751)", StringComparison.OrdinalIgnoreCase):
+                return Model.Z77_MPower;
             case var _ when name.Equals("X79-UD3", StringComparison.OrdinalIgnoreCase):
                 return Model.X79_UD3;
             case var _ when name.Equals("Z68A-D3H-B3", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
@@ -79,14 +79,10 @@ internal enum Chip : ushort
     W83687THF = 0x8541,
 
     IPMI = 0x4764,
-}
 
-internal enum ChipSmbus : ushort
-{
-    Unknown = 0,
-
-    // CHIPID reg at 0x5A (thats why another enum there)
-    // normal dev addr: 0x2D, 0x2E
+    // SMBus:
+    // CHIPID reg at 0x5A
+    // Normal dev addr: 0x2D, 0x2E
     F75373S = 0x0204,
     F75375S = 0x0306,
     F75387 = 0x0410,
@@ -111,9 +107,9 @@ internal class ChipName
             case Chip.F71889F: return "Fintek F71889F";
             case Chip.F71808E: return "Fintek F71808E";
 
-            case (Chip)ChipSmbus.F75373S: return "Fintek F75373S/F75373SG";
-            case (Chip)ChipSmbus.F75375S: return "Fintek F75375S/F75375SG";
-            case (Chip)ChipSmbus.F75387: return "Fintek F75387SG/F75387RG";
+            case Chip.F75373S: return "Fintek F75373S/SG";
+            case Chip.F75375S: return "Fintek F75375S/SG";
+            case Chip.F75387: return "Fintek F75387SG/RG";
 
             case Chip.IT8613E: return "ITE IT8613E";
             case Chip.IT8620E: return "ITE IT8620E";

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
@@ -81,6 +81,17 @@ internal enum Chip : ushort
     IPMI = 0x4764,
 }
 
+internal enum ChipSmbus : ushort
+{
+    Unknown = 0,
+
+    // CHIPID reg at 0x5A (thats why another enum there)
+    // normal dev addr: 0x2D, 0x2E
+    F75373S = 0x0204,
+    F75375S = 0x0306,
+    F75387 = 0x0410,
+}
+
 internal class ChipName
 {
     public static string GetName(Chip chip)
@@ -99,6 +110,11 @@ internal class ChipName
             case Chip.F71889ED: return "Fintek F71889ED";
             case Chip.F71889F: return "Fintek F71889F";
             case Chip.F71808E: return "Fintek F71808E";
+
+            case (Chip)ChipSmbus.F75373S: return "Fintek F75373S/F75373SG";
+            case (Chip)ChipSmbus.F75375S: return "Fintek F75375S/F75375SG";
+            case (Chip)ChipSmbus.F75387: return "Fintek F75387SG/F75387RG";
+
             case Chip.IT8613E: return "ITE IT8613E";
             case Chip.IT8620E: return "ITE IT8620E";
             case Chip.IT8625E: return "ITE IT8625E";

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/F718XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/F718XX.cs
@@ -26,7 +26,7 @@ internal class F718XX : ISuperIO
         Voltages = new float?[chip == Chip.F71858 ? 3 : 9];
         Temperatures = new float?[chip == Chip.F71808E ? 2 : 3];
         Fans = new float?[chip is Chip.F71882 or Chip.F71858 ? 4 : 3];
-        Controls = new float?[chip == Chip.F71878AD ? 3 : (chip == Chip.F71882 ? 4 : 0)];
+        Controls = new float?[chip == Chip.F71878AD || chip == Chip.F71889AD ? 3 : (chip == Chip.F71882 ? 4 : 0)];
     }
 
     public Chip Chip { get; }
@@ -191,7 +191,7 @@ internal class F718XX : ISuperIO
 
         for (int i = 0; i < Controls.Length; i++)
         {
-            if (Chip == Chip.F71882)
+            if (Chip == Chip.F71882 || Chip == Chip.F71889AD)
             {
                 Controls[i] = ReadByte((byte)(FAN_PWM_REG[i])) * 100.0f / 0xFF;
             }

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/F753XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/F753XX.cs
@@ -1,0 +1,383 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (C) LibreHardwareMonitor and Contributors.
+// Partial Copyright (C) Michael Möller <mmoeller@openhardwaremonitor.org> and Contributors.
+// All Rights Reserved.
+
+using System;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using static LibreHardwareMonitor.Hardware.Psu.Corsair.UsbApi;
+//using System.Collections.Generic;
+//using System.Runtime.InteropServices;
+
+// ReSharper disable once InconsistentNaming
+
+namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc;
+
+internal class F753XX : ISuperIO
+{
+    private readonly byte[] _initialFanPwmControl = new byte[2];
+    private readonly bool[] _restoreDefaultFanPwmControlRequired = new bool[2];
+    private readonly byte _chip_address;
+
+    public F753XX(ChipSmbus chip, byte addr, ushort smb_addr)
+    {
+        Chip = (Chip)chip;
+        _chip_address = addr;
+        SMB_ADDRESS = smb_addr;
+        SMBHSTSTS = (ushort)(0 + SMB_ADDRESS);
+        SMBHSTCNT = (ushort)(2 + SMB_ADDRESS);
+        SMBHSTCMD = (ushort)(3 + SMB_ADDRESS);
+        SMBHSTADD = (ushort)(4 + SMB_ADDRESS);
+        SMBHSTDAT0 = (ushort)(5 + SMB_ADDRESS);
+        SMBHSTDAT1 = (ushort)(6 + SMB_ADDRESS);
+        //SMBBLKDAT = (ushort)(7 + SMB_ADDRESS);
+        //SMBPEC = (ushort)(8 + SMB_ADDRESS);
+        //SMBAUXSTS = (ushort)(12 + SMB_ADDRESS);
+        SMBAUXCTL = (ushort)(13 + SMB_ADDRESS);
+        //SMBSLVSTS = (ushort)(16 + SMB_ADDRESS);
+        //SMBSLVCMD = (ushort)(17 + SMB_ADDRESS);
+        //SMBNTFDADD = (ushort)(20 + SMB_ADDRESS);
+
+        Voltages = new float?[4];
+        Temperatures = new float?[3];
+        Fans = new float?[2];
+        Controls = new float?[2];
+    }
+    public Chip Chip { get; } // ChipSmbus
+
+    public float?[] Controls { get; }
+
+    public float?[] Fans { get; }
+
+    public float?[] Temperatures { get; }
+
+    public float?[] Voltages { get; }
+
+    public byte? ReadGpio(int index)
+    {
+        return null;
+    }
+
+    public void WriteGpio(int index, byte value)
+    { }
+
+    public void SetControl(int index, byte? value)
+    {
+        if (index < 0 || index >= Controls.Length)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        if (!Ring0.WaitSmBusMutex(100))
+            return;
+
+        if (value.HasValue)
+        {
+            SaveDefaultFanPwmControl(index);
+
+            if (Chip == (Chip)ChipSmbus.F75387)
+                WriteByte(FAN_PWM_EXP_LSB_REG[index], value.Value);
+            else
+                WriteByte(FAN_PWM_REG[index], value.Value);
+        }
+        else
+        {
+            RestoreDefaultFanPwmControl(index);
+        }
+
+        Ring0.ReleaseSmBusMutex();
+    }
+
+    public string GetReport()
+    {
+        StringBuilder r = new();
+
+        r.AppendLine("SMBus " + GetType().Name);
+        r.AppendLine();
+        r.Append("Base Address: 0x");
+        r.AppendLine(_chip_address.ToString("X4", CultureInfo.InvariantCulture));
+        r.AppendLine();
+
+        if (!Ring0.WaitSmBusMutex(100))
+            return r.ToString();
+
+        r.AppendLine("Hardware Monitor Registers");
+        r.AppendLine();
+        r.AppendLine("      00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F");
+        r.AppendLine();
+        for (int i = 0; i <= 0xF; i++)
+        {
+            r.Append(" ");
+            r.Append((i << 4).ToString("X2", CultureInfo.InvariantCulture));
+            r.Append("  ");
+            for (int j = 0; j <= 0xF; j++)
+            {
+                r.Append(" ");
+                r.Append(ReadByte((byte)((i << 4) | j)).ToString("X2",
+                                                                 CultureInfo.InvariantCulture));
+            }
+
+            r.AppendLine();
+        }
+
+        r.AppendLine();
+
+        Ring0.ReleaseSmBusMutex();
+        return r.ToString();
+    }
+
+    public void Update()
+    {
+        if (!Ring0.WaitSmBusMutex(100))
+            return;
+
+        for (int i = 0; i < Voltages.Length; i++)
+        {
+            int value = ReadByte((byte)(VOLTAGE_BASE_REG + i));
+            Voltages[i] = 0.008f * value;
+        }
+
+        for (int i = 0; i < Temperatures.Length; i++)
+        {
+            float value = ReadByte(TEMPERATURE_MSB_REG[i]);
+            value += ReadByte(TEMPERATURE_LSB_REG[i]) / 256.0f;
+
+            if (value is < 140 and > 0) // real range is 0 to 140.875
+                Temperatures[i] = value;
+            else
+                Temperatures[i] = null;
+        }
+
+        for (int i = 0; i < Fans.Length; i++)
+        {
+            int value = ReadByte(FAN_TACHOMETER_MSB_REG[i]) << 8;
+            value |= ReadByte(FAN_TACHOMETER_LSB_REG[i]);
+
+            if (value > 0)
+                Fans[i] = value < 0xFFFF ? 1.5e6f / value : 0;
+            else
+                Fans[i] = null;
+        }
+
+        for (int i = 0; i < Controls.Length; i++)
+        {
+            int value = ReadByte(FAN_PWM_EXP_MSB_REG[i]) << 8;
+            value |= ReadByte(FAN_PWM_EXP_LSB_REG[i]);
+
+            Controls[i] = value * 100.0f / 0xFF;
+        }
+
+        Ring0.ReleaseSmBusMutex();
+    }
+
+    private void SaveDefaultFanPwmControl(int index)
+    {
+        if (!_restoreDefaultFanPwmControlRequired[index])
+        {
+            _initialFanPwmControl[index] = ReadByte(FAN_PWM_REG[index]);
+            _restoreDefaultFanPwmControlRequired[index] = true;
+        }
+    }
+
+    private void RestoreDefaultFanPwmControl(int index)
+    {
+        if (_restoreDefaultFanPwmControlRequired[index])
+        {
+            WriteByte(FAN_PWM_REG[index], _initialFanPwmControl[index]);
+            _restoreDefaultFanPwmControlRequired[index] = false;
+        }
+    }
+
+    private int CheckPre()
+    {
+        ushort status = Ring0.ReadSmbus(SMBHSTSTS);
+        if ((status & SMBHSTSTS_HOST_BUSY) > 0)
+        {
+            return -1;
+        }
+
+        status &= STATUS_FLAGS;
+        if (status > 0)
+        {
+            Ring0.WriteSmbus(SMBHSTSTS, (byte)status);
+            status = (ushort)(Ring0.ReadSmbus(SMBHSTSTS) & STATUS_FLAGS);
+            if (status > 0)
+            {
+                return -1;
+            }
+        }
+        return 0;
+    }
+
+    private int WaitIntr()
+    {
+        const int maxCount = 1000;
+        int timeout = 0;
+        ushort status;
+        bool val = false;
+        bool val2 = false;
+
+        do
+        {
+            status = Ring0.ReadSmbus(SMBHSTSTS);
+            val = (status & SMBHSTSTS_HOST_BUSY) > 0;
+            val2 = (status & (STATUS_ERROR_FLAGS | SMBHSTSTS_INTR)) > 0;
+
+        } while ((val || !val2) && timeout++ < maxCount);
+
+        if (timeout > maxCount)
+        {
+            return -1;
+        }
+        return status & (STATUS_ERROR_FLAGS | SMBHSTSTS_INTR);
+    }
+
+    private int CheckPost(int status)
+    {
+        if (status < 0)
+        {
+            Ring0.WriteSmbus(SMBHSTCNT, (byte)(Ring0.ReadSmbus(SMBHSTCNT) | SMBHSTCNT_KILL));
+            Thread.Sleep(1);
+            Ring0.WriteSmbus(SMBHSTCNT, (byte)(Ring0.ReadSmbus(SMBHSTCNT) & (~SMBHSTCNT_KILL)));
+
+            Ring0.WriteSmbus(SMBHSTSTS, (byte)STATUS_FLAGS);
+            return -1;
+        }
+
+        Ring0.WriteSmbus(SMBHSTSTS, (byte)status);
+
+        if ((status & SMBHSTSTS_FAILED) > 0 || (status & SMBHSTSTS_DEV_ERR) > 0 || (status & SMBHSTSTS_BUS_ERR) > 0)
+        {
+            return -1;
+        }
+
+        return 0;
+    }
+
+    private int Transaction(byte xact) // 0x0C WORD_DATA, 0x08 BYTE_DATA
+    {
+        int result = CheckPre();
+        if (result < 0)
+            return result;
+
+        Ring0.WriteSmbus(SMBHSTCNT, (byte)(Ring0.ReadSmbus(SMBHSTCNT) & ~SMBHSTCNT_INTREN));
+        Ring0.WriteSmbus(SMBHSTCNT, (byte)(xact | SMBHSTCNT_START));
+
+        int status = WaitIntr();
+
+        return CheckPost(status);
+    }
+
+    private void WriteSerialAddrReg(byte value)
+    {
+        byte[] sequence = { 0xA9, 0xC3, value };
+
+        Ring0.WriteSmbus(SMBHSTADD, (byte)(((_chip_address & 0x7f) << 1) | (SMB_WRITE & 0x01)));
+        Ring0.WriteSmbus(SMBHSTCMD, SERIAL_ADDR_REG);
+        for (int i = 0; i < sequence.Length; i++)
+        {
+            Ring0.WriteSmbus(SMBHSTDAT0, sequence[i]);
+        }
+        Ring0.WriteSmbus(SMBAUXCTL, (byte)(Ring0.ReadSmbus(SMBAUXCTL) & (~SMBAUXCTL_CRC)));
+    }
+
+// TODO: also add word read write
+    private byte ReadByte(byte register)
+    {
+        if (SMB_ADDRESS == 0)
+            return 0;
+
+        //WriteSerialAddrReg(register);
+
+        Ring0.WriteSmbus(SMBHSTADD, (byte)(((_chip_address & 0x7f) << 1) | (SMB_READ & 0x01)));
+        Ring0.WriteSmbus(SMBHSTCMD, register);
+
+        Ring0.WriteSmbus(SMBAUXCTL, (byte)(Ring0.ReadSmbus(SMBAUXCTL) & (~SMBAUXCTL_CRC)));
+
+        Transaction(0x08);
+
+        Ring0.WriteSmbus(SMBAUXCTL, (byte)(Ring0.ReadSmbus(SMBAUXCTL) & ~(SMBAUXCTL_CRC | SMBAUXCTL_E32B)));
+
+        return Ring0.ReadSmbus(SMBHSTDAT0);
+    }
+
+    private void WriteByte(byte register, byte value)
+    {
+        if (SMB_ADDRESS == 0)
+            return;
+
+        //WriteSerialAddrReg(register);
+
+        Ring0.WriteSmbus(SMBHSTADD, (byte)(((_chip_address & 0x7f) << 1) | (SMB_WRITE & 0x01)));
+        Ring0.WriteSmbus(SMBHSTCMD, register);
+        Ring0.WriteSmbus(SMBHSTDAT0, value);
+
+        Ring0.WriteSmbus(SMBAUXCTL, (byte)(Ring0.ReadSmbus(SMBAUXCTL) & (~SMBAUXCTL_CRC)));
+
+        Transaction(0x08);
+
+        Ring0.WriteSmbus(SMBAUXCTL, (byte)(Ring0.ReadSmbus(SMBAUXCTL) & ~(SMBAUXCTL_CRC | SMBAUXCTL_E32B)));
+    }
+
+    // ReSharper disable InconsistentNaming
+#pragma warning disable IDE1006 // Naming Styles
+
+    private const byte SERIAL_ADDR_REG = 0x04;
+
+    private readonly byte[] TEMPERATURE_MSB_REG = { 0x14, 0x15, 0x1C }; // read MSB first!  [T1, T2, Local]
+    private readonly byte[] TEMPERATURE_LSB_REG = { 0x1A, 0x1B, 0x1D };
+
+    private const byte VOLTAGE_BASE_REG = 0x10;                         // [VCC, V1, V2, V3]
+
+    private readonly byte[] FAN_PWM_REG = { 0x76, 0x86 };               // set pwm (use PWM_EXP for F75387)
+    private readonly byte[] FAN_PWM_EXP_MSB_REG = { 0x74, 0x84 };       // expected speed
+    private readonly byte[] FAN_PWM_EXP_LSB_REG = { 0x75, 0x85 };
+
+    private readonly byte[] FAN_TACHOMETER_MSB_REG = { 0x16, 0x18 };    // read MSB first!
+    private readonly byte[] FAN_TACHOMETER_LSB_REG = { 0x17, 0x19 };
+
+    //SMBus:
+    private readonly ushort SMB_ADDRESS = 0;
+
+    private ushort SMBHSTSTS = 0;
+    private ushort SMBHSTCNT = 0;
+    private ushort SMBHSTCMD = 0;
+    private ushort SMBHSTADD = 0;
+    private ushort SMBHSTDAT0 = 0;
+    private ushort SMBHSTDAT1 = 0;
+    //private ushort SMBBLKDAT = 0;
+    //private ushort SMBPEC = 0;
+    //private ushort SMBAUXSTS = 0;
+    private ushort SMBAUXCTL = 0;
+    //private ushort SMBSLVSTS = 0;
+    //private ushort SMBSLVCMD = 0;
+    //private ushort SMBNTFDADD = 0;
+
+    private const byte SMB_READ = 0x01;
+    private const byte SMB_WRITE = 0x00;
+
+    private static ushort SMBAUXCTL_CRC = (1 << 0);
+    private static ushort SMBAUXCTL_E32B = (1 << 1);
+
+    private static ushort SMBHSTCNT_INTREN = (1 << 0);
+    private static ushort SMBHSTCNT_KILL = (1 << 1);
+    //private static ushort SMBHSTCNT_LAST_BYTE = (1 << 5);
+    private static ushort SMBHSTCNT_START = (1 << 6);
+    //private static ushort SMBHSTCNT_PEC_EN = (1 << 7);
+
+    private static ushort SMBHSTSTS_BYTE_DONE = (1 << 7);
+    //private static ushort SMBHSTSTS_INUSE_STS = (1 << 6);
+    //private static ushort SMBHSTSTS_SMBALERT_STS = (1 << 5);
+    private static ushort SMBHSTSTS_FAILED = (1 << 4);
+    private static ushort SMBHSTSTS_BUS_ERR = (1 << 3);
+    private static ushort SMBHSTSTS_DEV_ERR = (1 << 2);
+    private static ushort SMBHSTSTS_INTR = (1 << 1);
+    private static ushort SMBHSTSTS_HOST_BUSY = (1 << 0);
+
+    private static ushort STATUS_ERROR_FLAGS = (ushort)(SMBHSTSTS_FAILED | SMBHSTSTS_BUS_ERR | SMBHSTSTS_DEV_ERR);
+    private static ushort STATUS_FLAGS = (ushort)(SMBHSTSTS_BYTE_DONE | SMBHSTSTS_INTR | STATUS_ERROR_FLAGS);
+
+    // ReSharper restore InconsistentNaming
+#pragma warning restore IDE1006 // Naming Styles
+}

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/F753XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/F753XX.cs
@@ -21,20 +21,20 @@ internal class F753XX : ISuperIO
     private readonly bool[] _restoreDefaultFanPwmControlRequired = new bool[2];
     SmBusDevice Dev;
 
-    public F753XX(ChipSmbus chip, byte addr, ushort smb_addr)
+    public F753XX(Chip chip, byte addr, ushort smb_addr)
     {
-        Chip = (Chip)chip;
+        Chip = chip;
         Dev = new SmBusDevice(addr, smb_addr);
         
         Voltages = new float?[4];
-        Temperatures = new float?[chip == ChipSmbus.F75387 ? 3 : 2];
+        Temperatures = new float?[chip == Chip.F75387 ? 3 : 2];
         Fans = new float?[2];
         Controls = new float?[2];
     }
 
-    public F753XX(ChipSmbus chip, SmBusDevice dev)
+    public F753XX(Chip chip, SmBusDevice dev)
     {
-        Chip = (Chip)chip;
+        Chip = chip;
         Dev = dev;
 
         Voltages = new float?[4];
@@ -75,7 +75,7 @@ internal class F753XX : ISuperIO
 
             // force change fan mode to manual
             byte fanmode = ReadByte(FAN_MODE_REG);
-            if (Chip == (Chip)ChipSmbus.F75387)
+            if (Chip == Chip.F75387)
             {
                 for (byte nr = 0; nr < Controls.Length; nr++)
                 {
@@ -95,7 +95,7 @@ internal class F753XX : ISuperIO
             }
             WriteByte(FAN_MODE_REG, fanmode);
 
-            if (Chip == (Chip)ChipSmbus.F75387)
+            if (Chip == Chip.F75387)
                 WriteByte(FAN_PWM_EXP_LSB_REG[index], value.Value);
             else
                 WriteByte(FAN_PWM_DUTY_REG[index], value.Value);
@@ -160,7 +160,7 @@ internal class F753XX : ISuperIO
         for (int i = 0; i < Temperatures.Length; i++)
         {
             float value = ReadByte(TEMPERATURE_MSB_REG[i]);
-            if (Chip == (Chip)ChipSmbus.F75387)
+            if (Chip == Chip.F75387)
                 value += ReadByte(TEMPERATURE_LSB_REG[i]) / 256.0f;
 
             if (value is < 140 and > 0) // real range is 0 to 140.875
@@ -195,7 +195,7 @@ internal class F753XX : ISuperIO
         {
             _initialFanPwmMode = ReadByte(FAN_MODE_REG);
 
-            if (Chip == (Chip)ChipSmbus.F75387)
+            if (Chip == Chip.F75387)
             {
                 _initialFanExpMsb[index] = ReadByte(FAN_PWM_EXP_MSB_REG[index]);
                 _initialFanPwmControl[index] = ReadByte(FAN_PWM_EXP_LSB_REG[index]);
@@ -215,7 +215,7 @@ internal class F753XX : ISuperIO
         {
             WriteByte(FAN_MODE_REG, _initialFanPwmMode);
 
-            if (Chip == (Chip)ChipSmbus.F75387)
+            if (Chip == Chip.F75387)
             {
                 WriteByte(FAN_PWM_EXP_MSB_REG[index], _initialFanExpMsb[index]);
                 WriteByte(FAN_PWM_EXP_LSB_REG[index], _initialFanPwmControl[index]);

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/F753XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/F753XX.cs
@@ -169,8 +169,7 @@ internal class F753XX : ISuperIO
 
         for (int i = 0; i < Fans.Length; i++)
         {
-            int value = ReadByte(FAN_TACHOMETER_MSB_REG[i]) << 8;
-            value |= ReadByte(FAN_TACHOMETER_LSB_REG[i]);
+            int value = ReadMsbLsb(FAN_TACHOMETER_MSB_REG[i], FAN_TACHOMETER_LSB_REG[i]);
 
             if (value > 0)
                 Fans[i] = value < 0x0FFE ? 1.5e6f / value : 0;
@@ -180,8 +179,7 @@ internal class F753XX : ISuperIO
 
         for (int i = 0; i < Controls.Length; i++)
         {
-            int value = ReadByte(FAN_PWM_EXP_MSB_REG[i]) << 8;
-            value |= ReadByte(FAN_PWM_EXP_LSB_REG[i]);
+            int value = ReadMsbLsb(FAN_PWM_EXP_MSB_REG[i], FAN_PWM_EXP_LSB_REG[i]);
 
             Controls[i] = value * 100.0f / 0xFF;
         }
@@ -219,9 +217,20 @@ internal class F753XX : ISuperIO
         }
     }
 
+    private ushort ReadMsbLsb(byte reg_msb, byte reg_lsb)
+    {
+        return (ushort)((Dev.ReadByte(reg_msb) << 8) | Dev.ReadByte(reg_lsb));
+    }
+
     private byte ReadByte(byte register)
     {
         return Dev.ReadByte(register);
+    }
+
+    private void WriteMsbLsb(byte reg_msb, byte reg_lsb, ushort value)
+    {
+        Dev.WriteByte(reg_msb, (byte)((value >> 8) & 0xff));
+        Dev.WriteByte(reg_lsb, (byte)(value & 0xff));
     }
 
     private void WriteByte(byte register, byte value)

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/F753XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/F753XX.cs
@@ -30,6 +30,18 @@ internal class F753XX : ISuperIO
         Fans = new float?[2];
         Controls = new float?[2];
     }
+
+    public F753XX(ChipSmbus chip, SmBusDevice dev)
+    {
+        Chip = (Chip)chip;
+        Dev = dev;
+
+        Voltages = new float?[4];
+        Temperatures = new float?[3];
+        Fans = new float?[2];
+        Controls = new float?[2];
+    }
+
     public Chip Chip { get; } // ChipSmbus
 
     public float?[] Controls { get; }

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LMSensors.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LMSensors.cs
@@ -73,13 +73,13 @@ internal class LMSensors
                         break;
 
                     case "f75375":
-                        _superIOs.Add(new LMChip((Chip)ChipSmbus.F75375S, path));
+                        _superIOs.Add(new LMChip(Chip.F75375S, path));
                         break;
                     case "f75373":
-                        _superIOs.Add(new LMChip((Chip)ChipSmbus.F75373S, path));
+                        _superIOs.Add(new LMChip(Chip.F75373S, path));
                         break;
                     case "f75387":
-                        _superIOs.Add(new LMChip((Chip)ChipSmbus.F75387, path));
+                        _superIOs.Add(new LMChip(Chip.F75387, path));
                         break;
 
                     case "it8705":

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LMSensors.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LMSensors.cs
@@ -72,6 +72,16 @@ internal class LMSensors
                         _superIOs.Add(new LMChip(Chip.F71808E, path));
                         break;
 
+                    case "f75375":
+                        _superIOs.Add(new LMChip((Chip)ChipSmbus.F75375S, path));
+                        break;
+                    case "f75373":
+                        _superIOs.Add(new LMChip((Chip)ChipSmbus.F75373S, path));
+                        break;
+                    case "f75387":
+                        _superIOs.Add(new LMChip((Chip)ChipSmbus.F75387, path));
+                        break;
+
                     case "it8705":
                         _superIOs.Add(new LMChip(Chip.IT8705F, path));
                         break;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
@@ -90,6 +90,11 @@ internal class LpcIO
     {
         SmBusDevice tempDev = new SmBusDevice(addr, smb_addr);
 
+        // read word don't work for this chip, or for target hardware
+        ushort vid = (ushort)((tempDev.ReadByte(FINTEK_VENDOR_ID_SMBUS_REGISTER) << 8) | tempDev.ReadByte(FINTEK_VENDOR_ID_SMBUS_REGISTER + 1));
+        if (vid != FINTEK_VENDOR_ID)
+            return false; // this is not a Fintek device
+
         ChipSmbus chip = (ChipSmbus)((tempDev.ReadByte(CHIP_ID_SMBUS_REGISTER) << 8) | tempDev.ReadByte(CHIP_ID_SMBUS_REGISTER + 1));
 
         switch (chip)
@@ -740,6 +745,7 @@ internal class LpcIO
 
     // SMBus
     private const byte CHIP_ID_SMBUS_REGISTER = 0x5A;
+    private const byte FINTEK_VENDOR_ID_SMBUS_REGISTER = 0x5D;
 
     // ReSharper restore InconsistentNaming
 }

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
@@ -95,13 +95,13 @@ internal class LpcIO
         if (vid != FINTEK_VENDOR_ID)
             return false; // this is not a Fintek device
 
-        ChipSmbus chip = (ChipSmbus)((tempDev.ReadByte(CHIP_ID_SMBUS_REGISTER) << 8) | tempDev.ReadByte(CHIP_ID_SMBUS_REGISTER + 1));
+        Chip chip = (Chip)((tempDev.ReadByte(CHIP_ID_SMBUS_REGISTER) << 8) | tempDev.ReadByte(CHIP_ID_SMBUS_REGISTER + 1));
 
         switch (chip)
         {
-            case ChipSmbus.F75373S:
-            case ChipSmbus.F75375S:
-            case ChipSmbus.F75387:
+            case Chip.F75373S:
+            case Chip.F75375S:
+            case Chip.F75387:
                 _superIOs.Add(new F753XX(chip, addr, smb_addr));
                 break;
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -103,6 +103,7 @@ public enum Model
     B450A_PRO,
     Z270_PC_MATE,
     Z77_MPower,
+    X79_XPower_II,
 
     // EVGA
     X58_SLI_Classified,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -102,6 +102,7 @@ public enum Model
     B360M_PRO_VDH,
     B450A_PRO,
     Z270_PC_MATE,
+    Z77_MPower,
 
     // EVGA
     X58_SLI_Classified,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2030,14 +2030,14 @@ internal sealed class SuperIOHardware : Hardware
                 switch(model)
                 {
                     case Model.Z77_MPower: // F71889AD
-                            {
+                    {
                         v.Add(new Voltage("VCC3V", 0, 150, 150));
-                        v.Add(new Voltage("CPU CORE", 1));
+                        v.Add(new Voltage("Vcore", 1));
                         v.Add(new Voltage("GPU", 2));
                         v.Add(new Voltage("+5V", 3, 20, 4.7f));
                         v.Add(new Voltage("+12V", 4, 68, 6.8f));
                         v.Add(new Voltage("DRAM", 5, 150, 150));
-                        v.Add(new Voltage("CPU I/O", 6));
+                        v.Add(new Voltage("CPU IO", 6));
                         v.Add(new Voltage("+3.3V", 7, 150, 150));
                         v.Add(new Voltage("VBat", 8, 150, 150));
 
@@ -2117,7 +2117,7 @@ internal sealed class SuperIOHardware : Hardware
             case Manufacturer.MSI:
                 switch (model)
                 {
-                    case Model.Z77_MPower: // F75387
+                    case Model.Z77_MPower: // Probably rev 4.0+ (F75387)
                         {
                             v.Add(new Voltage("VCC", 0, 150, 150));
                             for (int i = 1; i < superIO.Voltages.Length; i++)

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2020,6 +2020,64 @@ internal sealed class SuperIOHardware : Hardware
 
                 break;
 
+            case Manufacturer.MSI:
+                switch(model)
+                {
+                    case Model.Z77_MPower: // F71889AD
+                            {
+                        v.Add(new Voltage("VCC3V", 0, 150, 150));
+                        v.Add(new Voltage("Vcore", 1));
+                        v.Add(new Voltage("Vgpu", 2));
+                        v.Add(new Voltage("+5V", 3, 51.06f, 12));
+                        v.Add(new Voltage("+12V", 4, 68, 6.8f));
+                        v.Add(new Voltage("Vddr", 5, 150, 150));
+                        v.Add(new Voltage("Vccio", 6));
+                        v.Add(new Voltage("+3.3V", 7, 150, 150));
+                        v.Add(new Voltage("VBat", 8, 150, 150));
+
+                        t.Add(new Temperature("CPU", 0));
+                        t.Add(new Temperature("Probe", 1));
+                        t.Add(new Temperature("System", 2));
+
+                        f.Add(new Fan("CPU Fan", 0));
+                        for (int i = 1; i < superIO.Fans.Length; i++)
+                            f.Add(new Fan("System Fan " + i, i));
+
+                        c.Add(new Control("CPU Fan", 0));
+                        for (int i = 1; i < superIO.Controls.Length; i++)
+                            c.Add(new Control("System Fan " + i, i));
+
+                        break;
+                    }
+                    default:
+                    {
+                        v.Add(new Voltage("VCC3V", 0, 150, 150));
+                        v.Add(new Voltage("Vcore", 1));
+                        v.Add(new Voltage("Voltage #3", 2, true));
+                        v.Add(new Voltage("Voltage #4", 3, true));
+                        v.Add(new Voltage("Voltage #5", 4, true));
+                        v.Add(new Voltage("Voltage #6", 5, true));
+                        if (superIO.Chip != Chip.F71808E)
+                            v.Add(new Voltage("Voltage #7", 6, true));
+
+                        v.Add(new Voltage("VSB3V", 7, 150, 150));
+                        v.Add(new Voltage("VBat", 8, 150, 150));
+
+                        for (int i = 0; i < superIO.Temperatures.Length; i++)
+                            t.Add(new Temperature("Temperature #" + (i + 1), i));
+
+                        for (int i = 0; i < superIO.Fans.Length; i++)
+                            f.Add(new Fan("Fan #" + (i + 1), i));
+
+                        for (int i = 0; i < superIO.Controls.Length; i++)
+                            c.Add(new Control("Fan Control #" + (i + 1), i));
+
+                        break;
+                    }
+                }
+
+                break;
+
             default:
                 v.Add(new Voltage("VCC3V", 0, 150, 150));
                 v.Add(new Voltage("Vcore", 1));

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -263,9 +263,9 @@ internal sealed class SuperIOHardware : Hardware
                 GetFintekConfiguration(superIO, manufacturer, model, v, t, f, c);
                 break;
 
-            case (Chip)ChipSmbus.F75373S:
-            case (Chip)ChipSmbus.F75375S:
-            case (Chip)ChipSmbus.F75387:
+            case Chip.F75373S:
+            case Chip.F75375S:
+            case Chip.F75387:
                 GetFintekF753XXConfiguration(superIO, manufacturer, model, v, t, f, c);
                 break;
 
@@ -2144,7 +2144,7 @@ internal sealed class SuperIOHardware : Hardware
 
                         t.Add(new Temperature("Temperature #1", 0));
                         t.Add(new Temperature("Temperature #2", 1));
-                        if (superIO.Chip == (Chip)ChipSmbus.F75387)
+                        if (superIO.Chip == Chip.F75387)
                             t.Add(new Temperature("Local", 2));
 
                         for (int i = 0; i < superIO.Fans.Length; i++)
@@ -2161,7 +2161,7 @@ internal sealed class SuperIOHardware : Hardware
 
                         t.Add(new Temperature("Temperature #1", 0));
                         t.Add(new Temperature("Temperature #2", 1));
-                        if (superIO.Chip == (Chip)ChipSmbus.F75387)
+                        if (superIO.Chip == Chip.F75387)
                             t.Add(new Temperature("Local", 2));
 
                         for (int i = 0; i < superIO.Fans.Length; i++)
@@ -2181,7 +2181,7 @@ internal sealed class SuperIOHardware : Hardware
 
                 t.Add(new Temperature("Temperature #1", 0));
                 t.Add(new Temperature("Temperature #2", 1));
-                if (superIO.Chip == (Chip)ChipSmbus.F75387)
+                if (superIO.Chip == Chip.F75387)
                     t.Add(new Temperature("Local", 2));
 
                 for (int i = 0; i < superIO.Fans.Length; i++)

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2026,12 +2026,12 @@ internal sealed class SuperIOHardware : Hardware
                     case Model.Z77_MPower: // F71889AD
                             {
                         v.Add(new Voltage("VCC3V", 0, 150, 150));
-                        v.Add(new Voltage("Vcore", 1));
-                        v.Add(new Voltage("Vgpu", 2));
+                        v.Add(new Voltage("CPU CORE", 1));
+                        v.Add(new Voltage("GPU", 2));
                         v.Add(new Voltage("+5V", 3, 51.06f, 12));
                         v.Add(new Voltage("+12V", 4, 68, 6.8f));
-                        v.Add(new Voltage("Vddr", 5, 150, 150));
-                        v.Add(new Voltage("Vccio", 6));
+                        v.Add(new Voltage("DRAM", 5, 150, 150));
+                        v.Add(new Voltage("CPU I/O", 6));
                         v.Add(new Voltage("+3.3V", 7, 150, 150));
                         v.Add(new Voltage("VBat", 8, 150, 150));
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2047,11 +2047,11 @@ internal sealed class SuperIOHardware : Hardware
 
                         f.Add(new Fan("CPU Fan", 0));
                         for (int i = 1; i < superIO.Fans.Length; i++)
-                            f.Add(new Fan("System Fan " + i, i));
+                            f.Add(new Fan("System Fan #" + i, i));
 
                         c.Add(new Control("CPU Fan", 0));
                         for (int i = 1; i < superIO.Controls.Length; i++)
-                            c.Add(new Control("System Fan " + i, i));
+                            c.Add(new Control("System Fan #" + i, i));
 
                         break;
                     }
@@ -2114,10 +2114,52 @@ internal sealed class SuperIOHardware : Hardware
     {
         switch (manufacturer)
         {
+            case Manufacturer.MSI:
+                switch (model)
+                {
+                    case Model.Z77_MPower: // F75387
+                        {
+                            v.Add(new Voltage("VCC", 0, 150, 150));
+                            for (int i = 1; i < superIO.Voltages.Length; i++)
+                                v.Add(new Voltage("Voltage #" + i, i, true));
+
+                            t.Add(new Temperature("Temperature #1", 0));
+                            t.Add(new Temperature("Temperature #2", 1));
+                            t.Add(new Temperature("Local", 2));
+
+                            for (int i = 0; i < superIO.Fans.Length; i++)
+                                f.Add(new Fan("System Fan #" + (i + 3), i));
+
+                            for (int i = 0; i < superIO.Controls.Length; i++)
+                                c.Add(new Control("System Fan #" + (i + 3), i));
+
+                            break;
+                        }
+                    default:
+                        {
+                            v.Add(new Voltage("VCC", 0, 150, 150));
+                            for (int i = 1; i < superIO.Voltages.Length; i++)
+                                v.Add(new Voltage("Voltage #" + i, i, true));
+
+                            t.Add(new Temperature("Temperature #1", 0));
+                            t.Add(new Temperature("Temperature #2", 1));
+                            t.Add(new Temperature("Local", 2));
+
+                            for (int i = 0; i < superIO.Fans.Length; i++)
+                                f.Add(new Fan("Fan #" + (i + 1), i));
+
+                            for (int i = 0; i < superIO.Controls.Length; i++)
+                                c.Add(new Control("Fan #" + (i + 1), i));
+
+                            break;
+                        }
+                }
+                break;
+
             default:
                 v.Add(new Voltage("VCC", 0, 150, 150));
                 for (int i = 1; i < superIO.Voltages.Length; i++)
-                    v.Add(new Voltage("Voltage #" + i, i));
+                    v.Add(new Voltage("Voltage #" + i, i, true));
 
                 t.Add(new Temperature("Temperature #1", 0));
                 t.Add(new Temperature("Temperature #2", 1));

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -263,6 +263,12 @@ internal sealed class SuperIOHardware : Hardware
                 GetFintekConfiguration(superIO, manufacturer, model, v, t, f, c);
                 break;
 
+            case (Chip)ChipSmbus.F75373S:
+            case (Chip)ChipSmbus.F75375S:
+            case (Chip)ChipSmbus.F75387:
+                GetFintekF753XXConfiguration(superIO, manufacturer, model, v, t, f, c);
+                break;
+
             case Chip.W83627EHF:
                 GetWinbondConfigurationEhf(manufacturer, model, v, t, f, c);
                 break;
@@ -2093,6 +2099,29 @@ internal sealed class SuperIOHardware : Hardware
 
                 for (int i = 0; i < superIO.Temperatures.Length; i++)
                     t.Add(new Temperature("Temperature #" + (i + 1), i));
+
+                for (int i = 0; i < superIO.Fans.Length; i++)
+                    f.Add(new Fan("Fan #" + (i + 1), i));
+
+                for (int i = 0; i < superIO.Controls.Length; i++)
+                    c.Add(new Control("Fan #" + (i + 1), i));
+
+                break;
+        }
+    }
+
+    private static void GetFintekF753XXConfiguration(ISuperIO superIO, Manufacturer manufacturer, Model model, IList<Voltage> v, IList<Temperature> t, IList<Fan> f, IList<Control> c)
+    {
+        switch (manufacturer)
+        {
+            default:
+                v.Add(new Voltage("VCC", 0, 150, 150));
+                for (int i = 1; i < superIO.Voltages.Length; i++)
+                    v.Add(new Voltage("Voltage #" + i, i));
+
+                t.Add(new Temperature("Temperature #1", 0));
+                t.Add(new Temperature("Temperature #2", 1));
+                t.Add(new Temperature("Local", 2));
 
                 for (int i = 0; i < superIO.Fans.Length; i++)
                     f.Add(new Fan("Fan #" + (i + 1), i));

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2027,10 +2027,9 @@ internal sealed class SuperIOHardware : Hardware
                 break;
 
             case Manufacturer.MSI:
-                switch(model)
+                switch (model)
                 {
                     case Model.Z77_MPower: // F71889AD
-                    {
                         v.Add(new Voltage("VCC3V", 0, 150, 150));
                         v.Add(new Voltage("Vcore", 1));
                         v.Add(new Voltage("GPU", 2));
@@ -2054,9 +2053,31 @@ internal sealed class SuperIOHardware : Hardware
                             c.Add(new Control("System Fan #" + i, i));
 
                         break;
-                    }
+                    case Model.X79_XPower_II: // F71889AD
+                        v.Add(new Voltage("VCC3V", 0, 150, 150));
+                        v.Add(new Voltage("Vcore", 1));
+                        v.Add(new Voltage("CPU SA", 2));
+                        v.Add(new Voltage("+5V", 3, 20, 4.7f));
+                        v.Add(new Voltage("+12V", 4, 68, 6.8f));
+                        v.Add(new Voltage("DRAM A/B", 5, 150, 150));
+                        v.Add(new Voltage("DRAM C/D", 6, 150, 150));
+                        v.Add(new Voltage("+3.3V", 7, 150, 150));
+                        v.Add(new Voltage("VBat", 8, 150, 150));
+
+                        t.Add(new Temperature("CPU", 0));
+                        t.Add(new Temperature("Probe", 1));
+                        t.Add(new Temperature("System", 2));
+
+                        f.Add(new Fan("CPU Fan", 0));
+                        for (int i = 1; i < superIO.Fans.Length; i++)
+                            f.Add(new Fan("System Fan #" + i, i));
+
+                        c.Add(new Control("CPU Fan", 0));
+                        for (int i = 1; i < superIO.Controls.Length; i++)
+                            c.Add(new Control("System Fan #" + i, i));
+
+                        break;
                     default:
-                    {
                         v.Add(new Voltage("VCC3V", 0, 150, 150));
                         v.Add(new Voltage("Vcore", 1));
                         v.Add(new Voltage("Voltage #3", 2, true));
@@ -2079,7 +2100,6 @@ internal sealed class SuperIOHardware : Hardware
                             c.Add(new Control("Fan Control #" + (i + 1), i));
 
                         break;
-                    }
                 }
 
                 break;
@@ -2118,43 +2138,39 @@ internal sealed class SuperIOHardware : Hardware
                 switch (model)
                 {
                     case Model.Z77_MPower: // Probably rev 4.0+ (F75387)
-                        {
-                            v.Add(new Voltage("VCC", 0, 150, 150));
-                            for (int i = 1; i < superIO.Voltages.Length; i++)
-                                v.Add(new Voltage("Voltage #" + i, i, true));
+                        v.Add(new Voltage("VCC", 0, 150, 150));
+                        for (int i = 1; i < superIO.Voltages.Length; i++)
+                            v.Add(new Voltage("Voltage #" + i, i, true));
 
-                            t.Add(new Temperature("Temperature #1", 0));
-                            t.Add(new Temperature("Temperature #2", 1));
-                            if (superIO.Chip == (Chip)ChipSmbus.F75387)
-                                t.Add(new Temperature("Local", 2));
+                        t.Add(new Temperature("Temperature #1", 0));
+                        t.Add(new Temperature("Temperature #2", 1));
+                        if (superIO.Chip == (Chip)ChipSmbus.F75387)
+                            t.Add(new Temperature("Local", 2));
 
-                            for (int i = 0; i < superIO.Fans.Length; i++)
-                                f.Add(new Fan("System Fan #" + (i + 3), i));
+                        for (int i = 0; i < superIO.Fans.Length; i++)
+                            f.Add(new Fan("System Fan #" + (i + 3), i));
 
-                            for (int i = 0; i < superIO.Controls.Length; i++)
-                                c.Add(new Control("System Fan #" + (i + 3), i));
+                        for (int i = 0; i < superIO.Controls.Length; i++)
+                            c.Add(new Control("System Fan #" + (i + 3), i));
 
-                            break;
-                        }
+                        break;
                     default:
-                        {
-                            v.Add(new Voltage("VCC", 0, 150, 150));
-                            for (int i = 1; i < superIO.Voltages.Length; i++)
-                                v.Add(new Voltage("Voltage #" + i, i, true));
+                        v.Add(new Voltage("VCC", 0, 150, 150));
+                        for (int i = 1; i < superIO.Voltages.Length; i++)
+                            v.Add(new Voltage("Voltage #" + i, i, true));
 
-                            t.Add(new Temperature("Temperature #1", 0));
-                            t.Add(new Temperature("Temperature #2", 1));
-                            if (superIO.Chip == (Chip)ChipSmbus.F75387)
-                                t.Add(new Temperature("Local", 2));
+                        t.Add(new Temperature("Temperature #1", 0));
+                        t.Add(new Temperature("Temperature #2", 1));
+                        if (superIO.Chip == (Chip)ChipSmbus.F75387)
+                            t.Add(new Temperature("Local", 2));
 
-                            for (int i = 0; i < superIO.Fans.Length; i++)
-                                f.Add(new Fan("Fan #" + (i + 1), i));
+                        for (int i = 0; i < superIO.Fans.Length; i++)
+                            f.Add(new Fan("Fan #" + (i + 1), i));
 
-                            for (int i = 0; i < superIO.Controls.Length; i++)
-                                c.Add(new Control("Fan #" + (i + 1), i));
+                        for (int i = 0; i < superIO.Controls.Length; i++)
+                            c.Add(new Control("Fan #" + (i + 1), i));
 
-                            break;
-                        }
+                        break;
                 }
                 break;
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2034,7 +2034,7 @@ internal sealed class SuperIOHardware : Hardware
                         v.Add(new Voltage("VCC3V", 0, 150, 150));
                         v.Add(new Voltage("CPU CORE", 1));
                         v.Add(new Voltage("GPU", 2));
-                        v.Add(new Voltage("+5V", 3, 51.06f, 12));
+                        v.Add(new Voltage("+5V", 3, 20, 4.7f));
                         v.Add(new Voltage("+12V", 4, 68, 6.8f));
                         v.Add(new Voltage("DRAM", 5, 150, 150));
                         v.Add(new Voltage("CPU I/O", 6));
@@ -2125,7 +2125,8 @@ internal sealed class SuperIOHardware : Hardware
 
                             t.Add(new Temperature("Temperature #1", 0));
                             t.Add(new Temperature("Temperature #2", 1));
-                            t.Add(new Temperature("Local", 2));
+                            if (superIO.Chip == (Chip)ChipSmbus.F75387)
+                                t.Add(new Temperature("Local", 2));
 
                             for (int i = 0; i < superIO.Fans.Length; i++)
                                 f.Add(new Fan("System Fan #" + (i + 3), i));
@@ -2143,7 +2144,8 @@ internal sealed class SuperIOHardware : Hardware
 
                             t.Add(new Temperature("Temperature #1", 0));
                             t.Add(new Temperature("Temperature #2", 1));
-                            t.Add(new Temperature("Local", 2));
+                            if (superIO.Chip == (Chip)ChipSmbus.F75387)
+                                t.Add(new Temperature("Local", 2));
 
                             for (int i = 0; i < superIO.Fans.Length; i++)
                                 f.Add(new Fan("Fan #" + (i + 1), i));
@@ -2163,7 +2165,8 @@ internal sealed class SuperIOHardware : Hardware
 
                 t.Add(new Temperature("Temperature #1", 0));
                 t.Add(new Temperature("Temperature #2", 1));
-                t.Add(new Temperature("Local", 2));
+                if (superIO.Chip == (Chip)ChipSmbus.F75387)
+                    t.Add(new Temperature("Local", 2));
 
                 for (int i = 0; i < superIO.Fans.Length; i++)
                     f.Add(new Fan("Fan #" + (i + 1), i));

--- a/LibreHardwareMonitorLib/Hardware/SMBusDevice.cs
+++ b/LibreHardwareMonitorLib/Hardware/SMBusDevice.cs
@@ -1,0 +1,179 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (C) LibreHardwareMonitor and Contributors.
+// Partial Copyright (C) Michael Möller <mmoeller@openhardwaremonitor.org> and Contributors.
+// All Rights Reserved.
+
+using System;
+using System.Threading;
+using LibreHardwareMonitor.Hardware.Motherboard.Lpc;
+
+namespace LibreHardwareMonitor.Hardware;
+
+internal class SmBusDevice
+{
+    public SmBusDevice(byte addr, ushort smb_addr)
+    {
+        CHIP_ADDRESS = addr;
+        SMB_ADDRESS = smb_addr;
+        SMBHSTSTS = (ushort)(0 + SMB_ADDRESS);
+        SMBHSTCNT = (ushort)(2 + SMB_ADDRESS);
+        SMBHSTCMD = (ushort)(3 + SMB_ADDRESS);
+        SMBHSTADD = (ushort)(4 + SMB_ADDRESS);
+        SMBHSTDAT0 = (ushort)(5 + SMB_ADDRESS);
+        SMBHSTDAT1 = (ushort)(6 + SMB_ADDRESS);
+        SMBAUXCTL = (ushort)(13 + SMB_ADDRESS);
+    }
+
+    public byte ChipAddr { get => CHIP_ADDRESS; }
+
+    public ushort SmBusAddr { get => SMB_ADDRESS; }
+
+    private int CheckPre()
+    {
+        ushort status = Ring0.ReadSmbus(SMBHSTSTS);
+        if ((status & SMBHSTSTS_HOST_BUSY) > 0)
+        {
+            return -1;
+        }
+
+        status &= STATUS_FLAGS;
+        if (status > 0)
+        {
+            Ring0.WriteSmbus(SMBHSTSTS, (byte)status);
+            status = (ushort)(Ring0.ReadSmbus(SMBHSTSTS) & STATUS_FLAGS);
+            if (status > 0)
+            {
+                return -1;
+            }
+        }
+        return 0;
+    }
+
+    private int WaitIntr()
+    {
+        const int maxCount = 1000;
+        int timeout = 0;
+        ushort status;
+        bool val;
+        bool val2;
+
+        do
+        {
+            status = Ring0.ReadSmbus(SMBHSTSTS);
+            val = (status & SMBHSTSTS_HOST_BUSY) > 0;
+            val2 = (status & (STATUS_ERROR_FLAGS | SMBHSTSTS_INTR)) > 0;
+
+        } while ((val || !val2) && timeout++ < maxCount);
+
+        if (timeout > maxCount)
+        {
+            return -1;
+        }
+        return status & (STATUS_ERROR_FLAGS | SMBHSTSTS_INTR);
+    }
+
+    private int CheckPost(int status)
+    {
+        if (status < 0)
+        {
+            Ring0.WriteSmbus(SMBHSTCNT, (byte)(Ring0.ReadSmbus(SMBHSTCNT) | SMBHSTCNT_KILL));
+            Thread.Sleep(1);
+            Ring0.WriteSmbus(SMBHSTCNT, (byte)(Ring0.ReadSmbus(SMBHSTCNT) & (~SMBHSTCNT_KILL)));
+
+            Ring0.WriteSmbus(SMBHSTSTS, (byte)STATUS_FLAGS);
+            return -1;
+        }
+
+        Ring0.WriteSmbus(SMBHSTSTS, (byte)status);
+
+        if ((status & SMBHSTSTS_FAILED) > 0 || (status & SMBHSTSTS_DEV_ERR) > 0 || (status & SMBHSTSTS_BUS_ERR) > 0)
+        {
+            return -1;
+        }
+
+        return 0;
+    }
+
+    private int Transaction(byte xact) // 0x0C WORD_DATA, 0x08 BYTE_DATA
+    {
+        int result = CheckPre();
+        if (result < 0)
+            return result;
+
+        Ring0.WriteSmbus(SMBHSTCNT, (byte)(Ring0.ReadSmbus(SMBHSTCNT) & ~SMBHSTCNT_INTREN));
+        Ring0.WriteSmbus(SMBHSTCNT, (byte)(xact | SMBHSTCNT_START));
+
+        int status = WaitIntr();
+
+        return CheckPost(status);
+    }
+
+    public byte ReadByte(byte register)
+    {
+        if (SMB_ADDRESS == 0 || CHIP_ADDRESS == 0)
+            return 0xFF;
+
+        Ring0.WriteSmbus(SMBHSTADD, (byte)(((CHIP_ADDRESS & 0x7f) << 1) | (SMB_READ & 0x01)));
+        Ring0.WriteSmbus(SMBHSTCMD, register);
+
+        Ring0.WriteSmbus(SMBAUXCTL, (byte)(Ring0.ReadSmbus(SMBAUXCTL) & (~SMBAUXCTL_CRC)));
+
+        Transaction(0x08);
+
+        Ring0.WriteSmbus(SMBAUXCTL, (byte)(Ring0.ReadSmbus(SMBAUXCTL) & ~(SMBAUXCTL_CRC | SMBAUXCTL_E32B)));
+
+        return Ring0.ReadSmbus(SMBHSTDAT0);
+    }
+
+    public void WriteByte(byte register, byte value)
+    {
+        if (SMB_ADDRESS == 0 || CHIP_ADDRESS == 0)
+            return;
+
+        Ring0.WriteSmbus(SMBHSTADD, (byte)(((CHIP_ADDRESS & 0x7f) << 1) | (SMB_WRITE & 0x01)));
+        Ring0.WriteSmbus(SMBHSTCMD, register);
+        Ring0.WriteSmbus(SMBHSTDAT0, value);
+
+        Ring0.WriteSmbus(SMBAUXCTL, (byte)(Ring0.ReadSmbus(SMBAUXCTL) & (~SMBAUXCTL_CRC)));
+
+        Transaction(0x08);
+
+        Ring0.WriteSmbus(SMBAUXCTL, (byte)(Ring0.ReadSmbus(SMBAUXCTL) & ~(SMBAUXCTL_CRC | SMBAUXCTL_E32B)));
+    }
+
+    private readonly ushort SMB_ADDRESS = 0;
+    private readonly byte CHIP_ADDRESS = 0;
+
+    private ushort SMBHSTSTS = 0;
+    private ushort SMBHSTCNT = 0;
+    private ushort SMBHSTCMD = 0;
+    private ushort SMBHSTADD = 0;
+    private ushort SMBHSTDAT0 = 0;
+    private ushort SMBHSTDAT1 = 0;
+    private ushort SMBAUXCTL = 0;
+
+    private const byte SMB_READ = 0x01;
+    private const byte SMB_WRITE = 0x00;
+
+    private static ushort SMBAUXCTL_CRC = (1 << 0);
+    private static ushort SMBAUXCTL_E32B = (1 << 1);
+
+    private static ushort SMBHSTCNT_INTREN = (1 << 0);
+    private static ushort SMBHSTCNT_KILL = (1 << 1);
+    //private static ushort SMBHSTCNT_LAST_BYTE = (1 << 5);
+    private static ushort SMBHSTCNT_START = (1 << 6);
+    //private static ushort SMBHSTCNT_PEC_EN = (1 << 7);
+
+    private static ushort SMBHSTSTS_BYTE_DONE = (1 << 7);
+    //private static ushort SMBHSTSTS_INUSE_STS = (1 << 6);
+    //private static ushort SMBHSTSTS_SMBALERT_STS = (1 << 5);
+    private static ushort SMBHSTSTS_FAILED = (1 << 4);
+    private static ushort SMBHSTSTS_BUS_ERR = (1 << 3);
+    private static ushort SMBHSTSTS_DEV_ERR = (1 << 2);
+    private static ushort SMBHSTSTS_INTR = (1 << 1);
+    private static ushort SMBHSTSTS_HOST_BUSY = (1 << 0);
+
+    private static ushort STATUS_ERROR_FLAGS = (ushort)(SMBHSTSTS_FAILED | SMBHSTSTS_BUS_ERR | SMBHSTSTS_DEV_ERR);
+    private static ushort STATUS_FLAGS = (ushort)(SMBHSTSTS_BYTE_DONE | SMBHSTSTS_INTR | STATUS_ERROR_FLAGS);
+}


### PR DESCRIPTION
Before:
![lhm_stock](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/assets/19557325/3b409148-26a2-4fc2-9aeb-17ca18192623)

After:
![lhm_z77_mpower](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/assets/19557325/5ced656a-59eb-4194-b64c-4faeac6bcb66)

The names match the names in the bios and MSI Control Center software.
Tested only on Z77 MPower (F71889AD + F75387), but should work on all MS-7751 boards with different revisions.
Also added support for F75373S and F75375S, but not tested.
