### PR TITLE
fix heap corruption caused by incorrect pointer size in calls to Ftd2xx.dll

### DIFF
--- a/LibreHardwareMonitorLib/Interop/Ftd2xx.cs
+++ b/LibreHardwareMonitorLib/Interop/Ftd2xx.cs
@@ -161,7 +161,7 @@ internal static class Ftd2xx
     [StructLayout(LayoutKind.Sequential)]
     internal struct FT_HANDLE
     {
-        private readonly uint _handle;
+        private readonly IntPtr _handle;
     }
 
     [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
If any hardware containing a FTD2xx chip is attached to the PC (e.g. a Nexus 4 FPGA board), LHM crashes with error `0xc0000374` (`STATUS_HEAP_CORRUPTION`) while starting.

The error was narrowed down to an incorrect declaration of the `FT_HANDLE` field. As described on page 92 of the [D2XX Programmer’s Guide](https://ftdichip.com/document/programming-guides/), `FT_HANDLE` is a pointer, which occupies 64 bits on x64 systems. 

Because, `uint` only has a size of 32 bits, the call to `FT_GetDeviceInfoList` in `TBalancerGroup.cs` overruns the allocated memory region of the `info` array, crashing LHM.

This PR fixes the issue by using the correct `IntPtr` type.