### PR TITLE
Add support for .net framework 4.6.2

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -36,13 +36,19 @@ jobs:
       - name: Build
         run: msbuild LibreHardwareMonitor.sln -p:Configuration=Release -m
 
+      - name: Publish net462
+        uses: actions/upload-artifact@v2
+        with:
+          name: LibreHardwareMonitor-net462
+          path: |
+            bin/Release/net462
+
       - name: Publish net472
         uses: actions/upload-artifact@v2
         with:
           name: LibreHardwareMonitor-net472
           path: |
             bin/Release/net472
-
       - name: Publish netstandard20
         uses: actions/upload-artifact@v2
         with:

--- a/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
+++ b/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net472;netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <AssemblyName>LibreHardwareMonitorLib</AssemblyName>
     <RootNamespace>LibreHardwareMonitor</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -42,6 +42,7 @@
   <ItemGroup>
     <PackageReference Include="HidSharp" Version="2.1.0" />
     <PackageReference Include="System.Management" Version="8.0.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0"  Condition="'$(TargetFramework)' == 'net462'"  />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\packageicon.png" PackagePath="">


### PR DESCRIPTION
LibreHardwareMonitor currently has great coverage of .net in that it supports .net 4.7.2, 6.0, & 7.0.  
But there is a gap in that many devices only have 4.6.2.  For developers that target users with these devices, this PR enables them to target 4.6.2 instead of requiring users to install 4.7.2

According to Microsoft, there is a 1 years worth of devices that have 4.6.2 but not 4.7.2
Source: https://learn.microsoft.com/en-us/dotnet/framework/migration-guide/versions-and-dependencies

4.6.2 was included in Windows 10 after 1607 (August 2016)
4.7.2 was included in Windows 10 after 1709 (October 2017)

4.6.2 has end of support date  Jan 12, 2027 (https://learn.microsoft.com/en-us/lifecycle/products/microsoft-net-framework)
