### PR TITLE
Attached plot panel fixed width plot or sensor panel 

### DIFF
--- a/LibreHardwareMonitor/UI/MainForm.Designer.cs
+++ b/LibreHardwareMonitor/UI/MainForm.Designer.cs
@@ -87,10 +87,10 @@ namespace LibreHardwareMonitor.UI
             this.plotWindowMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
             this.plotBottomMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
             this.plotRightMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
-            this.attachedPlotPanelScalingMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.attachedPanelPercentageScalingMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
-            this.attachedPanelFixedWidthPlotScalingMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
-            this.attachedPanelFixedWidthSensorScalingMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.splitPlotPanelScalingMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.splitPanelPercentageScalingMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.splitPanelFixedPlotScalingMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.splitPanelFixedSensorScalingMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
             this.logSeparatorMenuItem = new System.Windows.Forms.ToolStripSeparator();
             this.logSensorsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.loggingIntervalMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -441,7 +441,7 @@ namespace LibreHardwareMonitor.UI
             this.separatorMenuItem,
             this.temperatureUnitsMenuItem,
             this.plotLocationMenuItem,
-            this.attachedPlotPanelScalingMenuItem,
+            this.splitPlotPanelScalingMenuItem,
             this.logSeparatorMenuItem,
             this.logSensorsMenuItem,
             this.loggingIntervalMenuItem,
@@ -540,34 +540,34 @@ namespace LibreHardwareMonitor.UI
             // 
             // attachedPlotPanelScalingMenuItem
             // 
-            this.attachedPlotPanelScalingMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.attachedPanelPercentageScalingMenuItem,
-            this.attachedPanelFixedWidthPlotScalingMenuItem,
-            this.attachedPanelFixedWidthSensorScalingMenuItem});
-            this.attachedPlotPanelScalingMenuItem.Name = "attachedPlotPanelScalingMenuItem";
-            this.attachedPlotPanelScalingMenuItem.Size = new System.Drawing.Size(221, 22);
-            this.attachedPlotPanelScalingMenuItem.Text = "Attached plot panel scaling mode";
+            this.splitPlotPanelScalingMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.splitPanelPercentageScalingMenuItem,
+            this.splitPanelFixedPlotScalingMenuItem,
+            this.splitPanelFixedSensorScalingMenuItem});
+            this.splitPlotPanelScalingMenuItem.Name = "attachedPlotPanelScalingMenuItem";
+            this.splitPlotPanelScalingMenuItem.Size = new System.Drawing.Size(221, 22);
+            this.splitPlotPanelScalingMenuItem.Text = "Split Panel Scaling Mode";
             // 
             // attachedPanelPercentageScalingMenuItem
             // 
-            this.attachedPanelPercentageScalingMenuItem.CheckOnClick = true;
-            this.attachedPanelPercentageScalingMenuItem.Name = "attachedPlotPanelPercentageScalingMenuItem";
-            this.attachedPanelPercentageScalingMenuItem.Size = new System.Drawing.Size(118, 22);
-            this.attachedPanelPercentageScalingMenuItem.Text = "Percentage scaling";
+            this.splitPanelPercentageScalingMenuItem.CheckOnClick = true;
+            this.splitPanelPercentageScalingMenuItem.Name = "attachedPlotPanelPercentageScalingMenuItem";
+            this.splitPanelPercentageScalingMenuItem.Size = new System.Drawing.Size(118, 22);
+            this.splitPanelPercentageScalingMenuItem.Text = "Percentage Scaling";
             // 
             // attachedPanelFixedWidthPlotPanelScalingMenuItem
             // 
-            this.attachedPanelFixedWidthPlotScalingMenuItem.CheckOnClick = true;
-            this.attachedPanelFixedWidthPlotScalingMenuItem.Name = "attachedBottomMenuItem";
-            this.attachedPanelFixedWidthPlotScalingMenuItem.Size = new System.Drawing.Size(118, 22);
-            this.attachedPanelFixedWidthPlotScalingMenuItem.Text = "Fixed width plot panel";
+            this.splitPanelFixedPlotScalingMenuItem.CheckOnClick = true;
+            this.splitPanelFixedPlotScalingMenuItem.Name = "attachedBottomMenuItem";
+            this.splitPanelFixedPlotScalingMenuItem.Size = new System.Drawing.Size(118, 22);
+            this.splitPanelFixedPlotScalingMenuItem.Text = "Fixed Size Plot Panel";
             // 
             // attachedPanelFixedWidthSensorPanelScalingMenuItem
             // 
