### PR TITLE
fix: Battery info Capabilities is a bit flag field

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Battery/BatteryGroup.cs
+++ b/LibreHardwareMonitorLib/Hardware/Battery/BatteryGroup.cs
@@ -91,7 +91,7 @@ internal class BatteryGroup : IGroup
                                                                  IntPtr.Zero))
                                     {
                                         // Only batteries count.
-                                        if (bi.Capabilities == Kernel32.BatteryCapabilities.BATTERY_SYSTEM_BATTERY)
+                                        if (0 != (bi.Capabilities & Kernel32.BatteryCapabilities.BATTERY_SYSTEM_BATTERY))
                                         {
                                             const int maxLoadString = 100;
 

--- a/LibreHardwareMonitorLib/Hardware/Battery/BatteryGroup.cs
+++ b/LibreHardwareMonitorLib/Hardware/Battery/BatteryGroup.cs
@@ -91,7 +91,7 @@ internal class BatteryGroup : IGroup
                                                                  IntPtr.Zero))
                                     {
                                         // Only batteries count.
-                                        if (0 != (bi.Capabilities & Kernel32.BatteryCapabilities.BATTERY_SYSTEM_BATTERY))
+                                        if (bi.Capabilities.HasFlag(Kernel32.BatteryCapabilities.BATTERY_SYSTEM_BATTERY))
                                         {
                                             const int maxLoadString = 100;
 


### PR DESCRIPTION
Capabilities is actually a bit flags field, but was incorrectly compared by equal operator. This led to battery device been filtered out.
See https://learn.microsoft.com/en-us/windows/win32/power/battery-information-str#members

Fixed an issue of missing battery info on Robo&Kala Windows on Arm tablet.

<img width="326" alt="image" src="https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/assets/24409942/cf91eba8-e904-4f7d-af96-074cd85ca4c2">
