### PR TITLE
Adding Cooler Master PSU support

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Computer.cs
+++ b/LibreHardwareMonitorLib/Hardware/Computer.cs
@@ -22,6 +22,7 @@ using LibreHardwareMonitor.Hardware.Memory;
 using LibreHardwareMonitor.Hardware.Motherboard;
 using LibreHardwareMonitor.Hardware.Network;
 using LibreHardwareMonitor.Hardware.Psu.Corsair;
+using LibreHardwareMonitor.Hardware.Psu.CoolerMaster;
 using LibreHardwareMonitor.Hardware.Storage;
 
 namespace LibreHardwareMonitor.Hardware;
@@ -249,10 +250,12 @@ public class Computer : IComputer
             {
                 if (value)
                 {
+                    Add(new CoolerMasterPsuGroup(_settings));
                     Add(new CorsairPsuGroup(_settings));
                 }
                 else
                 {
+                    RemoveType<CoolerMasterPsuGroup>();
                     RemoveType<CorsairPsuGroup>();
                 }
             }
@@ -533,7 +536,10 @@ public class Computer : IComputer
             Add(new NetworkGroup(_settings));
 
         if (_psuEnabled)
+        {
+            Add(new CoolerMasterPsuGroup(_settings));
             Add(new CorsairPsuGroup(_settings));
+        }
 
         if (_batteryEnabled)
             Add(new BatteryGroup(_settings));