-            this.attachedPanelFixedWidthSensorScalingMenuItem.CheckOnClick = true;
-            this.attachedPanelFixedWidthSensorScalingMenuItem.Name = "attachedRightMenuItem";
-            this.attachedPanelFixedWidthSensorScalingMenuItem.Size = new System.Drawing.Size(118, 22);
-            this.attachedPanelFixedWidthSensorScalingMenuItem.Text = "Fixed width sensor panel";
+            this.splitPanelFixedSensorScalingMenuItem.CheckOnClick = true;
+            this.splitPanelFixedSensorScalingMenuItem.Name = "attachedRightMenuItem";
+            this.splitPanelFixedSensorScalingMenuItem.Size = new System.Drawing.Size(118, 22);
+            this.splitPanelFixedSensorScalingMenuItem.Text = "Fixed Size Sensor Panel";
             // 
             // logSeparatorMenuItem
             // 
@@ -1048,10 +1048,10 @@ namespace LibreHardwareMonitor.UI
         private ToolStripRadioButtonMenuItem plotWindowMenuItem;
         private ToolStripRadioButtonMenuItem plotBottomMenuItem;
         private ToolStripRadioButtonMenuItem plotRightMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem attachedPlotPanelScalingMenuItem;
-        private ToolStripRadioButtonMenuItem attachedPanelPercentageScalingMenuItem;
-        private ToolStripRadioButtonMenuItem attachedPanelFixedWidthPlotScalingMenuItem;
-        private ToolStripRadioButtonMenuItem attachedPanelFixedWidthSensorScalingMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem splitPlotPanelScalingMenuItem;
+        private ToolStripRadioButtonMenuItem splitPanelPercentageScalingMenuItem;
+        private ToolStripRadioButtonMenuItem splitPanelFixedPlotScalingMenuItem;
+        private ToolStripRadioButtonMenuItem splitPanelFixedSensorScalingMenuItem;
         private System.Windows.Forms.ToolStripMenuItem webMenuItem;
         private System.Windows.Forms.ToolStripMenuItem runWebServerMenuItem;
         private System.Windows.Forms.ToolStripMenuItem serverPortMenuItem;

--- a/LibreHardwareMonitor/UI/MainForm.Designer.cs
+++ b/LibreHardwareMonitor/UI/MainForm.Designer.cs
@@ -87,6 +87,10 @@ namespace LibreHardwareMonitor.UI
             this.plotWindowMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
             this.plotBottomMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
             this.plotRightMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.attachedPlotPanelScalingMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.attachedPanelPercentageScalingMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.attachedPanelFixedWidthPlotScalingMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.attachedPanelFixedWidthSensorScalingMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
             this.logSeparatorMenuItem = new System.Windows.Forms.ToolStripSeparator();
             this.logSensorsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.loggingIntervalMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -437,6 +441,7 @@ namespace LibreHardwareMonitor.UI
             this.separatorMenuItem,
             this.temperatureUnitsMenuItem,
             this.plotLocationMenuItem,
+            this.attachedPlotPanelScalingMenuItem,
             this.logSeparatorMenuItem,
             this.logSensorsMenuItem,
             this.loggingIntervalMenuItem,
@@ -532,6 +537,37 @@ namespace LibreHardwareMonitor.UI
             this.plotRightMenuItem.Name = "plotRightMenuItem";
             this.plotRightMenuItem.Size = new System.Drawing.Size(118, 22);
             this.plotRightMenuItem.Text = "Right";
