### PR TITLE
Feat: Average sensor value

### DIFF
--- a/LibreHardwareMonitor/UI/MainForm.Designer.cs
+++ b/LibreHardwareMonitor/UI/MainForm.Designer.cs
@@ -380,7 +380,7 @@ namespace LibreHardwareMonitor.UI
             // 
             this.resetMinMaxMenuItem.Name = "resetMinMaxMenuItem";
             this.resetMinMaxMenuItem.Size = new System.Drawing.Size(188, 22);
-            this.resetMinMaxMenuItem.Text = "Reset Min/Max";
+            this.resetMinMaxMenuItem.Text = "Reset Min/Max/Average";
             this.resetMinMaxMenuItem.Click += new System.EventHandler(this.ResetMinMaxMenuItem_Click);
             // 
             // resetPlotMenuItem

--- a/LibreHardwareMonitor/UI/MainForm.Designer.cs
+++ b/LibreHardwareMonitor/UI/MainForm.Designer.cs
@@ -40,12 +40,14 @@ namespace LibreHardwareMonitor.UI
             this.value = new Aga.Controls.Tree.TreeColumn();
             this.min = new Aga.Controls.Tree.TreeColumn();
             this.max = new Aga.Controls.Tree.TreeColumn();
+            this.average = new Aga.Controls.Tree.TreeColumn();
             this.nodeImage = new Aga.Controls.Tree.NodeControls.NodeIcon();
             this.nodeCheckBox = new Aga.Controls.Tree.NodeControls.NodeCheckBox();
             this.nodeTextBoxText = new Aga.Controls.Tree.NodeControls.NodeTextBox();
             this.nodeTextBoxValue = new Aga.Controls.Tree.NodeControls.NodeTextBox();
             this.nodeTextBoxMin = new Aga.Controls.Tree.NodeControls.NodeTextBox();
             this.nodeTextBoxMax = new Aga.Controls.Tree.NodeControls.NodeTextBox();
+            this.nodeTextBoxAverage = new Aga.Controls.Tree.NodeControls.NodeTextBox();
             this.mainMenu = new System.Windows.Forms.MenuStrip();
             this.fileMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveReportMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -74,6 +76,7 @@ namespace LibreHardwareMonitor.UI
             this.valueMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.minMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.maxMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.averageMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.optionsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.startMinMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.minTrayMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -171,6 +174,13 @@ namespace LibreHardwareMonitor.UI
             this.max.TooltipText = null;
             this.max.Width = 100;
             // 
+            // average
+            // 
+            this.average.Header = "Average";
+            this.average.SortOrder = System.Windows.Forms.SortOrder.None;
+            this.average.TooltipText = null;
+            this.average.Width = 100;
+            // 
             // nodeImage
             // 
             this.nodeImage.DataPropertyName = "Image";
@@ -221,6 +231,15 @@ namespace LibreHardwareMonitor.UI
             this.nodeTextBoxMax.ParentColumn = this.max;
             this.nodeTextBoxMax.Trimming = System.Drawing.StringTrimming.EllipsisCharacter;
             this.nodeTextBoxMax.UseCompatibleTextRendering = true;
+            // 
+            // nodeTextBoxAverage
+            // 
+            this.nodeTextBoxAverage.DataPropertyName = "Average";
+            this.nodeTextBoxAverage.IncrementalSearchEnabled = true;
+            this.nodeTextBoxAverage.LeftMargin = 3;
+            this.nodeTextBoxAverage.ParentColumn = this.average;
+            this.nodeTextBoxAverage.Trimming = System.Drawing.StringTrimming.EllipsisCharacter;
+            this.nodeTextBoxAverage.UseCompatibleTextRendering = true;
             // 
             // mainMenu
             // 
@@ -404,7 +423,8 @@ namespace LibreHardwareMonitor.UI
             this.columnsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.valueMenuItem,
             this.minMenuItem,
-            this.maxMenuItem});
+            this.maxMenuItem,
+            this.averageMenuItem});
             this.columnsMenuItem.Name = "columnsMenuItem";
             this.columnsMenuItem.Size = new System.Drawing.Size(188, 22);
             this.columnsMenuItem.Text = "Columns";
@@ -426,6 +446,12 @@ namespace LibreHardwareMonitor.UI
             this.maxMenuItem.Name = "maxMenuItem";
             this.maxMenuItem.Size = new System.Drawing.Size(180, 22);
             this.maxMenuItem.Text = "Max";
