### PR TITLE
add B650M_AORUS_PRO_AX

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -393,6 +393,14 @@ internal class Identification
                 return Model.B560M_AORUS_PRO_AX;
             case var _ when name.Equals("B560I AORUS PRO AX", StringComparison.OrdinalIgnoreCase):
                 return Model.B560I_AORUS_PRO_AX;
+            case var _ when name.Equals("B650M AORUS PRO", StringComparison.OrdinalIgnoreCase):
+                return Model.B650M_AORUS_PRO;
+            case var _ when name.Equals("B650M AORUS PRO AX", StringComparison.OrdinalIgnoreCase):
+                return Model.B650M_AORUS_PRO_AX;
+            case var _ when name.Equals("B650M AORUS ELITE", StringComparison.OrdinalIgnoreCase):
+                return Model.B650M_AORUS_ELITE;
+            case var _ when name.Equals("B650M AORUS ELITE AX", StringComparison.OrdinalIgnoreCase):
+                return Model.B650M_AORUS_ELITE_AX;
             case var _ when name.Equals("ROG STRIX Z390-E GAMING", StringComparison.OrdinalIgnoreCase):
                 return Model.ROG_STRIX_Z390_E_GAMING;
             case var _ when name.Equals("ROG STRIX Z390-F GAMING", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -183,6 +183,10 @@ public enum Model
     X570_AORUS_MASTER,
     X570_GAMING_X,
     X570_AORUS_ULTRA,
+    B650M_AORUS_PRO,
+    B650M_AORUS_PRO_AX,
+    B650M_AORUS_ELITE,
+    B650M_AORUS_ELITE_AX,
 
     // Shuttle
     FH67,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1402,7 +1402,7 @@ internal sealed class SuperIOHardware : Hardware
                         c.Add(new Control("System Fan #1", 1));
                         c.Add(new Control("System Fan #2", 2));
                         c.Add(new Control("System Fan #3", 3));
-                        c.Add(new Control("CPU Pump Fan", 3));
+                        c.Add(new Control("CPU Pump Fan", 4));
                         c.Add(new Control("CPU Optional Fan", 5));
 
                         break;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1372,6 +1372,41 @@ internal sealed class SuperIOHardware : Hardware
 
                         break;
 
+                    case Model.B650M_AORUS_PRO: // IT8689E
+                    case Model.B650M_AORUS_PRO_AX:
+                    case Model.B650M_AORUS_ELITE:
+                    case Model.B650M_AORUS_ELITE_AX:
+                        v.Add(new Voltage("Vcore", 0));
+                        v.Add(new Voltage("+3.3V", 1, 29.4f, 45.3f));
+                        v.Add(new Voltage("+12V", 2, 10f, 2f));
+                        v.Add(new Voltage("+5V", 3, 15f, 10f));
+                        v.Add(new Voltage("iGPU VAGX", 4));
+                        v.Add(new Voltage("VCCSA", 5));
+                        v.Add(new Voltage("DRAM", 6));
+                        v.Add(new Voltage("3VSB", 7, 10f, 10f));
+                        v.Add(new Voltage("VBat", 8, 10f, 10f));
+                        v.Add(new Voltage("AVCC3", 9, 59.9f, 9.8f));
+                        t.Add(new Temperature("System #1", 0));
+                        t.Add(new Temperature("PCH", 1));
+                        t.Add(new Temperature("CPU", 2));
+                        t.Add(new Temperature("PCIe x16", 3));
+                        t.Add(new Temperature("VRM MOS", 4));
+                        t.Add(new Temperature("System #2", 5));
+                        f.Add(new Fan("CPU Fan", 0));
+                        f.Add(new Fan("System Fan #1", 1));
+                        f.Add(new Fan("System Fan #2", 2));
+                        f.Add(new Fan("System Fan #3", 3));
+                        f.Add(new Fan("CPU Pump Fan", 4));
+                        f.Add(new Fan("CPU Optional Fan", 5));
+                        c.Add(new Control("CPU Fan", 0));
+                        c.Add(new Control("System Fan #1", 1));
+                        c.Add(new Control("System Fan #2", 2));
+                        c.Add(new Control("System Fan #3", 3));
+                        c.Add(new Control("CPU Pump Fan", 3));
+                        c.Add(new Control("CPU Optional Fan", 5));
+
+                        break;
+
                     case Model.B360_AORUS_GAMING_3_WIFI_CF: // IT8688E
                         v.Add(new Voltage("Vcore", 0));
                         v.Add(new Voltage("+3.3V", 1, 29.4f, 45.3f));

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1380,9 +1380,9 @@ internal sealed class SuperIOHardware : Hardware
                         v.Add(new Voltage("+3.3V", 1, 29.4f, 45.3f));
                         v.Add(new Voltage("+12V", 2, 10f, 2f));
                         v.Add(new Voltage("+5V", 3, 15f, 10f));
-                        v.Add(new Voltage("iGPU VAGX", 4));
-                        v.Add(new Voltage("VCCSA", 5));
-                        v.Add(new Voltage("DRAM", 6));
+                        v.Add(new Voltage("CPU Vcore SoC", 4));
+                        v.Add(new Voltage("CPU Vcore MISC", 5));
+                        v.Add(new Voltage("VIN6", 6));
                         v.Add(new Voltage("3VSB", 7, 10f, 10f));
                         v.Add(new Voltage("VBat", 8, 10f, 10f));
                         v.Add(new Voltage("AVCC3", 9, 59.9f, 9.8f));
@@ -1391,7 +1391,7 @@ internal sealed class SuperIOHardware : Hardware
                         t.Add(new Temperature("CPU", 2));
                         t.Add(new Temperature("PCIe x16", 3));
                         t.Add(new Temperature("VRM MOS", 4));
-                        t.Add(new Temperature("System #2", 5));
+                        t.Add(new Temperature("VSOC MOS", 5));
                         f.Add(new Fan("CPU Fan", 0));
                         f.Add(new Fan("System Fan #1", 1));
                         f.Add(new Fan("System Fan #2", 2));


### PR DESCRIPTION
Since gigabyte let these 4 motherboards use a same manual, it should have the same layout
https://download.gigabyte.com/FileList/Manual/mb_manual_b650m-aorus-pro-elite-ax_1302_e.pdf
![image](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/assets/7452372/cd3fc929-9eef-44dc-bcc8-4f044f1532cc)

I don't know meaning of some field in voltage and temp, just copied them from hwinfo

![ScreenShot_24-03-28_17-20-32-389](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/assets/7452372/fb675fcd-e2c1-439e-a148-93422a6a2f05)

![image](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/assets/7452372/a876b55f-4574-41c4-ae41-e7f7edcd4ebf)