+            // 
+            // attachedPlotPanelScalingMenuItem
+            // 
+            this.attachedPlotPanelScalingMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.attachedPanelPercentageScalingMenuItem,
+            this.attachedPanelFixedWidthPlotScalingMenuItem,
+            this.attachedPanelFixedWidthSensorScalingMenuItem});
+            this.attachedPlotPanelScalingMenuItem.Name = "attachedPlotPanelScalingMenuItem";
+            this.attachedPlotPanelScalingMenuItem.Size = new System.Drawing.Size(221, 22);
+            this.attachedPlotPanelScalingMenuItem.Text = "Attached plot panel scaling mode";
+            // 
+            // attachedPanelPercentageScalingMenuItem
+            // 
+            this.attachedPanelPercentageScalingMenuItem.CheckOnClick = true;
+            this.attachedPanelPercentageScalingMenuItem.Name = "attachedPlotPanelPercentageScalingMenuItem";
+            this.attachedPanelPercentageScalingMenuItem.Size = new System.Drawing.Size(118, 22);
+            this.attachedPanelPercentageScalingMenuItem.Text = "Percentage scaling";
+            // 
+            // attachedPanelFixedWidthPlotPanelScalingMenuItem
+            // 
+            this.attachedPanelFixedWidthPlotScalingMenuItem.CheckOnClick = true;
+            this.attachedPanelFixedWidthPlotScalingMenuItem.Name = "attachedBottomMenuItem";
+            this.attachedPanelFixedWidthPlotScalingMenuItem.Size = new System.Drawing.Size(118, 22);
+            this.attachedPanelFixedWidthPlotScalingMenuItem.Text = "Fixed width plot panel";
+            // 
+            // attachedPanelFixedWidthSensorPanelScalingMenuItem
+            // 
+            this.attachedPanelFixedWidthSensorScalingMenuItem.CheckOnClick = true;
+            this.attachedPanelFixedWidthSensorScalingMenuItem.Name = "attachedRightMenuItem";
+            this.attachedPanelFixedWidthSensorScalingMenuItem.Size = new System.Drawing.Size(118, 22);
+            this.attachedPanelFixedWidthSensorScalingMenuItem.Text = "Fixed width sensor panel";
             // 
             // logSeparatorMenuItem
             // 
@@ -1012,6 +1048,10 @@ namespace LibreHardwareMonitor.UI
         private ToolStripRadioButtonMenuItem plotWindowMenuItem;
         private ToolStripRadioButtonMenuItem plotBottomMenuItem;
         private ToolStripRadioButtonMenuItem plotRightMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem attachedPlotPanelScalingMenuItem;
+        private ToolStripRadioButtonMenuItem attachedPanelPercentageScalingMenuItem;
+        private ToolStripRadioButtonMenuItem attachedPanelFixedWidthPlotScalingMenuItem;
+        private ToolStripRadioButtonMenuItem attachedPanelFixedWidthSensorScalingMenuItem;
         private System.Windows.Forms.ToolStripMenuItem webMenuItem;
         private System.Windows.Forms.ToolStripMenuItem runWebServerMenuItem;
         private System.Windows.Forms.ToolStripMenuItem serverPortMenuItem;

--- a/LibreHardwareMonitor/UI/MainForm.cs
+++ b/LibreHardwareMonitor/UI/MainForm.cs
@@ -55,6 +55,7 @@ public sealed partial class MainForm : Form
     private int _delayCount;
     private Form _plotForm;
     private UserRadioGroup _plotLocation;
+    private UserRadioGroup _attachedPlotPanelScalingSetting;
     private bool _selectionDragging;
     private IDictionary<ISensor, Color> _sensorPlotColors = new Dictionary<ISensor, Color>();
     private UserOption _showPlot;
@@ -507,6 +508,7 @@ public sealed partial class MainForm : Form
 
         _showPlot = new UserOption("plotMenuItem", false, plotMenuItem, _settings);
         _plotLocation = new UserRadioGroup("plotLocation", 0, new[] { plotWindowMenuItem, plotBottomMenuItem, plotRightMenuItem }, _settings);
