### PR TITLE
Add index to superIO identifier if required

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -27,19 +27,8 @@ internal sealed class SuperIOHardware : Hardware
     private readonly List<Sensor> _temperatures = new();
     private readonly List<Sensor> _voltages = new();
 
-    private static Identifier CreateIdentifier(ISuperIO superIO, int? index = null)
-    {
-        List<string> identifierParts = new() { "lpc", superIO.Chip.ToString().ToLowerInvariant() };
-        if (index != null)
-        {
-            identifierParts.Add(index.ToString());
-        }
-
-        return new Identifier(identifierParts.ToArray());
-    }
-
-    public SuperIOHardware(Motherboard motherboard, ISuperIO superIO, Manufacturer manufacturer, Model model, ISettings settings, int? index = null)
-        : base(ChipName.GetName(superIO.Chip), CreateIdentifier(superIO, index), settings)
+    public SuperIOHardware(Motherboard motherboard, ISuperIO superIO, Manufacturer manufacturer, Model model, ISettings settings, int index)
+        : base(ChipName.GetName(superIO.Chip), new Identifier("lpc", superIO.Chip.ToString().ToLowerInvariant(), index.ToString()), settings)
     {
         _motherboard = motherboard;
         _superIO = superIO;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -27,8 +27,19 @@ internal sealed class SuperIOHardware : Hardware
     private readonly List<Sensor> _temperatures = new();
     private readonly List<Sensor> _voltages = new();
 
-    public SuperIOHardware(Motherboard motherboard, ISuperIO superIO, Manufacturer manufacturer, Model model, ISettings settings)
-        : base(ChipName.GetName(superIO.Chip), new Identifier("lpc", superIO.Chip.ToString().ToLowerInvariant()), settings)
+    private static Identifier CreateIdentifier(ISuperIO superIO, int? index = null)
+    {
+        List<string> identifierParts = new() { "lpc", superIO.Chip.ToString().ToLowerInvariant() };
+        if (index != null)
+        {
+            identifierParts.Add(index.ToString());
+        }
+
+        return new Identifier(identifierParts.ToArray());
+    }
+
+    public SuperIOHardware(Motherboard motherboard, ISuperIO superIO, Manufacturer manufacturer, Model model, ISettings settings, int? index = null)
+        : base(ChipName.GetName(superIO.Chip), CreateIdentifier(superIO, index), settings)
     {
         _motherboard = motherboard;
         _superIO = superIO;
@@ -1681,27 +1692,6 @@ internal sealed class SuperIOHardware : Hardware
                         break;
 
                     case Model.B660M_DS3H_AX_DDR4:
-                        v.Add(new Voltage("Vcore",0));
-                        v.Add(new Voltage("VAXG",1));
-                        v.Add(new Voltage("VCCIN AUX",2));
-                        v.Add(new Voltage("DIMM AB",3));
-                        v.Add(new Voltage("+12V",4));
-                        v.Add(new Voltage("+3.3V",5));
-                        v.Add(new Voltage("+5V",6));
-                        t.Add(new Temperature("CPU",0));
-                        t.Add(new Temperature("PCH",1));
-                        t.Add(new Temperature("PCIEX16",2));
-                        t.Add(new Temperature("System #1",3));
-                        t.Add(new Temperature("System #2",4));
-                        t.Add(new Temperature("VRAM MOS",5));
-                        f.Add(new Fan("CPU Fan",0));
-                        f.Add(new Fan("System Fan #1",2));
-                        f.Add(new Fan("System Fan #2",3));
-                        f.Add(new Fan("System Fan #3",4));
-                        c.Add(new Control("CPU Fan",0));
-                        c.Add(new Control("System Fan #1",2));
-                        c.Add(new Control("System Fan #2",3));
-                        c.Add(new Control("System Fan #3",4));
                         break;
 
                     default:

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1692,6 +1692,28 @@ internal sealed class SuperIOHardware : Hardware
                         break;
 
                     case Model.B660M_DS3H_AX_DDR4:
+                        v.Add(new Voltage("Vcore", 0));
+                        v.Add(new Voltage("VAXG", 1));
+                        v.Add(new Voltage("VCCIN AUX", 2));
+                        v.Add(new Voltage("DIMM AB", 3));
+                        v.Add(new Voltage("+12V", 4));
+                        v.Add(new Voltage("+3.3V", 5));
+                        v.Add(new Voltage("+5V", 6));
+                        t.Add(new Temperature("CPU", 0));
+                        t.Add(new Temperature("PCH", 1));
+                        t.Add(new Temperature("PCIEX16", 2));
+                        t.Add(new Temperature("System #1", 3));
+                        t.Add(new Temperature("System #2", 4));
+                        t.Add(new Temperature("VRAM MOS", 5));
+                        f.Add(new Fan("CPU Fan", 0));
+                        f.Add(new Fan("System Fan #1", 2));
+                        f.Add(new Fan("System Fan #2", 3));
+                        f.Add(new Fan("System Fan #3", 4));
+                        c.Add(new Control("CPU Fan", 0));
+                        c.Add(new Control("System Fan #1", 2));
+                        c.Add(new Control("System Fan #2", 3));
+                        c.Add(new Control("System Fan #3", 4));
+
                         break;
 
                     default:


### PR DESCRIPTION
Fixes https://github.com/Rem0o/FanControl.Releases/issues/2094#issuecomment-1771219002

That specific board has 2 of the same chip, which creates an identifier conflict.  Identifiers should be unique per contract, so I fixed it in LHM directly. 

Decided not to modify identifiers if there is only 1 of that SuperIO chip to not break compatibility. 