--- a/LibreHardwareMonitorLib/Hardware/Psu/CoolerMaster/CoolerMasterPsu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Psu/CoolerMaster/CoolerMasterPsu.cs
@@ -1,0 +1,486 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (C) 2020 Wilken Gottwalt<wilken.gottwalt@posteo.net>
+// Copyright (C) LibreHardwareMonitor and Contributors.
+// All Rights Reserved.
+// Implemented after the Linuix kernel driver corsair_psu by Wilken Gottwalt and contributers
+
+
+// https://github.com/Jannis234/cm-psu
+// https://github.com/wgottwalt/corsair-psu
+
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using HidSharp;
+
+namespace LibreHardwareMonitor.Hardware.Psu.CoolerMaster;
+
+internal class SensorIndices
+{
+    private readonly Dictionary<SensorType, int> _lastIndices = new();
+
+    public int NextIndex(SensorType type)
+    {
+        if (!_lastIndices.ContainsKey(type))
+        {
+            _lastIndices.Add(type, 0);
+            return 0;
+        }
+
+        int res = _lastIndices[type] + 1;
+        _lastIndices[type] = res;
+        return res;
+    }
+}
+
+// might need refactoring into two classes if AXi series API differs significantly
+internal sealed class CoolerMasterPsu : Hardware
+{
+    private readonly List<CompositeSensor> _compositeSensors = new();
+    private readonly HidDevice _device;
+    private readonly List<PsuSensor> _sensors = new();
+
+    public CoolerMasterPsu(HidDevice device, ISettings settings, int index)
+        : base("CoolerMaster PSU", new Identifier("psu", "coolermaster", index.ToString()), settings)
+    {
+        _device = device;
+        using HidStream stream = device.Open();
+
+        UsbApi.Init(stream);
+        UsbApi.FirmwareInfo fwInfo = UsbApi.FwInfo(stream);
+        Name = $"{CultureInfo.InvariantCulture.TextInfo.ToTitleCase(fwInfo.Vendor.ToLowerInvariant())} {fwInfo.Product}";
+
+        AddSensors(UsbApi.GetOptionalCommands(stream), UsbApi.GetCriticals(stream), settings);
+    }
+
+    public override HardwareType HardwareType => HardwareType.Psu;
+
+    public override IDictionary<string, string> Properties
+    {
+        get
+        {
+            SortedDictionary<string, string> properties = new();
+
+            using HidStream stream = _device.Open();
+
+            float? mode = UsbApi.GetValue(stream, UsbApi.Command.OCPMODE, 0);
+            if (mode.HasValue)
+                properties.Add("Over-current protection", mode > 1.0 ? "multi-rail" : "single-rail");
+
+            return properties;
+        }
+    }
+
+    public override void Update()
+    {
+        using HidStream stream = _device.Open();
+        _sensors.ForEach(s => s.Update(stream));
+    }
+
+    private void AddSensors(UsbApi.OptionalCommands optionalCommands, UsbApi.Criticals criticals, ISettings settings)
+    {
+        SensorIndices indices = new();
+        _sensors.Add(new PsuSensorWithLimits("VRM",
+                                             indices,
+                                             SensorType.Temperature,
+                                             this,
+                                             settings,
+                                             UsbApi.Command.TEMP0,
+                                             null,
+                                             criticals.TempMax[0]));
+
+        _sensors.Add(new PsuSensorWithLimits("Case",
+                                             indices,
+                                             SensorType.Temperature,
+                                             this,
+                                             settings,
+                                             UsbApi.Command.TEMP1,
+                                             null,
+                                             criticals.TempMax[1]));
+
+        _sensors.Add(new PsuSensor("Case", indices, SensorType.Fan, this, settings, UsbApi.Command.FAN_RPM));
+
+        _sensors.Add(new PsuSensor("Input", indices, SensorType.Voltage, this, settings, UsbApi.Command.IN_VOLTS));
+        _sensors.Add(new PsuSensorWithLimits("+12V",
+                                             indices,
+                                             SensorType.Voltage,
+                                             this,
+                                             settings,
+                                             UsbApi.Command.RAIL_VOLTS,
+                                             criticals.VoltageMin[(byte)Rail._12V],
+                                             criticals.VoltageMax[(byte)Rail._12V]));
+
+        _sensors.Add(new PsuSensorWithLimits("+5V",
+                                             indices,
+                                             SensorType.Voltage,
+                                             this,
+                                             settings,
+                                             UsbApi.Command.RAIL_VOLTS,
+                                             criticals.VoltageMin[(byte)Rail._5V],
+                                             criticals.VoltageMax[(byte)Rail._5V],
+                                             Rail._5V));
+
+        _sensors.Add(new PsuSensorWithLimits("+3.3V",
+                                             indices,
+                                             SensorType.Voltage,
+                                             this,
+                                             settings,
+                                             UsbApi.Command.RAIL_VOLTS,
+                                             criticals.VoltageMin[(byte)Rail._3V],
+                                             criticals.VoltageMax[(byte)Rail._3V],
+                                             Rail._3V));
+
+        if (optionalCommands.HasFlag(UsbApi.OptionalCommands.InputCurrent))
+        {
+            _sensors.Add(new PsuSensor("Input", indices, SensorType.Current, this, settings, UsbApi.Command.IN_AMPS));
+        }
+
+        _sensors.Add(new PsuSensorWithLimits("+12V",
+                                             indices,
+                                             SensorType.Current,
+                                             this,
+                                             settings,
+                                             UsbApi.Command.RAIL_AMPS,
+                                             null,
+                                             criticals.CurrentMax[(byte)Rail._12V]));
+
+        _sensors.Add(new PsuSensorWithLimits("+5V",
+                                             indices,
+                                             SensorType.Current,
+                                             this,
+                                             settings,
+                                             UsbApi.Command.RAIL_AMPS,
+                                             null,
+                                             criticals.CurrentMax[(byte)Rail._5V],
+                                             Rail._5V));
+
+        _sensors.Add(new PsuSensorWithLimits("+3.3V",
+                                             indices,
+                                             SensorType.Current,
+                                             this,
+                                             settings,
+                                             UsbApi.Command.RAIL_AMPS,
+                                             null,
+                                             criticals.CurrentMax[(byte)Rail._3V],
+                                             Rail._3V));
+
+        PsuSensor[] powerRails =
+        {
+            new("+12V", indices, SensorType.Power, this, settings, UsbApi.Command.RAIL_WATTS),
+            new("+5V", indices, SensorType.Power, this, settings, UsbApi.Command.RAIL_WATTS, Rail._5V),
+            new("+3.3V", indices, SensorType.Power, this, settings, UsbApi.Command.RAIL_WATTS, Rail._3V)
+        };
+
+        _sensors.AddRange(powerRails);
+        _sensors.Add(new PsuSensor("Total watts", indices, SensorType.Power, this, settings, UsbApi.Command.TOTAL_WATTS));
+        _compositeSensors.Add(new CompositeSensor("Total Output",
+                                                  indices.NextIndex(SensorType.Power),
+                                                  SensorType.Power,
+                                                  this,
+                                                  settings,
+                                                  powerRails,
+                                                  (acc, sensor) => acc + sensor.Value ?? 0f));
+
+        ActivateSensor(_compositeSensors[_compositeSensors.Count - 1]);
+
+        _sensors.Add(new PsuSensor("Uptime", indices, SensorType.TimeSpan, this, settings, UsbApi.Command.UPTIME, Rail._12V, true));
+        _sensors.Add(new PsuSensor("Total uptime", indices, SensorType.TimeSpan, this, settings, UsbApi.Command.TOTAL_UPTIME, Rail._12V, true));
+    }
+
+    private class PsuSensor : Sensor
+    {
+        private readonly UsbApi.Command _cmd;
+        private readonly byte _rail;
+
+        public PsuSensor(string name, SensorIndices indices, SensorType type, CoolerMasterPsu hardware, ISettings settings, UsbApi.Command cmd, Rail rail = Rail._12V, bool noHistory = false)
+            : base(name, indices.NextIndex(type), false, type, hardware, null, settings, noHistory)
+        {
+            _cmd = cmd;
+            _rail = (byte)rail;
+
+            hardware.ActivateSensor(this);
+        }
+
+        public void Update(HidStream stream)
+        {
+            Value = UsbApi.GetValue(stream, _cmd, _rail);
+        }
+    }
+
+    private class PsuSensorWithLimits : PsuSensor, ICriticalSensorLimits
+    {
+        public PsuSensorWithLimits
+        (
+            string name,
+            SensorIndices indices,
+            SensorType type,
+            CoolerMasterPsu hardware,
+            ISettings settings,
+            UsbApi.Command cmd,
+            float? lowCritical,
+            float? highCritical,
+            Rail rail = Rail._12V)
+            : base(name, indices, type, hardware, settings, cmd, rail)
+        {
+            CriticalLowLimit = lowCritical;
+            CriticalHighLimit = highCritical;
+        }
+
+        public float? CriticalHighLimit { get; }
+
+        public float? CriticalLowLimit { get; }
+    }
+
+    private enum Rail : byte
+    {
+        _12V = 0,
+        _5V = 1,
+        _3V = 2
+    }
+}
+
+#region Exception classes
+
+public class CommunicationProtocolError : ApplicationException
+{
+    public CommunicationProtocolError(HidDevice device, string message)
+        : base($"Error communicating with the PSU controller at {device.DevicePath}: {message}")
+    { }
+}
+
+#endregion
+
+#region PSU USB communication protocol implementation
+
+internal static class UsbApi
+{
+    /* some values are SMBus LINEAR11 data which need a conversion */
+#if false
+        static int Linear11ToInt(ushort val, int scale)
+        {
+            int exp = ((short)val) >> 11;
+            int mant = (((short)(val & 0x7ff)) << 5) >> 5;
+            int result = mant * scale;
+
+            return (exp >= 0) ? (result << exp) : (result >> -exp);
+        }
+#endif
+    static float Linear11ToFloat32(ushort val)
+    {
+        int exp = (short)val >> 11;
+        int mant = ((short)(val & 0x7ff) << 5) >> 5;
+        return mant * (float)Math.Pow(2, exp);
+    }
+
+    static bool SendCommand(HidStream stream, byte length, Command cmd, byte arg, out byte[] replyData)
+    {
+        /*
+         * Corsair protocol for PSUs
+         *
+         * message size = 64 bytes (request and response, little endian)
+         * request:
+         *	[length][command][param0][param1][paramX]...
+         * reply:
+         *	[echo of length][echo of command][data0][data1][dataX]...
+         *
+         *	- commands are byte sized opcodes
+         *	- length is the sum of all bytes of the commands/params
+         *	- the micro-controller of most of these PSUs support concatenation in the request and reply,
+         *	  but it is better to not rely on this (it is also hard to parse)
+         *	- the driver uses raw events to be accessible from userspace (though this is not really
+         *	  supported, it is just there for convenience, may be removed in the future)
+         *	- a reply always start with the length and command in the same order the request used it
+         *	- length of the reply data is specific to the command used
+         *	- some of the commands work on a rail and can be switched to a specific rail (0 = 12v,
+         *	  1 = 5v, 2 = 3.3v)
+         *	- the format of the init command 0xFE is swapped length/command bytes
+         *	- parameter bytes amount and values are specific to the command (rail setting is the only
+         *	  for now that uses non-zero values)
+         *	- there are much more commands, especially for configuring the device, but they are not
+         *	  supported because a wrong command/length can lockup the micro-controller
+         *	- the driver supports debugfs for values not fitting into the hwmon class
+         *	- not every device class (HXi, RMi or AXi) supports all commands
+         *	- it is a pure sensors reading driver (will not support configuring)
+        */
+
+        const int cmdBufferSize = 64;
+        const int replySize = 16;
+
+        byte[] cmdBuffer = new byte[cmdBufferSize + 1];
+        cmdBuffer[0] = 0; // report id
+        cmdBuffer[1] = length;
+        cmdBuffer[2] = (byte)cmd;
+        cmdBuffer[3] = arg;
+
+        stream.Write(cmdBuffer);
+        byte[] reply = stream.Read();
+        replyData = new byte[replySize];
+        Array.Copy(reply, 3, replyData, 0, replySize);
+
+        return reply[1] == cmdBuffer[1] && reply[2] == cmdBuffer[2];
+    }
+
+    public static void Init(HidStream stream)
+    {
+        /*
+         * PSU_CMD_INIT uses swapped length/command and expects 2 parameter bytes, this command
+         * actually generates a reply, but we don't need it
+         */
+        SendCommand(stream, (byte)Command.INIT, (Command)3, 0, out _);
+    }
+
+    public struct FirmwareInfo
+    {
+        public string Vendor;
+        public string Product;
+    }
+
+    public static FirmwareInfo FwInfo(HidStream stream)
+    {
+        if (!SendCommand(stream, 3, Command.VEND_STR, 0, out byte[] vendorArr))
+            throw new CommunicationProtocolError(stream.Device, "Can't read vendor string");
+
+        if (!SendCommand(stream, 3, Command.PROD_STR, 0, out byte[] productArr))
+            throw new CommunicationProtocolError(stream.Device, "Can't read product");
+
+        string ArrayToString(byte[] ar)
+        {
+            return Encoding.ASCII.GetString(ar.TakeWhile(x => x != 0).ToArray());
+        }
+
+        return new FirmwareInfo { Vendor = ArrayToString(vendorArr), Product = ArrayToString(productArr) };
+    }
+
+    static bool Request(HidStream stream, Command cmd, byte rail, out byte[] data)
+    {
+        //mutex_lock(&priv->lock) ;
+        switch (cmd)
+        {
+            case Command.RAIL_VOLTS_HCRIT:
+            case Command.RAIL_VOLTS_LCRIT:
+            case Command.RAIL_AMPS_HCRIT:
+            case Command.RAIL_VOLTS:
+            case Command.RAIL_AMPS:
+            case Command.RAIL_WATTS:
+                if (!SendCommand(stream, 2, Command.SELECT_RAIL, rail, out _))
+                {
+                    data = null;
+                    return false;
+                }
+
+                break;
+        }
+
+        return SendCommand(stream, 3, cmd, 0, out data);
+
+        //  mutex_unlock(&priv->lock) ;
+        //  return ret;
+    }
+
+    public static float? GetValue(HidStream stream, Command cmd, byte rail)
+    {
+        if (!Request(stream, cmd, rail, out byte[] data))
+        {
+            return null;
+        }
+
+        /*
+         * the biggest value here comes from the uptime command and to exceed MAXINT total uptime
+         * needs to be about 68 years, the rest are u16 values and the biggest value coming out of
+         * the LINEAR11 conversion are the watts values which are about 1200 for the strongest psu
+         * supported (HX1200i)
+         */
+        int tmp = BitConverter.ToInt32(data, 0); // ((int)data[3] << 24) + (data[2] << 16) + (data[1] << 8) + data[0];
+        return cmd switch
+        {
+            Command.RAIL_VOLTS_HCRIT or Command.RAIL_VOLTS_LCRIT or Command.RAIL_AMPS_HCRIT or Command.TEMP_HCRIT or Command.IN_VOLTS or Command.IN_AMPS or Command.RAIL_VOLTS or Command.RAIL_AMPS
+                or Command.TEMP0 or Command.TEMP1 or Command.FAN_RPM or Command.RAIL_WATTS or Command.TOTAL_WATTS => Linear11ToFloat32((ushort)tmp), // Linear11ToInt((ushort)tmp, 1000000);
+            Command.TOTAL_UPTIME or Command.UPTIME or Command.OCPMODE => tmp,
+            _ => null
+        };
+    }
+
+    public struct Criticals
+    {
+        public float?[] TempMax;
+
+        public float?[] VoltageMin;
+        public float?[] VoltageMax;
+
+        public float?[] CurrentMax;
+    }
+
+    public static Criticals GetCriticals(HidStream stream)
+    {
+        Criticals res = new();
+        const byte tempCount = 2;
+        res.TempMax = new float?[tempCount];
+
+        for (byte rail = 0; rail < tempCount; rail++)
+        {
+            res.TempMax[rail] = GetValue(stream, Command.TEMP_HCRIT, rail);
+        }
+
+        const byte railCount = 3; /* 3v + 5v + 12v */
+        res.VoltageMin = new float?[railCount];
+        res.VoltageMax = new float?[railCount];
+        res.CurrentMax = new float?[railCount];
+
+        for (byte rail = 0; rail < railCount; rail++)
+        {
+            res.VoltageMax[rail] = GetValue(stream, Command.RAIL_VOLTS_HCRIT, rail);
+            res.VoltageMin[rail] = GetValue(stream, Command.RAIL_VOLTS_LCRIT, rail);
+            res.CurrentMax[rail] = GetValue(stream, Command.RAIL_AMPS_HCRIT, rail);
+        }
+
+        return res;
+    }
+
+    [Flags]
+    public enum OptionalCommands
+    {
+        None = 0x0,
+        InputCurrent = 0x1
+    }
+
+    public static OptionalCommands GetOptionalCommands(HidStream stream)
+    {
+        OptionalCommands res = OptionalCommands.None;
+        if (GetValue(stream, Command.IN_AMPS, 0).HasValue)
+        {
+            res |= OptionalCommands.InputCurrent;
+        }
+
+        return res;
+    }
+
+    public enum Command : byte
+    {
+        SELECT_RAIL = 0x00, /* expects length 2 */
+        RAIL_VOLTS_HCRIT = 0x40, /* the rest of the commands expect length 3 */
+        RAIL_VOLTS_LCRIT = 0x44,
+        RAIL_AMPS_HCRIT = 0x46,
+        TEMP_HCRIT = 0x4F,
+        IN_VOLTS = 0x88,
+        IN_AMPS = 0x89,
+        RAIL_VOLTS = 0x8B,
+        RAIL_AMPS = 0x8C,
+        TEMP0 = 0x8D,
+        TEMP1 = 0x8E,
+        FAN_RPM = 0x90,
+        RAIL_WATTS = 0x96,
+        VEND_STR = 0x99,
+        PROD_STR = 0x9A,
+        TOTAL_UPTIME = 0xD1,
+        UPTIME = 0xD2,
+        OCPMODE = 0xD8,
+        TOTAL_WATTS = 0xEE,
+        INIT = 0xFE
+    }
+}
+
+#endregion