+        _attachedPlotPanelScalingSetting = new UserRadioGroup("attachedPlotPanelScalingSetting", 0, new[] { attachedPanelPercentageScalingMenuItem, attachedPanelFixedWidthPlotScalingMenuItem, attachedPanelFixedWidthSensorScalingMenuItem }, _settings);
 
         _showPlot.Changed += delegate
         {
@@ -535,7 +537,6 @@ public sealed partial class MainForm : Form
                     _plotForm.Controls.Add(_plotPanel);
                     if (_showPlot.Value && Visible)
                         _plotForm.Show();
-                    splitContainer.FixedPanel = FixedPanel.None;
                     break;
                 case 1:
                     _plotForm.Controls.Clear();
@@ -543,7 +544,6 @@ public sealed partial class MainForm : Form
                     splitContainer.Orientation = Orientation.Horizontal;
                     splitContainer.Panel2.Controls.Add(_plotPanel);
                     splitContainer.Panel2Collapsed = !_showPlot.Value;
-                    splitContainer.FixedPanel = FixedPanel.None;
                     break;
                 case 2:
                     _plotForm.Controls.Clear();
@@ -551,6 +551,21 @@ public sealed partial class MainForm : Form
                     splitContainer.Orientation = Orientation.Vertical;
                     splitContainer.Panel2.Controls.Add(_plotPanel);
                     splitContainer.Panel2Collapsed = !_showPlot.Value;
+                    break;
+            }
+        };
+
+        _attachedPlotPanelScalingSetting.Changed += delegate
+        {
+            switch (_attachedPlotPanelScalingSetting.Value)
+            {
+                case 0:
+                    splitContainer.FixedPanel = FixedPanel.None;
+                    break;
+                case 1:
+                    splitContainer.FixedPanel = FixedPanel.Panel2;
+                    break;
+                case 2:
                     splitContainer.FixedPanel = FixedPanel.Panel1;
                     break;
             }

--- a/LibreHardwareMonitor/UI/MainForm.cs
+++ b/LibreHardwareMonitor/UI/MainForm.cs
@@ -55,7 +55,7 @@ public sealed partial class MainForm : Form
     private int _delayCount;
     private Form _plotForm;
     private UserRadioGroup _plotLocation;
-    private UserRadioGroup _attachedPlotPanelScalingSetting;
+    private UserRadioGroup _splitPanelScalingSetting;
     private bool _selectionDragging;
     private IDictionary<ISensor, Color> _sensorPlotColors = new Dictionary<ISensor, Color>();
     private UserOption _showPlot;
@@ -508,7 +508,7 @@ public sealed partial class MainForm : Form
 
         _showPlot = new UserOption("plotMenuItem", false, plotMenuItem, _settings);
         _plotLocation = new UserRadioGroup("plotLocation", 0, new[] { plotWindowMenuItem, plotBottomMenuItem, plotRightMenuItem }, _settings);
-        _attachedPlotPanelScalingSetting = new UserRadioGroup("attachedPlotPanelScalingSetting", 0, new[] { attachedPanelPercentageScalingMenuItem, attachedPanelFixedWidthPlotScalingMenuItem, attachedPanelFixedWidthSensorScalingMenuItem }, _settings);
+        _splitPanelScalingSetting = new UserRadioGroup("splitPanelScalingSetting", 0, new[] { splitPanelPercentageScalingMenuItem, splitPanelFixedPlotScalingMenuItem, splitPanelFixedSensorScalingMenuItem }, _settings);
 
         _showPlot.Changed += delegate
         {
@@ -555,9 +555,9 @@ public sealed partial class MainForm : Form
             }
         };
 
-        _attachedPlotPanelScalingSetting.Changed += delegate
+        _splitPanelScalingSetting.Changed += delegate
         {
-            switch (_attachedPlotPanelScalingSetting.Value)
+            switch (_splitPanelScalingSetting.Value)
             {
                 case 0:
                     splitContainer.FixedPanel = FixedPanel.None;

--- a/LibreHardwareMonitor/UI/MainForm.cs
+++ b/LibreHardwareMonitor/UI/MainForm.cs
@@ -535,7 +535,7 @@ public sealed partial class MainForm : Form
                     _plotForm.Controls.Add(_plotPanel);
                     if (_showPlot.Value && Visible)
                         _plotForm.Show();
-
+                    splitContainer.FixedPanel = FixedPanel.None;
                     break;
                 case 1:
                     _plotForm.Controls.Clear();
@@ -543,6 +543,7 @@ public sealed partial class MainForm : Form
                     splitContainer.Orientation = Orientation.Horizontal;
                     splitContainer.Panel2.Controls.Add(_plotPanel);
                     splitContainer.Panel2Collapsed = !_showPlot.Value;
+                    splitContainer.FixedPanel = FixedPanel.None;
                     break;
                 case 2:
                     _plotForm.Controls.Clear();
@@ -550,6 +551,7 @@ public sealed partial class MainForm : Form
                     splitContainer.Orientation = Orientation.Vertical;
                     splitContainer.Panel2.Controls.Add(_plotPanel);
                     splitContainer.Panel2Collapsed = !_showPlot.Value;
+                    splitContainer.FixedPanel = FixedPanel.Panel1;
                     break;
             }
         };


### PR DESCRIPTION
When scaling the window and the plot panel is attached to the window the width of both panels scale procentualy.
I always use this program with the plot panel attached to the right. I want the sensor panel to have a fixed width so I can freely change the size of the window without having to adjust the width of the sensor panel every time.

In my first commit, I made changes to make it work the way I want it to. But I am not sure everyone agrees with that. In the second commit I added it to the settings and the menu so its optional. the settings also work for when the plot panel is attached to the bottom.

https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/assets/5478599/a37777a2-6b03-4692-afa5-b85a2013fb82

