### PR TITLE
Few Temporary Core Temperature Support for my 7950x

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
@@ -590,7 +590,7 @@ internal sealed class Amd17Cpu : AmdCpu
             if (!double.IsNaN(energy))
                 _power.Value = (float)energy;
 
-            if (_cpu._lastPMTable.Length > 1 && _cpu._smu.IsPmTableLayoutDefined() && _cpu._family == 0x19 && _cpu._model == 0x61)
+            if (_cpu._lastPMTable.Length > 1 && _cpu._smu.IsPmTableLayoutDefined() && _cpu._family == 0x19)
             {
                 _temperature.Value = _cpu._lastPMTable[324 + CoreId];
             }

--- a/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
@@ -476,6 +476,7 @@ internal sealed class Amd17Cpu : AmdCpu
         private readonly Sensor _multiplier;
         private readonly Sensor _power;
         private readonly Sensor _vcore;
+        private readonly Sensor _vcore2;
         private readonly Sensor _temperature;
         private ISensor _busSpeed;
         private DateTime _lastPwrTime = new(0);
@@ -490,12 +491,14 @@ internal sealed class Amd17Cpu : AmdCpu
             _multiplier = new Sensor("Core #" + CoreId, cpu._sensorTypeIndex[SensorType.Factor]++, SensorType.Factor, cpu, cpu._settings);
             _power = new Sensor("Core #" + CoreId + " (SMU)", cpu._sensorTypeIndex[SensorType.Power]++, SensorType.Power, cpu, cpu._settings);
             _vcore = new Sensor("Core #" + CoreId + " VID", cpu._sensorTypeIndex[SensorType.Voltage]++, SensorType.Voltage, cpu, cpu._settings);
+            _vcore2 = new Sensor("Core #" + CoreId + " VID (PMT)", cpu._sensorTypeIndex[SensorType.Voltage]++, SensorType.Voltage, cpu, cpu._settings);
             _temperature = new Sensor("Core #" + CoreId + " (PMT)", cpu._sensorTypeIndex[SensorType.Temperature]++, SensorType.Temperature, cpu, cpu._settings);
 
             cpu.ActivateSensor(_clock);
             cpu.ActivateSensor(_multiplier);
             cpu.ActivateSensor(_power);
             cpu.ActivateSensor(_vcore);
+            cpu.ActivateSensor(_vcore2);
             cpu.ActivateSensor(_temperature);
         }
 
@@ -592,6 +595,7 @@ internal sealed class Amd17Cpu : AmdCpu
 
             if (_cpu._lastPMTable.Length > 1 && _cpu._smu.IsPmTableLayoutDefined() && _cpu._smu.GetPmTableVersion() == 0x00540004)
             {
+                _vcore2.Value = _cpu._lastPMTable[308 + CoreId];
                 _temperature.Value = _cpu._lastPMTable[324 + CoreId];
             }
 

--- a/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
@@ -590,7 +590,7 @@ internal sealed class Amd17Cpu : AmdCpu
             if (!double.IsNaN(energy))
                 _power.Value = (float)energy;
 
-            if (_cpu._lastPMTable.Length > 1 && _cpu._smu.IsPmTableLayoutDefined() && _cpu._family == 0x19)
+            if (_cpu._lastPMTable.Length > 1 && _cpu._smu.IsPmTableLayoutDefined() && _cpu._smu.GetPmTableVersion() == 0x00540004)
             {
                 _temperature.Value = _cpu._lastPMTable[324 + CoreId];
             }

--- a/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
@@ -593,7 +593,7 @@ internal sealed class Amd17Cpu : AmdCpu
             if (!double.IsNaN(energy))
                 _power.Value = (float)energy;
 