--- a/LibreHardwareMonitorLib/Hardware/Psu/CoolerMaster/CoolerMasterPsu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Psu/CoolerMaster/CoolerMasterPsu.cs
@@ -1,486 +1,248 @@
 ﻿// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 // Copyright (C) 2020 Wilken Gottwalt<wilken.gottwalt@posteo.net>
+// Copyright (C) 2023 Jannis234
 // Copyright (C) LibreHardwareMonitor and Contributors.
+// Partial Copyright (C) Michael Möller <mmoeller@openhardwaremonitor.org> and Contributors.
 // All Rights Reserved.
-// Implemented after the Linuix kernel driver corsair_psu by Wilken Gottwalt and contributers
 
+// Implemented after the Linux kernel driver corsair_psu by Wilken Gottwalt and contributers
+// Implemented after the Linux kernel driver cm_psu by Jannis234 and contributers https://github.com/Jannis234/cm-psu
 
-// https://github.com/Jannis234/cm-psu
-// https://github.com/wgottwalt/corsair-psu
 
 
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
+using System.Linq.Expressions;
+using System.Runtime.InteropServices.ComTypes;
 using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
 using HidSharp;
+using HidSharp.Utility;
+using LibreHardwareMonitor.Hardware.Motherboard.Lpc;
+using LibreHardwareMonitor.Hardware.Psu.Corsair;
+using static LibreHardwareMonitor.Interop.Ftd2xx;
 
 namespace LibreHardwareMonitor.Hardware.Psu.CoolerMaster;
 
