### PR TITLE
Add preliminary NCT6685D support

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
@@ -67,6 +67,7 @@ internal enum Chip : ushort
     NCT6686D = 0xD440,
     NCT6687D = 0xD592,
     NCT6683D = 0xC732,
+    NCT6685D = 0xC73A,
     NCT6799D = 0xD802,
 
     W83627DHG = 0xA020,
@@ -140,6 +141,7 @@ internal class ChipName
             case Chip.NCT6686D: return "Nuvoton NCT6686D";
             case Chip.NCT6687D: return "Nuvoton NCT6687D";
             case Chip.NCT6683D: return "Nuvoton NCT6683D";
+            case Chip.NCT6685D: return "Nuvoton NCT6685D";
 
             case Chip.W83627DHG: return "Winbond W83627DHG";
             case Chip.W83627DHGP: return "Winbond W83627DHG-P";

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
@@ -312,6 +312,10 @@ internal class LpcIO
                         chip = Chip.NCT6683D;
                         logicalDeviceNumber = WINBOND_NUVOTON_HARDWARE_MONITOR_LDN;
                         break;
+                    case 0x3a:
+                        chip = Chip.NCT6685D;
+                        logicalDeviceNumber = WINBOND_NUVOTON_HARDWARE_MONITOR_LDN;
+                        break;
                 }
 
                 break;
@@ -493,6 +497,7 @@ internal class LpcIO
                 case Chip.NCT6686D:
                 case Chip.NCT6687D:
                 case Chip.NCT6683D:
+                case Chip.NCT6685D:
                     _superIOs.Add(new Nct677X(chip, revision, address, port));
                     break;
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
@@ -69,7 +69,7 @@ internal class Nct677X : ISuperIO
 
             _vBatMonitorControlRegister = 0x0318;
         }