-            if (_cpu._lastPMTable.Length > 1 && _cpu._smu.IsPmTableLayoutDefined() && _cpu._smu.GetPmTableVersion() == 0x00540004)
+            if (_cpu._smu.IsPmTableLayoutDefined() && _cpu._smu.GetPmTableVersion() == 0x00540004 && _cpu._lastPMTable.Length > 1)
             {
                 _vcore2.Value = _cpu._lastPMTable[308 + CoreId];
                 _temperature.Value = _cpu._lastPMTable[324 + CoreId];

--- a/LibreHardwareMonitorLib/Hardware/Cpu/CpuId.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/CpuId.cs
@@ -112,13 +112,14 @@ public class CpuId
         nameBuilder.Replace("Quad-Core Processor", string.Empty);
         nameBuilder.Replace("Six-Core Processor", string.Empty);
         nameBuilder.Replace("Eight-Core Processor", string.Empty);
-        nameBuilder.Replace("6-Core Processor", string.Empty);
-        nameBuilder.Replace("8-Core Processor", string.Empty);
-        nameBuilder.Replace("12-Core Processor", string.Empty);
-        nameBuilder.Replace("16-Core Processor", string.Empty);
-        nameBuilder.Replace("24-Core Processor", string.Empty);
-        nameBuilder.Replace("32-Core Processor", string.Empty);
         nameBuilder.Replace("64-Core Processor", string.Empty);
+        nameBuilder.Replace("32-Core Processor", string.Empty);
+        nameBuilder.Replace("24-Core Processor", string.Empty);
+        nameBuilder.Replace("16-Core Processor", string.Empty);
+        nameBuilder.Replace("12-Core Processor", string.Empty);
+        nameBuilder.Replace("8-Core Processor", string.Empty);
+        nameBuilder.Replace("6-Core Processor", string.Empty);
+
 
         for (int i = 0; i < 10; i++)
             nameBuilder.Replace("  ", " ");

--- a/LibreHardwareMonitorLib/Hardware/RyzenSMU.cs
+++ b/LibreHardwareMonitorLib/Hardware/RyzenSMU.cs
@@ -273,6 +273,11 @@ internal class RyzenSMU
         return 0;
     }
 