+            // 
+            //  averageMenuItem
+            // 
+            this.averageMenuItem.Name = " averageMenuItem";
+            this.averageMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.averageMenuItem.Text = "Average";
             // 
             // optionsMenuItem
             // 
@@ -902,6 +928,7 @@ namespace LibreHardwareMonitor.UI
             this.treeView.Columns.Add(this.value);
             this.treeView.Columns.Add(this.min);
             this.treeView.Columns.Add(this.max);
+            this.treeView.Columns.Add(this.average);
             this.treeView.DefaultToolTipProvider = null;
             this.treeView.Dock = System.Windows.Forms.DockStyle.Fill;
             this.treeView.DragDropMarkColor = System.Drawing.Color.Black;
@@ -917,6 +944,7 @@ namespace LibreHardwareMonitor.UI
             this.treeView.NodeControls.Add(this.nodeTextBoxValue);
             this.treeView.NodeControls.Add(this.nodeTextBoxMin);
             this.treeView.NodeControls.Add(this.nodeTextBoxMax);
+            this.treeView.NodeControls.Add(this.nodeTextBoxAverage);
             this.treeView.SelectedNode = null;
             this.treeView.Size = new System.Drawing.Size(386, 354);
             this.treeView.TabIndex = 0;
@@ -969,11 +997,13 @@ namespace LibreHardwareMonitor.UI
         private Aga.Controls.Tree.TreeColumn value;
         private Aga.Controls.Tree.TreeColumn min;
         private Aga.Controls.Tree.TreeColumn max;
+        private Aga.Controls.Tree.TreeColumn average;
         private Aga.Controls.Tree.NodeControls.NodeIcon nodeImage;
         private Aga.Controls.Tree.NodeControls.NodeTextBox nodeTextBoxText;
         private Aga.Controls.Tree.NodeControls.NodeTextBox nodeTextBoxValue;
         private Aga.Controls.Tree.NodeControls.NodeTextBox nodeTextBoxMin;
         private Aga.Controls.Tree.NodeControls.NodeTextBox nodeTextBoxMax;
+        private Aga.Controls.Tree.NodeControls.NodeTextBox nodeTextBoxAverage;
         private SplitContainerAdv splitContainer;
         private System.Windows.Forms.ToolStripMenuItem viewMenuItem;
         private System.Windows.Forms.ToolStripMenuItem plotMenuItem;
@@ -996,6 +1026,7 @@ namespace LibreHardwareMonitor.UI
         private System.Windows.Forms.ToolStripMenuItem valueMenuItem;
         private System.Windows.Forms.ToolStripMenuItem minMenuItem;
         private System.Windows.Forms.ToolStripMenuItem maxMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem averageMenuItem;
         private System.Windows.Forms.ToolStripMenuItem temperatureUnitsMenuItem;
         private System.Windows.Forms.ToolStripSeparator webMenuItemSeparator;
         private ToolStripRadioButtonMenuItem celsiusMenuItem;

--- a/LibreHardwareMonitor/UI/MainForm.cs
+++ b/LibreHardwareMonitor/UI/MainForm.cs
@@ -1101,6 +1101,7 @@ public sealed partial class MainForm : Form
         {
             sensorClick.ResetMin();
             sensorClick.ResetMax();
+            sensorClick.ResetAverage();
         }));
     }
 

--- a/LibreHardwareMonitor/UI/MainForm.cs
+++ b/LibreHardwareMonitor/UI/MainForm.cs
@@ -95,6 +95,7 @@ public sealed partial class MainForm : Form
         nodeTextBoxValue.DrawText += NodeTextBoxText_DrawText;
         nodeTextBoxMin.DrawText += NodeTextBoxText_DrawText;
         nodeTextBoxMax.DrawText += NodeTextBoxText_DrawText;
+        nodeTextBoxAverage.DrawText += NodeTextBoxText_DrawText;
         nodeTextBoxText.EditorShowing += NodeTextBoxText_EditorShowing;
 
         foreach (TreeColumn column in treeView.Columns)
@@ -174,6 +175,9 @@ public sealed partial class MainForm : Form
 
         UserOption showMax = new("maxMenuItem", true, maxMenuItem, _settings);
         showMax.Changed += delegate { treeView.Columns[3].IsVisible = showMax.Value; };
