### PR TITLE
Ported SensorNotifyIcon drawing logic of CreateTransparentIcon() from  the OpenHwRepository

### DIFF
--- a/LibreHardwareMonitor/UI/SensorNotifyIcon.cs
+++ b/LibreHardwareMonitor/UI/SensorNotifyIcon.cs
@@ -198,11 +198,36 @@ public class SensorNotifyIcon : IDisposable
                 count++;
         bool small = count > 2;
 
-        _graphics.Clear(Color.Transparent);
-        Rectangle bounds = new Rectangle(Point.Empty, _bitmap.Size);
-        TextRenderer.DrawText(_graphics, text, small ? _smallFont : _font, bounds, _color, Color.Transparent, TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter);
+        _graphics.Clear(Color.Black);
+        TextRenderer.DrawText(_graphics, text, small ? _smallFont : _font,
+            new Point(-2, small ? 1 : 0), Color.White, Color.Black);
 
-        return IconFactory.Create(_bitmap);
+        BitmapData data = _bitmap.LockBits(
+            new Rectangle(0, 0, _bitmap.Width, _bitmap.Height),
+            ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+
+        IntPtr Scan0 = data.Scan0;
+
+        int numBytes = _bitmap.Width * _bitmap.Height * 4;
+        byte[] bytes = new byte[numBytes];
+        Marshal.Copy(Scan0, bytes, 0, numBytes);
+        _bitmap.UnlockBits(data);
+
+        byte red, green, blue;
+        for (int i = 0; i < bytes.Length; i += 4)
+        {
+            blue = bytes[i];
+            green = bytes[i + 1];
+            red = bytes[i + 2];
+
+            bytes[i] = _color.B;
+            bytes[i + 1] = _color.G;
+            bytes[i + 2] = _color.R;
+            bytes[i + 3] = (byte)(0.3 * red + 0.59 * green + 0.11 * blue);
+        }
+
+        return IconFactory.Create(bytes, _bitmap.Width, _bitmap.Height,
+            PixelFormat.Format32bppArgb);
     }
 
     private Icon CreatePercentageIcon()

--- a/LibreHardwareMonitor/UI/SensorNotifyIcon.cs
+++ b/LibreHardwareMonitor/UI/SensorNotifyIcon.cs
@@ -199,9 +199,10 @@ public class SensorNotifyIcon : IDisposable
         bool small = count > 2;
 
         _graphics.Clear(Color.Black);
+        Rectangle bounds = new Rectangle(Point.Empty, _bitmap.Size);
         TextRenderer.DrawText(_graphics, text, small ? _smallFont : _font,
-            new Point(-2, small ? 1 : 0), Color.White, Color.Black);
-
+            bounds, Color.White, Color.Black, TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter);
+        
         BitmapData data = _bitmap.LockBits(
             new Rectangle(0, 0, _bitmap.Width, _bitmap.Height),
             ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);


### PR DESCRIPTION
I hate unreadable text in tray icon. Ported the working code from the unmaintained repository for the temperature tray icon to draw the way the original one draws.

Compared the **OpenHW icon generated on the left** to the **LibreHWMonitor on the right**:
![image](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/assets/1347327/750f38ac-ac12-43a1-b0d4-37dba38e6a6d)

**On the left** before my commit **on the right** after my commit:
![image](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/assets/1347327/6745e4d0-1ec5-4c23-a330-14b5391347b7)