+    public uint GetPmTableVersion()
+    {
+        return _pmTableVersion;
+    }
+
     public Dictionary<uint, SmuSensorType> GetPmTableStructure()
     {
         if (!IsPmTableLayoutDefined())

--- a/LibreHardwareMonitorLib/Hardware/RyzenSMU.cs
+++ b/LibreHardwareMonitorLib/Hardware/RyzenSMU.cs
@@ -124,6 +124,22 @@ internal class RyzenSMU
                 { 539, new SmuSensorType { Name = "L3 (CCD1)", Type = SensorType.Temperature, Scale = 1 } },
                 { 540, new SmuSensorType { Name = "L3 (CCD2)", Type = SensorType.Temperature, Scale = 1 } },
                 { 268, new SmuSensorType { Name = "LDO VDD", Type = SensorType.Voltage, Scale = 1 } },
+                { 325, new SmuSensorType { Name = "Core #1", Type = SensorType.Temperature, Scale = 1 } },
+                { 326, new SmuSensorType { Name = "Core #2", Type = SensorType.Temperature, Scale = 1 } },
+                { 327, new SmuSensorType { Name = "Core #3", Type = SensorType.Temperature, Scale = 1 } },
+                { 328, new SmuSensorType { Name = "Core #4", Type = SensorType.Temperature, Scale = 1 } },
+                { 329, new SmuSensorType { Name = "Core #5", Type = SensorType.Temperature, Scale = 1 } },
+                { 330, new SmuSensorType { Name = "Core #6", Type = SensorType.Temperature, Scale = 1 } },
+                { 331, new SmuSensorType { Name = "Core #7", Type = SensorType.Temperature, Scale = 1 } },
+                { 332, new SmuSensorType { Name = "Core #8", Type = SensorType.Temperature, Scale = 1 } },
+                { 333, new SmuSensorType { Name = "Core #9", Type = SensorType.Temperature, Scale = 1 } },
+                { 334, new SmuSensorType { Name = "Core #10", Type = SensorType.Temperature, Scale = 1 } },
+                { 335, new SmuSensorType { Name = "Core #11", Type = SensorType.Temperature, Scale = 1 } },
+                { 336, new SmuSensorType { Name = "Core #12", Type = SensorType.Temperature, Scale = 1 } },
+                { 337, new SmuSensorType { Name = "Core #13", Type = SensorType.Temperature, Scale = 1 } },
+                { 338, new SmuSensorType { Name = "Core #14", Type = SensorType.Temperature, Scale = 1 } },
+                { 339, new SmuSensorType { Name = "Core #15", Type = SensorType.Temperature, Scale = 1 } },
+                { 340, new SmuSensorType { Name = "Core #16", Type = SensorType.Temperature, Scale = 1 } },
 
                 // This is not working, some cores can be deactivated with the core disabled map.
                 // When Core 2 is disabled and Core 3 is enabled, the name of Core 3 == "Core 2".

--- a/LibreHardwareMonitorLib/Hardware/RyzenSMU.cs
+++ b/LibreHardwareMonitorLib/Hardware/RyzenSMU.cs
@@ -124,22 +124,7 @@ internal class RyzenSMU
                 { 539, new SmuSensorType { Name = "L3 (CCD1)", Type = SensorType.Temperature, Scale = 1 } },
                 { 540, new SmuSensorType { Name = "L3 (CCD2)", Type = SensorType.Temperature, Scale = 1 } },
                 { 268, new SmuSensorType { Name = "LDO VDD", Type = SensorType.Voltage, Scale = 1 } },
-                { 325, new SmuSensorType { Name = "Core #1", Type = SensorType.Temperature, Scale = 1 } },
-                { 326, new SmuSensorType { Name = "Core #2", Type = SensorType.Temperature, Scale = 1 } },
-                { 327, new SmuSensorType { Name = "Core #3", Type = SensorType.Temperature, Scale = 1 } },
-                { 328, new SmuSensorType { Name = "Core #4", Type = SensorType.Temperature, Scale = 1 } },
-                { 329, new SmuSensorType { Name = "Core #5", Type = SensorType.Temperature, Scale = 1 } },
-                { 330, new SmuSensorType { Name = "Core #6", Type = SensorType.Temperature, Scale = 1 } },
-                { 331, new SmuSensorType { Name = "Core #7", Type = SensorType.Temperature, Scale = 1 } },
-                { 332, new SmuSensorType { Name = "Core #8", Type = SensorType.Temperature, Scale = 1 } },
-                { 333, new SmuSensorType { Name = "Core #9", Type = SensorType.Temperature, Scale = 1 } },
-                { 334, new SmuSensorType { Name = "Core #10", Type = SensorType.Temperature, Scale = 1 } },
-                { 335, new SmuSensorType { Name = "Core #11", Type = SensorType.Temperature, Scale = 1 } },
-                { 336, new SmuSensorType { Name = "Core #12", Type = SensorType.Temperature, Scale = 1 } },
-                { 337, new SmuSensorType { Name = "Core #13", Type = SensorType.Temperature, Scale = 1 } },
-                { 338, new SmuSensorType { Name = "Core #14", Type = SensorType.Temperature, Scale = 1 } },
-                { 339, new SmuSensorType { Name = "Core #15", Type = SensorType.Temperature, Scale = 1 } },
-                { 340, new SmuSensorType { Name = "Core #16", Type = SensorType.Temperature, Scale = 1 } },
+
 
                 // This is not working, some cores can be deactivated with the core disabled map.
                 // When Core 2 is disabled and Core 3 is enabled, the name of Core 3 == "Core 2".


### PR DESCRIPTION
Yes, I know these change is ugly.
But at least it work on my 7950x .
I have no idea how to make it to be best pratice or have chance to verify on other device.

And I notice the comment
```
// This is not working, some cores can be deactivated with the core disabled map.
// When Core 2 is disabled and Core 3 is enabled, the name of Core 3 == "Core 2".
```
make me no idea how to let it work correctly on few core or blocked core device.

So i limit it only work on 7950x.