-internal class SensorIndices
-{
-    private readonly Dictionary<SensorType, int> _lastIndices = new();
 
-    public int NextIndex(SensorType type)
-    {
-        if (!_lastIndices.ContainsKey(type))
-        {
-            _lastIndices.Add(type, 0);
-            return 0;
-        }
-
-        int res = _lastIndices[type] + 1;
-        _lastIndices[type] = res;
-        return res;
-    }
-}
-
-// might need refactoring into two classes if AXi series API differs significantly
 internal sealed class CoolerMasterPsu : Hardware
 {
-    private readonly List<CompositeSensor> _compositeSensors = new();
+
     private readonly HidDevice _device;
     private readonly List<PsuSensor> _sensors = new();
+    private HidStream stream;
+    private bool _running;
+
 
     public CoolerMasterPsu(HidDevice device, ISettings settings, int index)
         : base("CoolerMaster PSU", new Identifier("psu", "coolermaster", index.ToString()), settings)
     {
         _device = device;
-        using HidStream stream = device.Open();
 
-        UsbApi.Init(stream);
-        UsbApi.FirmwareInfo fwInfo = UsbApi.FwInfo(stream);
-        Name = $"{CultureInfo.InvariantCulture.TextInfo.ToTitleCase(fwInfo.Vendor.ToLowerInvariant())} {fwInfo.Product}";
+        if (_device.TryOpen(out stream))
+        {
+            _running = true;
 
-        AddSensors(UsbApi.GetOptionalCommands(stream), UsbApi.GetCriticals(stream), settings);
+            stream = device.Open();
+
+            Task.Run(ReadStream);
+        }
+
+        AddSensors(settings);
     }
+
 
     public override HardwareType HardwareType => HardwareType.Psu;
 
-    public override IDictionary<string, string> Properties
-    {
-        get
-        {
-            SortedDictionary<string, string> properties = new();
-
-            using HidStream stream = _device.Open();
-
-            float? mode = UsbApi.GetValue(stream, UsbApi.Command.OCPMODE, 0);
-            if (mode.HasValue)
-                properties.Add("Over-current protection", mode > 1.0 ? "multi-rail" : "single-rail");
-
-            return properties;
-        }
-    }
 
     public override void Update()
     {
-        using HidStream stream = _device.Open();
+
         _sensors.ForEach(s => s.Update(stream));
     }
 
-    private void AddSensors(UsbApi.OptionalCommands optionalCommands, UsbApi.Criticals criticals, ISettings settings)
+
+    private void ReadStream()
+    {
+        byte[] inputReportBuffer = new byte[_device.GetMaxInputReportLength()];
+
+        while (_running)
+        {
+            IAsyncResult ar = null;
+
+            while (_running)
+            {
+                ar ??= stream.BeginRead(inputReportBuffer, 0, inputReportBuffer.Length, null, null);
+
+                if (ar.IsCompleted)
+                {
+                    int byteCount = stream.EndRead(ar);
+                    ar = null;
+                    Decode(inputReportBuffer);
+
+                }
+                else
+                {
+                    ar.AsyncWaitHandle.WaitOne(1000);
+                }
+            }
+        }
+    }
+
+
+    private void Decode(byte[] data)
+    {
+        float Value1;
+        float Value2;
+
+        try
+        {
+            // Extract values
+            String valueString = System.Text.Encoding.ASCII.GetString(data, 4, 10).Replace("]", "");
+            String[] Values = valueString.Split('/');
+            Value1 = float.Parse(Values[0]);
+            if (Values.Length == 2) Value2 = float.Parse(Values[1]); else Value2 = 0;
+
+            // Extract channel
+            int Channel = data[3] - 48;
+            if (Channel == 4) Channel = 5;
+
+            switch (data[2])
+            {
+                case 0x56: // Volts
+                    UpdateSensor((Rail)Channel, SensorType.Voltage, Value1);
+                    break;
+
+                case 0x49: // Current
+                    UpdateSensor((Rail)Channel, SensorType.Current, Value1);
+                    break;
+
+                case 0x50: // Power
+                    if (Channel == 2)
+                    {
+                        UpdateSensor("Power In", SensorType.Power, Value1);
+                        UpdateSensor("Power Out", SensorType.Power, Value2);
+                    }
+                    break;
+
+                case 0x54: // Temp
+                    if (Channel == 1)
+                        UpdateSensor("Case", SensorType.Temperature, Value1);
+                    else
+                        UpdateSensor("VRM", SensorType.Temperature, Value1);
+                    break;
+
+                case 0x52:
+                    UpdateSensor("Case", SensorType.Fan, Value1);
+                    break;
+
+                default:
+                    //   ReadingType = "Unknown";
+                    break;
+            }
+        }
+        catch
+        {
+        }
+    }
+
+
+    private void UpdateSensor(Rail rail, SensorType sensorType, float Value)
+    {
+        if (rail != null && sensorType != null)
+        {
+            foreach (PsuSensor sensor in _sensors)
+            {
+                if (sensor.rail == rail && sensor.SensorType == sensorType)
+                {
+                    sensor.Value = Value;
+                }
+            }
+        }
+    }
+
+
+    private void UpdateSensor(String name, SensorType sensorType, float Value)
+    {
+        if (name != null && sensorType != null)
+        {
+            foreach (PsuSensor sensor in _sensors)
+            {
+                if (sensor.Name == name && sensor.SensorType == sensorType)
+                {
+                    sensor.Value = Value;
+                }
+            }
+        }
+    }
+
+
+    public override void Close()
+    {
+        _running = false;
+        stream.Close();
+        base.Close();
+    }
+
+
+    private void AddSensors(ISettings settings)
     {
         SensorIndices indices = new();
-        _sensors.Add(new PsuSensorWithLimits("VRM",
-                                             indices,
-                                             SensorType.Temperature,
-                                             this,
-                                             settings,
-                                             UsbApi.Command.TEMP0,
-                                             null,
-                                             criticals.TempMax[0]));
+        _sensors.Add(new PsuSensor("VRM", indices, SensorType.Temperature, this, settings));
+        _sensors.Add(new PsuSensor("Case", indices, SensorType.Temperature, this,settings));
 
-        _sensors.Add(new PsuSensorWithLimits("Case",
-                                             indices,
-                                             SensorType.Temperature,
-                                             this,
-                                             settings,
-                                             UsbApi.Command.TEMP1,
-                                             null,
-                                             criticals.TempMax[1]));
+        _sensors.Add(new PsuSensor("Case", indices, SensorType.Fan, this, settings));
 
-        _sensors.Add(new PsuSensor("Case", indices, SensorType.Fan, this, settings, UsbApi.Command.FAN_RPM));
+        _sensors.Add(new PsuSensor("Input", indices, SensorType.Voltage, this, settings, Rail._Input));
+        _sensors.Add(new PsuSensor("+12V", indices, SensorType.Voltage, this, settings, Rail._12V ));
+        _sensors.Add(new PsuSensor("+5V", indices, SensorType.Voltage, this, settings, Rail._5V));
+        _sensors.Add(new PsuSensor("+3.3V", indices, SensorType.Voltage, this, settings, Rail._3V));
+  
+        _sensors.Add(new PsuSensor("Input", indices, SensorType.Current, this, settings, Rail._Input));
+        _sensors.Add(new PsuSensor("+12V", indices, SensorType.Current, this, settings, Rail._12V));
+        _sensors.Add(new PsuSensor("+5V", indices, SensorType.Current, this,  settings, Rail._5V));
+        _sensors.Add(new PsuSensor("+3.3V", indices,  SensorType.Current, this, settings, Rail._3V));
 
-        _sensors.Add(new PsuSensor("Input", indices, SensorType.Voltage, this, settings, UsbApi.Command.IN_VOLTS));
-        _sensors.Add(new PsuSensorWithLimits("+12V",
-                                             indices,
-                                             SensorType.Voltage,
-                                             this,
-                                             settings,
-                                             UsbApi.Command.RAIL_VOLTS,
-                                             criticals.VoltageMin[(byte)Rail._12V],
-                                             criticals.VoltageMax[(byte)Rail._12V]));
 
-        _sensors.Add(new PsuSensorWithLimits("+5V",
-                                             indices,
-                                             SensorType.Voltage,
-                                             this,
-                                             settings,
-                                             UsbApi.Command.RAIL_VOLTS,
-                                             criticals.VoltageMin[(byte)Rail._5V],
-                                             criticals.VoltageMax[(byte)Rail._5V],
-                                             Rail._5V));
-
-        _sensors.Add(new PsuSensorWithLimits("+3.3V",
-                                             indices,
-                                             SensorType.Voltage,
-                                             this,
-                                             settings,
-                                             UsbApi.Command.RAIL_VOLTS,
-                                             criticals.VoltageMin[(byte)Rail._3V],
-                                             criticals.VoltageMax[(byte)Rail._3V],
-                                             Rail._3V));
-
-        if (optionalCommands.HasFlag(UsbApi.OptionalCommands.InputCurrent))
-        {
-            _sensors.Add(new PsuSensor("Input", indices, SensorType.Current, this, settings, UsbApi.Command.IN_AMPS));
-        }
-
-        _sensors.Add(new PsuSensorWithLimits("+12V",
-                                             indices,
-                                             SensorType.Current,
-                                             this,
-                                             settings,
-                                             UsbApi.Command.RAIL_AMPS,
-                                             null,
-                                             criticals.CurrentMax[(byte)Rail._12V]));
-
-        _sensors.Add(new PsuSensorWithLimits("+5V",
-                                             indices,
-                                             SensorType.Current,
-                                             this,
-                                             settings,
-                                             UsbApi.Command.RAIL_AMPS,
-                                             null,
-                                             criticals.CurrentMax[(byte)Rail._5V],
-                                             Rail._5V));
-
-        _sensors.Add(new PsuSensorWithLimits("+3.3V",
-                                             indices,
-                                             SensorType.Current,
-                                             this,
-                                             settings,
-                                             UsbApi.Command.RAIL_AMPS,
-                                             null,
-                                             criticals.CurrentMax[(byte)Rail._3V],
-                                             Rail._3V));
-
-        PsuSensor[] powerRails =
-        {
-            new("+12V", indices, SensorType.Power, this, settings, UsbApi.Command.RAIL_WATTS),
-            new("+5V", indices, SensorType.Power, this, settings, UsbApi.Command.RAIL_WATTS, Rail._5V),
-            new("+3.3V", indices, SensorType.Power, this, settings, UsbApi.Command.RAIL_WATTS, Rail._3V)
-        };
-
-        _sensors.AddRange(powerRails);
-        _sensors.Add(new PsuSensor("Total watts", indices, SensorType.Power, this, settings, UsbApi.Command.TOTAL_WATTS));
-        _compositeSensors.Add(new CompositeSensor("Total Output",
-                                                  indices.NextIndex(SensorType.Power),
-                                                  SensorType.Power,
-                                                  this,
-                                                  settings,
-                                                  powerRails,
-                                                  (acc, sensor) => acc + sensor.Value ?? 0f));
-
-        ActivateSensor(_compositeSensors[_compositeSensors.Count - 1]);
-
-        _sensors.Add(new PsuSensor("Uptime", indices, SensorType.TimeSpan, this, settings, UsbApi.Command.UPTIME, Rail._12V, true));
-        _sensors.Add(new PsuSensor("Total uptime", indices, SensorType.TimeSpan, this, settings, UsbApi.Command.TOTAL_UPTIME, Rail._12V, true));
+        _sensors.Add(new PsuSensor("Power In", indices, SensorType.Power, this, settings, Rail._Input));
+        _sensors.Add(new PsuSensor("Power Out", indices, SensorType.Power, this, settings, Rail._Input));
     }
+
 
     private class PsuSensor : Sensor
     {
         private readonly UsbApi.Command _cmd;
-        private readonly byte _rail;
+        public readonly Rail rail;
 
-        public PsuSensor(string name, SensorIndices indices, SensorType type, CoolerMasterPsu hardware, ISettings settings, UsbApi.Command cmd, Rail rail = Rail._12V, bool noHistory = false)
+        float parsedvalue;
+
+        public PsuSensor(string name, SensorIndices indices, SensorType type, CoolerMasterPsu hardware, ISettings settings, Rail rail = Rail._12V, bool noHistory = false)
             : base(name, indices.NextIndex(type), false, type, hardware, null, settings, noHistory)
         {
-            _cmd = cmd;
-            _rail = (byte)rail;
+            this.rail = rail;
 
             hardware.ActivateSensor(this);
         }
 
         public void Update(HidStream stream)
         {
-            Value = UsbApi.GetValue(stream, _cmd, _rail);
+            //Value = parsedvalue;
         }
     }
 
-    private class PsuSensorWithLimits : PsuSensor, ICriticalSensorLimits
-    {
-        public PsuSensorWithLimits
-        (
-            string name,
-            SensorIndices indices,
-            SensorType type,
-            CoolerMasterPsu hardware,
-            ISettings settings,
-            UsbApi.Command cmd,
-            float? lowCritical,
-            float? highCritical,
-            Rail rail = Rail._12V)
-            : base(name, indices, type, hardware, settings, cmd, rail)
-        {
-            CriticalLowLimit = lowCritical;
-            CriticalHighLimit = highCritical;
-        }
-
-        public float? CriticalHighLimit { get; }
-
-        public float? CriticalLowLimit { get; }
-    }
 
     private enum Rail : byte
     {
-        _12V = 0,
-        _5V = 1,
-        _3V = 2
+        _Input = 1,
+        _5V = 2,
+        _3V = 3,
+        _12V = 5,
     }
 }
 
