### PR TITLE
Bugfix: Crash when access to nvml api is unavailable

### DIFF
--- a/LibreHardwareMonitorLib/Interop/NvidiaML.cs
+++ b/LibreHardwareMonitorLib/Interop/NvidiaML.cs
@@ -295,8 +295,15 @@ internal static class NvidiaML
                         return nvmlDevice;
                 }
             }
-            else if (_windowsNvmlDeviceGetHandleByIndex(index, out nvmlDevice) == NvmlReturn.Success)
-                return nvmlDevice;
+            else
+            {
+                try
+                {
+                    if (_windowsNvmlDeviceGetHandleByIndex(index, out nvmlDevice) == NvmlReturn.Success)
+                        return nvmlDevice;
+                }
+                catch { }
+            }
         }
 
         return null;
@@ -312,8 +319,15 @@ internal static class NvidiaML
                 if (nvmlDeviceGetHandleByPciBusId(pciBusId, out nvmlDevice) == NvmlReturn.Success)
                     return nvmlDevice;
             }
-            else if (_windowsNvmlDeviceGetHandleByPciBusId(pciBusId, out nvmlDevice) == NvmlReturn.Success)
-                return nvmlDevice;
+            else
+            {
+                try
+                {
+                    if (_windowsNvmlDeviceGetHandleByPciBusId(pciBusId, out nvmlDevice) == NvmlReturn.Success)
+                        return nvmlDevice;
+                }
+                catch { }
+            }
         }
 
         return null;
@@ -329,8 +343,15 @@ internal static class NvidiaML
                 if (nvmlDeviceGetPowerUsage(nvmlDevice, out powerUsage) == NvmlReturn.Success)
                     return powerUsage;
             }
-            else if (_windowsNvmlDeviceGetPowerUsage(nvmlDevice, out powerUsage) == NvmlReturn.Success)
-                return powerUsage;
+            else
+            {
+                try
+                {
+                    if (_windowsNvmlDeviceGetPowerUsage(nvmlDevice, out powerUsage) == NvmlReturn.Success)
+                        return powerUsage;
+                }
+                catch { }
+            }
         }
 
         return null;
@@ -346,8 +367,15 @@ internal static class NvidiaML
                 if (nvmlDeviceGetPcieThroughput(nvmlDevice, counter, out pcieThroughput) == NvmlReturn.Success)
                     return pcieThroughput;
             }
-            else if (_windowsNvmlDeviceGetPcieThroughputDelegate(nvmlDevice, counter, out pcieThroughput) == NvmlReturn.Success)
-                return pcieThroughput;
+            else
+            {
+                try
+                {
+                    if (_windowsNvmlDeviceGetPcieThroughputDelegate(nvmlDevice, counter, out pcieThroughput) == NvmlReturn.Success)
+                        return pcieThroughput;
+                }
+                catch { }
+            }
         }
 
         return null;
@@ -364,8 +392,15 @@ internal static class NvidiaML
                 if (nvmlDeviceGetPciInfo(nvmlDevice, ref pci) == NvmlReturn.Success)
                     return pci;
             }
-            else if (_windowsNvmlDeviceGetPciInfo(nvmlDevice, ref pci) == NvmlReturn.Success)
-                return pci;
+            else
+            {
+                try
+                {
+                    if (_windowsNvmlDeviceGetPciInfo(nvmlDevice, ref pci) == NvmlReturn.Success)
+                        return pci;
+                }
+                catch { }
+            }
         }
 
         return null;


### PR DESCRIPTION
Bugfix: Application/Lib Crash when a access to Nividia ML Lib fails.