+
+        UserOption showAverage = new("averageMenuItem", true, averageMenuItem, _settings);
+        showAverage.Changed += delegate { treeView.Columns[4].IsVisible = showAverage.Value; };
 
         var _ = new UserOption("startMinMenuItem", false, startMinMenuItem, _settings);
         _minimizeToTray = new UserOption("minTrayMenuItem", true, minTrayMenuItem, _settings);

--- a/LibreHardwareMonitor/UI/SensorNode.cs
+++ b/LibreHardwareMonitor/UI/SensorNode.cs
@@ -117,6 +117,11 @@ public class SensorNode : Node
         get { return ValueToString(Sensor.Min); }
     }
 
+    public string Average
+    {
+        get { return ValueToString(Sensor.Average); }
+    }
+
     public Color? PenColor
     {
         get { return _penColor; }

--- a/LibreHardwareMonitor/Utilities/HttpServer.cs
+++ b/LibreHardwareMonitor/Utilities/HttpServer.cs
@@ -560,7 +560,8 @@ public class HttpServer
             ["Text"] = n.Text,
             ["Min"] = string.Empty,
             ["Value"] = string.Empty,
-            ["Max"] = string.Empty
+            ["Max"] = string.Empty,
+            ["Average"] = string.Empty
         };
 
         if (n is SensorNode sensorNode)
@@ -570,6 +571,7 @@ public class HttpServer
             jsonNode["Min"] = sensorNode.Min;
             jsonNode["Value"] = sensorNode.Value;
             jsonNode["Max"] = sensorNode.Max;
+            jsonNode["Average"] = sensorNode.Average;
             jsonNode["ImageURL"] = "images/transparent.png";
         }
         else if (n is HardwareNode hardwareNode)

--- a/LibreHardwareMonitorLib/Hardware/ISensor.cs
+++ b/LibreHardwareMonitorLib/Hardware/ISensor.cs
@@ -90,6 +90,11 @@ public interface ISensor : IElement
     float? Min { get; }
 
     /// <summary>
+    /// Gets an average value recorded for the given sensor.
+    /// </summary>
+    float? Average { get; }
+
+    /// <summary>
     /// Gets or sets a sensor name.
     /// <para>By default determined by the library.</para>
     /// </summary>

--- a/LibreHardwareMonitorLib/Hardware/ISensor.cs
+++ b/LibreHardwareMonitorLib/Hardware/ISensor.cs
@@ -130,6 +130,11 @@ public interface ISensor : IElement
     void ResetMax();
 
     /// <summary>
+    /// Resets calculated Average <see cref="Average"/>.
+    /// </summary>
+    void ResetAverage();
+
+    /// <summary>
     /// Clears the values stored in <see cref="Values"/>.
     /// </summary>
     void ClearValues();

--- a/LibreHardwareMonitorLib/Hardware/Sensor.cs
+++ b/LibreHardwareMonitorLib/Hardware/Sensor.cs
@@ -246,7 +246,7 @@ internal class Sensor : ISensor
                             break;
 
                         float value = reader.ReadSingle();
-                        AppendValue(value, time);
+                        AppendValue(value, time, false);
                         readLen = reader.BaseStream.Length - reader.BaseStream.Position;
                     }
                 }
@@ -266,14 +266,15 @@ internal class Sensor : ISensor
         _settings.Remove(name);
     }
 
-    private void AppendValue(float value, DateTime time)
+    private void AppendValue(float value, DateTime time, bool updateAverage = true)
     {
         if (_values.Count >= 2 && _values[_values.Count - 1].Value == value && _values[_values.Count - 2].Value == value)
             _values[_values.Count - 1] = new SensorValue(value, time);
         else
             _values.Add(new SensorValue(value, time));
 
-        Average = EstimateAverage();
+        if(updateAverage)
+            Average = EstimateAverage();
     }
 
     /// <summary>