-#region Exception classes
 
-public class CommunicationProtocolError : ApplicationException
-{
-    public CommunicationProtocolError(HidDevice device, string message)
-        : base($"Error communicating with the PSU controller at {device.DevicePath}: {message}")
-    { }
-}
-
-#endregion
-
-#region PSU USB communication protocol implementation
-
-internal static class UsbApi
-{
-    /* some values are SMBus LINEAR11 data which need a conversion */
-#if false
-        static int Linear11ToInt(ushort val, int scale)
-        {
-            int exp = ((short)val) >> 11;
-            int mant = (((short)(val & 0x7ff)) << 5) >> 5;
-            int result = mant * scale;
-
-            return (exp >= 0) ? (result << exp) : (result >> -exp);
-        }
-#endif
-    static float Linear11ToFloat32(ushort val)
-    {
-        int exp = (short)val >> 11;
-        int mant = ((short)(val & 0x7ff) << 5) >> 5;
-        return mant * (float)Math.Pow(2, exp);
-    }
-
-    static bool SendCommand(HidStream stream, byte length, Command cmd, byte arg, out byte[] replyData)
-    {
-        /*
-         * Corsair protocol for PSUs
-         *
-         * message size = 64 bytes (request and response, little endian)
-         * request:
-         *	[length][command][param0][param1][paramX]...
-         * reply:
-         *	[echo of length][echo of command][data0][data1][dataX]...
-         *
-         *	- commands are byte sized opcodes
-         *	- length is the sum of all bytes of the commands/params
-         *	- the micro-controller of most of these PSUs support concatenation in the request and reply,
-         *	  but it is better to not rely on this (it is also hard to parse)
-         *	- the driver uses raw events to be accessible from userspace (though this is not really
-         *	  supported, it is just there for convenience, may be removed in the future)
-         *	- a reply always start with the length and command in the same order the request used it
-         *	- length of the reply data is specific to the command used
-         *	- some of the commands work on a rail and can be switched to a specific rail (0 = 12v,
-         *	  1 = 5v, 2 = 3.3v)
-         *	- the format of the init command 0xFE is swapped length/command bytes
-         *	- parameter bytes amount and values are specific to the command (rail setting is the only
-         *	  for now that uses non-zero values)
-         *	- there are much more commands, especially for configuring the device, but they are not
-         *	  supported because a wrong command/length can lockup the micro-controller
-         *	- the driver supports debugfs for values not fitting into the hwmon class
-         *	- not every device class (HXi, RMi or AXi) supports all commands
-         *	- it is a pure sensors reading driver (will not support configuring)
-        */
-
-        const int cmdBufferSize = 64;
-        const int replySize = 16;
-
-        byte[] cmdBuffer = new byte[cmdBufferSize + 1];
-        cmdBuffer[0] = 0; // report id
-        cmdBuffer[1] = length;
-        cmdBuffer[2] = (byte)cmd;
-        cmdBuffer[3] = arg;
-
-        stream.Write(cmdBuffer);
-        byte[] reply = stream.Read();
-        replyData = new byte[replySize];
-        Array.Copy(reply, 3, replyData, 0, replySize);
-
-        return reply[1] == cmdBuffer[1] && reply[2] == cmdBuffer[2];
-    }
-
-    public static void Init(HidStream stream)
-    {
-        /*
-         * PSU_CMD_INIT uses swapped length/command and expects 2 parameter bytes, this command
-         * actually generates a reply, but we don't need it
-         */
-        SendCommand(stream, (byte)Command.INIT, (Command)3, 0, out _);
-    }
-
-    public struct FirmwareInfo
-    {
-        public string Vendor;
-        public string Product;
-    }
-
-    public static FirmwareInfo FwInfo(HidStream stream)
-    {
-        if (!SendCommand(stream, 3, Command.VEND_STR, 0, out byte[] vendorArr))
-            throw new CommunicationProtocolError(stream.Device, "Can't read vendor string");
-
-        if (!SendCommand(stream, 3, Command.PROD_STR, 0, out byte[] productArr))
-            throw new CommunicationProtocolError(stream.Device, "Can't read product");
-
-        string ArrayToString(byte[] ar)
-        {
-            return Encoding.ASCII.GetString(ar.TakeWhile(x => x != 0).ToArray());
-        }
-
-        return new FirmwareInfo { Vendor = ArrayToString(vendorArr), Product = ArrayToString(productArr) };
-    }
-
-    static bool Request(HidStream stream, Command cmd, byte rail, out byte[] data)
-    {
-        //mutex_lock(&priv->lock) ;
-        switch (cmd)
-        {
-            case Command.RAIL_VOLTS_HCRIT:
-            case Command.RAIL_VOLTS_LCRIT:
-            case Command.RAIL_AMPS_HCRIT:
-            case Command.RAIL_VOLTS:
-            case Command.RAIL_AMPS:
-            case Command.RAIL_WATTS:
-                if (!SendCommand(stream, 2, Command.SELECT_RAIL, rail, out _))
-                {
-                    data = null;
-                    return false;
-                }
-
-                break;
-        }
-
-        return SendCommand(stream, 3, cmd, 0, out data);
-
-        //  mutex_unlock(&priv->lock) ;
-        //  return ret;
-    }
-
-    public static float? GetValue(HidStream stream, Command cmd, byte rail)
-    {
-        if (!Request(stream, cmd, rail, out byte[] data))
-        {
-            return null;
-        }
-
-        /*
-         * the biggest value here comes from the uptime command and to exceed MAXINT total uptime
-         * needs to be about 68 years, the rest are u16 values and the biggest value coming out of
-         * the LINEAR11 conversion are the watts values which are about 1200 for the strongest psu
-         * supported (HX1200i)
-         */
-        int tmp = BitConverter.ToInt32(data, 0); // ((int)data[3] << 24) + (data[2] << 16) + (data[1] << 8) + data[0];
-        return cmd switch
-        {
-            Command.RAIL_VOLTS_HCRIT or Command.RAIL_VOLTS_LCRIT or Command.RAIL_AMPS_HCRIT or Command.TEMP_HCRIT or Command.IN_VOLTS or Command.IN_AMPS or Command.RAIL_VOLTS or Command.RAIL_AMPS
-                or Command.TEMP0 or Command.TEMP1 or Command.FAN_RPM or Command.RAIL_WATTS or Command.TOTAL_WATTS => Linear11ToFloat32((ushort)tmp), // Linear11ToInt((ushort)tmp, 1000000);
-            Command.TOTAL_UPTIME or Command.UPTIME or Command.OCPMODE => tmp,
-            _ => null
-        };
-    }
-
-    public struct Criticals
-    {
-        public float?[] TempMax;
-
-        public float?[] VoltageMin;
-        public float?[] VoltageMax;
-
-        public float?[] CurrentMax;
-    }
-
-    public static Criticals GetCriticals(HidStream stream)
-    {
-        Criticals res = new();
-        const byte tempCount = 2;
-        res.TempMax = new float?[tempCount];
-
-        for (byte rail = 0; rail < tempCount; rail++)
-        {
-            res.TempMax[rail] = GetValue(stream, Command.TEMP_HCRIT, rail);
-        }
-
-        const byte railCount = 3; /* 3v + 5v + 12v */
-        res.VoltageMin = new float?[railCount];
-        res.VoltageMax = new float?[railCount];
-        res.CurrentMax = new float?[railCount];
-
-        for (byte rail = 0; rail < railCount; rail++)
-        {
-            res.VoltageMax[rail] = GetValue(stream, Command.RAIL_VOLTS_HCRIT, rail);
-            res.VoltageMin[rail] = GetValue(stream, Command.RAIL_VOLTS_LCRIT, rail);
-            res.CurrentMax[rail] = GetValue(stream, Command.RAIL_AMPS_HCRIT, rail);
-        }
-
-        return res;
-    }
-
-    [Flags]
-    public enum OptionalCommands
-    {
-        None = 0x0,
-        InputCurrent = 0x1
-    }
-
-    public static OptionalCommands GetOptionalCommands(HidStream stream)
-    {
-        OptionalCommands res = OptionalCommands.None;
-        if (GetValue(stream, Command.IN_AMPS, 0).HasValue)
-        {
-            res |= OptionalCommands.InputCurrent;
-        }
-
-        return res;
-    }
-
-    public enum Command : byte
-    {
-        SELECT_RAIL = 0x00, /* expects length 2 */
-        RAIL_VOLTS_HCRIT = 0x40, /* the rest of the commands expect length 3 */
-        RAIL_VOLTS_LCRIT = 0x44,
-        RAIL_AMPS_HCRIT = 0x46,
-        TEMP_HCRIT = 0x4F,
-        IN_VOLTS = 0x88,
-        IN_AMPS = 0x89,
-        RAIL_VOLTS = 0x8B,
-        RAIL_AMPS = 0x8C,
-        TEMP0 = 0x8D,
-        TEMP1 = 0x8E,
-        FAN_RPM = 0x90,
-        RAIL_WATTS = 0x96,
-        VEND_STR = 0x99,
-        PROD_STR = 0x9A,
-        TOTAL_UPTIME = 0xD1,
-        UPTIME = 0xD2,
-        OCPMODE = 0xD8,
-        TOTAL_WATTS = 0xEE,
-        INIT = 0xFE
-    }
-}
-
-#endregion