-        else if (chip is Chip.NCT6683D or Chip.NCT6686D or Chip.NCT6687D)
+        else if (chip is Chip.NCT6683D or Chip.NCT6685D or Chip.NCT6686D or Chip.NCT6687D)
         {
             FAN_PWM_OUT_REG = new ushort[] { 0x160, 0x161, 0x162, 0x163, 0x164, 0x165, 0x166, 0x167 };
             FAN_PWM_COMMAND_REG = new ushort[] { 0xA28, 0xA29, 0xA2A, 0xA2B, 0xA2C, 0xA2D, 0xA2E, 0xA2F };
@@ -263,6 +263,7 @@ internal class Nct677X : ISuperIO
                 break;
 
             case Chip.NCT6683D:
+            case Chip.NCT6685D:
             case Chip.NCT6686D:
             case Chip.NCT6687D:
                 Fans = new float?[8];
@@ -368,7 +369,7 @@ internal class Nct677X : ISuperIO
         {
             SaveDefaultFanControl(index);
 
-            if (Chip is not Chip.NCT6683D and not Chip.NCT6686D and not Chip.NCT6687D)
+            if (Chip is not Chip.NCT6683D and not Chip.NCT6685D and not Chip.NCT6686D and not Chip.NCT6687D)
             {
                 // set manual mode
                 WriteByte(FAN_CONTROL_MODE_REG[index], 0);
@@ -421,7 +422,7 @@ internal class Nct677X : ISuperIO
 
         for (int i = 0; i < Voltages.Length; i++)
         {
-            if (Chip is not Chip.NCT6683D and not Chip.NCT6686D and not Chip.NCT6687D)
+            if (Chip is not Chip.NCT6683D and not Chip.NCT6685D and not Chip.NCT6686D and not Chip.NCT6687D)
             {
                 float value = 0.008f * ReadByte(_voltageRegisters[i]);
                 bool valid = value > 0;
@@ -463,6 +464,7 @@ internal class Nct677X : ISuperIO
                 case Chip.NCT6687D:
                 case Chip.NCT6686D:
                 case Chip.NCT6683D:
+                case Chip.NCT6685D:
                     value = (sbyte)ReadByte(ts.Register);
                     int half = (ReadByte((ushort)(ts.Register + 1)) >> 7) & 0x1;
                     Temperatures[i] = value + (0.5f * half);
@@ -580,7 +582,7 @@ internal class Nct677X : ISuperIO
 
         for (int i = 0; i < Fans.Length; i++)
         {
-            if (Chip is not Chip.NCT6683D and not Chip.NCT6686D and not Chip.NCT6687D)
+            if (Chip is not Chip.NCT6683D and not Chip.NCT6685D and not Chip.NCT6686D and not Chip.NCT6687D)
             {
                 if (_fanCountRegister != null)
                 {
@@ -621,7 +623,7 @@ internal class Nct677X : ISuperIO
 
         for (int i = 0; i < Controls.Length; i++)
         {
-            if (Chip is not Chip.NCT6683D and not Chip.NCT6686D and not Chip.NCT6687D)
+            if (Chip is not Chip.NCT6683D and not Chip.NCT6685D and not Chip.NCT6686D and not Chip.NCT6687D)
             {
                 int value = ReadByte(FAN_PWM_OUT_REG[i]);
                 Controls[i] = value / 2.55f;
@@ -762,7 +764,7 @@ internal class Nct677X : ISuperIO
         r.AppendLine("        00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F");
         r.AppendLine();
 
-        if (Chip is not Chip.NCT6683D and not Chip.NCT6686D and not Chip.NCT6687D)
+        if (Chip is not Chip.NCT6683D and not Chip.NCT6685D and not Chip.NCT6686D and not Chip.NCT6687D)
         {
             foreach (ushort address in addresses)
             {
@@ -805,7 +807,7 @@ internal class Nct677X : ISuperIO
 
     private byte ReadByte(ushort address)
     {
-        if (Chip is not Chip.NCT6683D and not Chip.NCT6686D and not Chip.NCT6687D)
+        if (Chip is not Chip.NCT6683D and not Chip.NCT6685D and not Chip.NCT6686D and not Chip.NCT6687D)
         {
             byte bank = (byte)(address >> 8);
             byte register = (byte)(address & 0xFF);
@@ -825,7 +827,7 @@ internal class Nct677X : ISuperIO
 
     private void WriteByte(ushort address, byte value)
     {
-        if (Chip is not Chip.NCT6683D and not Chip.NCT6686D and not Chip.NCT6687D)
+        if (Chip is not Chip.NCT6683D and not Chip.NCT6685D and not Chip.NCT6686D and not Chip.NCT6687D)
         {
             byte bank = (byte)(address >> 8);
             byte register = (byte)(address & 0xFF);
@@ -847,14 +849,14 @@ internal class Nct677X : ISuperIO
 
     private bool IsNuvotonVendor()
     {
-        return Chip is Chip.NCT6683D or Chip.NCT6686D or Chip.NCT6687D || ((ReadByte(VENDOR_ID_HIGH_REGISTER) << 8) | ReadByte(VENDOR_ID_LOW_REGISTER)) == NUVOTON_VENDOR_ID;
+        return Chip is Chip.NCT6683D or Chip.NCT6685D or Chip.NCT6686D or Chip.NCT6687D || ((ReadByte(VENDOR_ID_HIGH_REGISTER) << 8) | ReadByte(VENDOR_ID_LOW_REGISTER)) == NUVOTON_VENDOR_ID;
     }
 
     private void SaveDefaultFanControl(int index)
     {
         if (!_restoreDefaultFanControlRequired[index])
         {
-            if (Chip is not Chip.NCT6683D and not Chip.NCT6686D and not Chip.NCT6687D)
+            if (Chip is not Chip.NCT6683D and not Chip.NCT6685D and not Chip.NCT6686D and not Chip.NCT6687D)
             {
                 _initialFanControlMode[index] = ReadByte(FAN_CONTROL_MODE_REG[index]);
             }
@@ -874,7 +876,7 @@ internal class Nct677X : ISuperIO
     {
         if (_restoreDefaultFanControlRequired[index])
         {
-            if (Chip is not Chip.NCT6683D and not Chip.NCT6686D and not Chip.NCT6687D)
+            if (Chip is not Chip.NCT6683D and not Chip.NCT6685D and not Chip.NCT6686D and not Chip.NCT6687D)
             {
                 WriteByte(FAN_CONTROL_MODE_REG[index], _initialFanControlMode[index]);
                 WriteByte(FAN_PWM_COMMAND_REG[index], _initialFanPwmCommand[index]);

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -352,6 +352,7 @@ internal sealed class SuperIOHardware : Hardware
             case Chip.NCT6798D:
             case Chip.NCT6799D:
             case Chip.NCT6683D:
+            case Chip.NCT6685D:
                 GetNuvotonConfigurationD(superIO, manufacturer, model, v, t, f, c);
                 break;
 


### PR DESCRIPTION
This SuperIO chip is seen on MSI infinite S 9th gaming PCs.

NCT6685D is identical to NCT6683D.

Due to the lack of documentation on the motherboard B9181 and NCT6685D, the "Voltages" information is currently incorrect. Nevertheless, this patch gives correct fan speed info and is able to control the fan speed.

<img src="https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/assets/1687847/14067125-b898-4d42-9446-bd92f9ebc009">