--- a/LibreHardwareMonitorLib/Hardware/Sensor.cs
+++ b/LibreHardwareMonitorLib/Hardware/Sensor.cs
@@ -44,9 +44,12 @@ internal class Sensor : ISensor
             if (_lastTime.HasValue)
             {
                 var delta = time - _lastTime.Value;
-                var weighted = _sum * _timeSpan.TotalSeconds + (_lastValue + value) * delta.TotalSeconds / 2;
-                _timeSpan += delta;
-                _sum = weighted / _timeSpan.TotalSeconds;
+                if (delta.TotalSeconds > 0) // can be negative if system time changed
+                {
+                    var weighted = _sum * _timeSpan.TotalSeconds + (_lastValue + value) * delta.TotalSeconds / 2;
+                    _timeSpan += delta;
+                    _sum = weighted / _timeSpan.TotalSeconds;
+                }
             }
             else
             {

--- a/LibreHardwareMonitorLib/Hardware/Sensor.cs
+++ b/LibreHardwareMonitorLib/Hardware/Sensor.cs
@@ -92,6 +92,8 @@ internal class Sensor : ISensor
 
     public float? Min { get; private set; }
 
+    public float? Average { get; private set; }
+
     public string Name
     {
         get { return _name; }
@@ -155,7 +157,7 @@ internal class Sensor : ISensor
         {
             _valuesTimeWindow = value;
             if (value == TimeSpan.Zero)
-                _values.Clear();
+                ClearValues();
         }
     }
 
@@ -172,6 +174,7 @@ internal class Sensor : ISensor
     public void ClearValues()
     {
         _values.Clear();
+        Average = null;
     }
 
     public void Accept(IVisitor visitor)
@@ -266,11 +269,64 @@ internal class Sensor : ISensor
     private void AppendValue(float value, DateTime time)
     {
         if (_values.Count >= 2 && _values[_values.Count - 1].Value == value && _values[_values.Count - 2].Value == value)
-        {
             _values[_values.Count - 1] = new SensorValue(value, time);
-            return;
-        }
+        else
+            _values.Add(new SensorValue(value, time));
 
-        _values.Add(new SensorValue(value, time));
+        Average = EstimateAverage();
+    }
+
+    /// <summary>
+    /// Estimate average value of time series.
+    /// Updated every 4 measurements, since Sensor code performs basic filtering by averaging every 4 values.
+    /// Does not respect Mix/Max reset, but we can add it by introducing cutoff timestamp, or integrating as we go instead
+    /// (latter will also require much less computations: we will only update the last average value).
+    /// </summary>
+    /// <param name = "lastPeriodOnly">Only average values the last application launch (till first break in histroy)</param>
+    /// <returns>Estimated average</returns>
+    private float? EstimateAverage(bool lastPeriodOnly = true)
+    {
+        if (_values.Count < 1)
+            return null;
+
+        if(_values.Count == 1)
+            return float.IsNaN(_values[0].Value) ? null : _values[0].Value;
+
+        // Lame unequal time intervals time series average.
+        // Basically counts total area of trapezoids between adjacent points and norms it by total time.
+        // Not very correct, but good enough for the purpose.
+        var totalTime = TimeSpan.Zero;
+        var totalAverage = 0.0;
+        for (var i = _values.Count - 1; i >= 1; --i)
+        {
+            var left = _values[i - 1];
+            var right = _values[i];
+            if (float.IsNaN(left.Value))
+            {
+                if (!lastPeriodOnly)
+                    continue;
+                else
+                {
+                    // End of period since last restart, stop.
+                    if (0.0 == totalTime.TotalSeconds)
+                        // We only have one new value since last restart
+                        return float.IsNaN(right.Value) ? null : right.Value;
+                    break;
+                }
+            }
+
+            if (float.IsNaN(right.Value))
+                continue; // Start of period, ignore for now (should not happen now since we average only last period)
+
+            var delta = right.Time - left.Time;
+
+            if (delta.TotalSeconds <= 0.0)
+                continue; // Should not happen, but just in case. Project in general will have issues if system time changes.
+
+            totalAverage += (left.Value + right.Value) * delta.TotalSeconds / 2;
+            totalTime += delta;
+        }
+        totalAverage /= totalTime.TotalSeconds;
+        return (float)totalAverage;
     }
 }


### PR DESCRIPTION
Average sensor value calculation using basic continuous integration (not that one).
It's aligned to the current Min/Max values behavior, which is seems to be expected now (i.e. values are preserved since last app start/reset even if the original event is not in the timeline history anymore).

Known issues:
- calculates averages values for parameters that do not make physical sense (like accumulated totals for traffic, etc.). We can filter these out if needed.
- does not handle system time change in a nice way (plots will not handle it properly too, though).

![image](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/assets/24409942/654369d4-3922-4534-ad7c-72852bf1d944)

Form was edited from code, since I can't open form editor (need to run IDE in x86 mode or something, probably).

Comments welcome.

#967