--- a/LibreHardwareMonitorLib/Hardware/Psu/CoolerMaster/CoolerMasterPsuGroup.cs
+++ b/LibreHardwareMonitorLib/Hardware/Psu/CoolerMaster/CoolerMasterPsuGroup.cs
@@ -1,0 +1,71 @@
+﻿// This Source Code Form is subject to the terms of the GNU Public License, v. 2.0.
+// Copyright(C) 2020 Wilken Gottwalt<wilken.gottwalt@posteo.net>
+// Copyright (C) LibreHardwareMonitor and Contributors.
+// All Rights Reserved.
+// Implemented after the Linuix kernel driver corsair_psu by Wilken Gottwalt and contributers
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using HidSharp;
+
+namespace LibreHardwareMonitor.Hardware.Psu.CoolerMaster;
+
+public class CoolerMasterPsuGroup : IGroup
+{
+    private static readonly int[] _productIds =
+    {
+        0x0030, /* MasterWatt 1200 */
+	    0x018D, /* V550 GOLD i MULTI */
+	    0x018F, /* V650 GOLD i MULTI */
+	    0x0191, /* V750 GOLD i MULTI */
+	    0x0193, /* V850 GOLD i MULTI */
+	    0x0195, /* V550 GOLD i 12VO */
+	    0x0197, /* V650 GOLD i 12VO */
+	    0x0199, /* V750 GOLD i 12VO */
+	    0x019B, /* V850 GOLD i 12VO */
+	    0x019D, /* V650 PLATINUM i 12VO */
+	    0x019F, /* V750 PLATINUM i 12VO */
+	    0x01A1, /* V850 PLATINUM i 12VO */
+        0x01A5, /* FANLESS 1300 */
+    };
+
+    private static readonly ushort _vendorId = 0x2516;
+    private readonly List<IHardware> _hardware;
+    private readonly StringBuilder _report;
+
+    public CoolerMasterPsuGroup(ISettings settings)
+    {
+        _report = new StringBuilder();
+        _report.AppendLine("CoolerMaster V Gold i series PSU Hardware");
+        _report.AppendLine();
+
+        _hardware = new List<IHardware>();
+        foreach (HidDevice dev in DeviceList.Local.GetHidDevices(_vendorId))
+        {
+            if (_productIds.Contains(dev.ProductID))
+            {
+                var device = new CoolerMasterPsu(dev, settings, _hardware.Count);
+                _hardware.Add(device);
+                _report.AppendLine($"Device name: {device.Name}");
+                _report.AppendLine();
+            }
+        }
+    }
+
+    public IReadOnlyList<IHardware> Hardware => _hardware;
+
+    public void Close()
+    {
+        foreach (IHardware iHardware in _hardware)
+        {
+            if (iHardware is Hardware hardware)
+                hardware.Close();
+        }
+    }
+
+    public string GetReport()
+    {
+        return _report.ToString();
+    }
+}

