### PR TITLE
Add support for Gigabyte B75M-D3H

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -248,6 +248,8 @@ internal class Identification
                 return Model.H67A_USB3_B3;
             case var _ when name.Equals("H81M-HD3", StringComparison.OrdinalIgnoreCase):
                 return Model.H81M_HD3;
+            case var _ when name.Equals("B75M-D3H", StringComparison.OrdinalIgnoreCase):
+                return Model.B75M_D3H;
             case var _ when name.Equals("P35-DS3", StringComparison.OrdinalIgnoreCase):
                 return Model.P35_DS3;
             case var _ when name.Equals("P35-DS3L", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -133,6 +133,7 @@ public enum Model
     H67A_UD3H_B3,
     H67A_USB3_B3,
     H81M_HD3,
+    B75M_D3H,
     MA770T_UD3,
     MA770T_UD3P,
     MA785GM_US2H,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1157,6 +1157,25 @@ internal sealed class SuperIOHardware : Hardware
 
                         break;
 
+                    case Model.B75M_D3H: // IT8728F
+                        v.Add(new Voltage("VTT", 0));
+                        v.Add(new Voltage("+3.3V", 1, 6.49f, 10));
+                        v.Add(new Voltage("+5V", 3, 15, 10));
+                        v.Add(new Voltage("+12V", 2, 10, 2));
+                        v.Add(new Voltage("iGPU VAXG", 4));
+                        v.Add(new Voltage("Vcore", 5));
+                        v.Add(new Voltage("DIMM", 6));
+                        v.Add(new Voltage("3VSB", 7, 10, 10));
+                        v.Add(new Voltage("VBat", 8, 10, 10));
+                        t.Add(new Temperature("System", 0));
+                        t.Add(new Temperature("CPU", 2));
+                        f.Add(new Fan("CPU Fan", 0));
+                        f.Add(new Fan("System Fan", 1));
+                        c.Add(new Control("CPU Fan", 2));
+                        c.Add(new Control("System Fan", 1));
+
+                        break;
+
                     case Model.H81M_HD3: //IT8620E
                         v.Add(new Voltage("Vcore", 0));
                         v.Add(new Voltage("Voltage #2", 1, true));


### PR DESCRIPTION
![image](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/assets/29529557/04f5f939-8e48-4610-80ae-f4fec2cd971a)

Compared with HWiNFO this additionally gets +5V reading. I'm unsure if `iGPU VAXG` is correct tho, I only added it because HWiNFO had it.