### PR TITLE
Add MS-7672 and MS-7757 boards

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -285,7 +285,14 @@ internal class Identification
             case var _ when name.Equals("Z77A-GD65 GAMING (MS-7751)", StringComparison.OrdinalIgnoreCase):
             case var _ when name.Equals("Z77A-GD55", StringComparison.OrdinalIgnoreCase):        // MS-7751 Rev 1.x
             case var _ when name.Equals("Z77A-GD55 (MS-7751)", StringComparison.OrdinalIgnoreCase):
+            case var _ when name.Equals("Z77A-GD80", StringComparison.OrdinalIgnoreCase):
+            case var _ when name.Equals("Z77A-GD80 (MS-7757)", StringComparison.OrdinalIgnoreCase):
                 return Model.Z77_MS7751;
+            case var _ when name.Equals("Z68A-GD80", StringComparison.OrdinalIgnoreCase):
+            case var _ when name.Equals("Z68A-GD80 (MS-7672)", StringComparison.OrdinalIgnoreCase):
+            case var _ when name.Equals("P67A-GD80", StringComparison.OrdinalIgnoreCase):
+            case var _ when name.Equals("P67A-GD80 (MS-7672)", StringComparison.OrdinalIgnoreCase):
+                return Model.Z68_MS7672;
             case var _ when name.Equals("X79-UD3", StringComparison.OrdinalIgnoreCase):
                 return Model.X79_UD3;
             case var _ when name.Equals("Z68A-D3H-B3", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -104,6 +104,7 @@ public enum Model
     B450A_PRO,
     Z270_PC_MATE,
     Z77_MS7751,
+    Z68_MS7672,
 
     // EVGA
     X58_SLI_Classified,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2042,6 +2042,7 @@ internal sealed class SuperIOHardware : Hardware
                 switch (model)
                 {
                     case Model.Z77_MS7751: // F71889AD
+                    case Model.Z68_MS7672: // F71889AD
                         v.Add(new Voltage("VCC3V", 0, 150, 150));
                         v.Add(new Voltage("Vcore", 1));
                         v.Add(new Voltage("iGPU", 2));


### PR DESCRIPTION
MS-7672 also like a Z77 MPower have F75388SG chip. I have a code that already tested (my master branch), but it won't work without smbus support.

These boards are not tested irl, but it works like a MS-7751 and have the same hardware. I used schematics and boardview.