--- a/LibreHardwareMonitorLib/Hardware/Psu/CoolerMaster/CoolerMasterPsuGroup.cs
+++ b/LibreHardwareMonitorLib/Hardware/Psu/CoolerMaster/CoolerMasterPsuGroup.cs
@@ -1,8 +1,15 @@
-﻿// This Source Code Form is subject to the terms of the GNU Public License, v. 2.0.
-// Copyright(C) 2020 Wilken Gottwalt<wilken.gottwalt@posteo.net>
+﻿// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (C) 2020 Wilken Gottwalt<wilken.gottwalt@posteo.net>
+// Copyright (C) 2023 Jannis234
 // Copyright (C) LibreHardwareMonitor and Contributors.
+// Partial Copyright (C) Michael Möller <mmoeller@openhardwaremonitor.org> and Contributors.
 // All Rights Reserved.
-// Implemented after the Linuix kernel driver corsair_psu by Wilken Gottwalt and contributers
+
+// Implemented after the Linux kernel driver corsair_psu by Wilken Gottwalt and contributers
+// Implemented after the Linux kernel driver cm_psu by Jannis234 and contributers https://github.com/Jannis234/cm-psu
+
+
 
 using System.Collections.Generic;
 using System.Linq;

--- a/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
+++ b/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
@@ -48,4 +48,7 @@
       <Pack>True</Pack>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Hardware\Psu\CoolerMaster\" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Adding Cooler Master PSU support. The following PSUs are supported

- V550 GOLD i MULTI
- V650 GOLD i MULTI
- V750 GOLD i MULTI
- V850 GOLD i MULTI
- V550 GOLD i 12VO
- V650 GOLD i 12VO
- V750 GOLD i 12VO
- V850 GOLD i 12VO
- V650 PLATINUM i 12VO
- V750 PLATINUM i 12VO
- V850 PLATINUM i 12VO
- FANLESS 1300

Tested on V850 Gold i.

![image](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/assets/32393643/90138efe-6940-4ad0-87c7-00984788bd1d)


This is based on work by Jannis234

https://github.com/Jannis234/cm-psu