### PR TITLE
Fix NullReferenceException on linux systems where the specified paths don't exist

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LMSensors.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LMSensors.cs
@@ -16,25 +16,21 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc;
 
 internal class LMSensors
 {
-    private readonly List<ISuperIO> _superIOs = new();
-    private static string _hwMonDirectoryPath = "/sys/class/hwmon/";
+    private const string HwMonPath = "/sys/class/hwmon/";
+    private readonly List<ISuperIO> _superIOs = [];
 
     public LMSensors()
     {
-        string[] subDirectories = [];
+        if (!Directory.Exists(HwMonPath))
+            return;
 
-        if (Directory.Exists(_hwMonDirectoryPath))
-        {
-            subDirectories = Directory.GetDirectories(_hwMonDirectoryPath);
-        }
-
-        foreach (string basePath in subDirectories)
+        foreach (string basePath in Directory.GetDirectories(HwMonPath))
         {
             foreach (string devicePath in new[] { "/device", string.Empty })
             {
                 string path = basePath + devicePath;
-
                 string name = null;
+
                 try
                 {
                     using StreamReader reader = new(path + "/name");

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LMSensors.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LMSensors.cs
@@ -17,10 +17,18 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc;
 internal class LMSensors
 {
     private readonly List<ISuperIO> _superIOs = new();
+    private static string _hwMonDirectoryPath = "/sys/class/hwmon/";
 
     public LMSensors()
     {
-        foreach (string basePath in Directory.GetDirectories("/sys/class/hwmon/"))
+        string[] subDirectories = [];
+
+        if (Directory.Exists(_hwMonDirectoryPath))
+        {
+            subDirectories = Directory.GetDirectories(_hwMonDirectoryPath);
+        }
+
+        foreach (string basePath in subDirectories)
         {
             foreach (string devicePath in new[] { "/device", string.Empty })
             {

--- a/LibreHardwareMonitorLib/Hardware/SMBios.cs
+++ b/LibreHardwareMonitorLib/Hardware/SMBios.cs
@@ -1323,11 +1323,11 @@ public class SMBios
                 return reader.ReadLine();
             }
 
-            return null;
+            return string.Empty;
         }
         catch
         {
-            return null;
+            return string.Empty;
         }
     }
 


### PR DESCRIPTION
As mentioned in the issue #1178 it throws a NullReference Exception on linux systems if it can't find the specified path. 

ReadFsSys now returns an empty string instead of null so that the switch case in the methods Identification.GetManufacturer and Identification.GetModel can end up in the default case instead of throwing a NullReference Exception.

In the LMSensors constructor it checks now if the hwmon directory exists before trying to get the sub directories.