### PR TITLE
Fix support for Nvidia and Battery when running as a 32-bit process

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Battery/BatteryGroup.cs
+++ b/LibreHardwareMonitorLib/Hardware/Battery/BatteryGroup.cs
@@ -52,7 +52,7 @@ internal class BatteryGroup : IGroup
                     if (Marshal.GetLastWin32Error() == SetupApi.ERROR_INSUFFICIENT_BUFFER)
                     {
                         IntPtr pdidd = Kernel32.LocalAlloc(Kernel32.LPTR, cbRequired);
-                        Marshal.WriteInt32(pdidd, Environment.Is64BitOperatingSystem ? 8 : 4); // cbSize.
+                        Marshal.WriteInt32(pdidd, Environment.Is64BitProcess ? 8 : 4 + Marshal.SystemDefaultCharSize); // cbSize.
 
                         if (SetupApi.SetupDiGetDeviceInterfaceDetail(hdev,
                                                                      did,

--- a/LibreHardwareMonitorLib/Interop/NvApi.cs
+++ b/LibreHardwareMonitorLib/Interop/NvApi.cs
@@ -218,7 +218,7 @@ internal static class NvApi
 
     private static void GetDelegate<T>(uint id, out T newDelegate) where T : class
     {
-        IntPtr ptr = Environment.Is64BitOperatingSystem ? NvAPI64_QueryInterface(id) : NvAPI32_QueryInterface(id);
+        IntPtr ptr = Environment.Is64BitProcess ? NvAPI64_QueryInterface(id) : NvAPI32_QueryInterface(id);
 
         if (ptr != IntPtr.Zero)
             newDelegate = Marshal.GetDelegateForFunctionPointer(ptr, typeof(T)) as T;
@@ -228,7 +228,7 @@ internal static class NvApi
 
     public static bool DllExists()
     {
-        IntPtr module = Kernel32.LoadLibrary(Environment.Is64BitOperatingSystem ? DllName64 : DllName);
+        IntPtr module = Kernel32.LoadLibrary(Environment.Is64BitProcess ? DllName64 : DllName);
         if (module == IntPtr.Zero)
             return false;
 


### PR DESCRIPTION
This PR fixes two issues related to LibreHardwareMonitorLib running as a 32-bit process:
- Nvidia GPU support would not work when the process ran through Windows x86 emulation on a 64-bit machine.
- Battery monitoring would not work on native or emulated 32-bit machines.

For the Nvidia case, the app must load the correct NvAPI DLL depending on if the application is running as a 32- or 64-bit process. Nvidia ships both versions of the DLL for their drivers on 64-bit Windows, so this change allows for maximum compatibility.

This issue was encounter by myself and by another user as reported here:
https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/issues/987

Nvidia support used to work on x86 emulation but was broken in this commit when the `DLLExists()` function was added.
https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/commit/47f33f91d9e9cbf8e39d794826c551747839869b
There wasn't much context provided in this commit so I can't be sure if these changes were intentional to fix some _other_ issue that I haven't encountered. If there are other edge cases, let me know and I'm happy to look into them.

For the Battery fix, the call to `SetupDiGetDeviceInterfaceDetail` expects a `cbSize` value of 8 on 64-bit machines and 4 + 2 on 32-bit machines using Unicode. Here are some references discussing this:
https://stackoverflow.com/a/9247377/15588729
http://www.janaxelson.com/forum/index.php?topic=656.0

I verified the following cases with these changes:
- 64-bit process running on a 64-bit OS
- 32-bit process running on a 64-bit OS
- 32-bit process running on a 32-bit OS

Here is a screenshot showing an RTX GPU working with these changes. The left window is a 32-bit process, which would not show the GPU at all without these changes. The right window is a 64-bit process. Note there are differences in the supported sensors because NvidiaML does _not_ support 32-bit.

![libre x86 on left](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/assets/3517846/607ad689-9ac8-4d57-b933-ce34076462e7)
