### PR TITLE
Fix memory size calculation with extended size

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/SMBios.cs
+++ b/LibreHardwareMonitorLib/Hardware/SMBios.cs
@@ -1094,10 +1094,9 @@ public class MemoryDevice : InformationBase
         ConfiguredSpeed = GetWord(0x20);
         ConfiguredVoltage = GetWord(0x26);
         Size = GetWord(0x0C);
+        if (Size == 0x7FFF)
+            Size = GetDword(0x1C);
         Type = (MemoryType)GetByte(0x12);
-
-        if (GetWord(0x1C) > 0)
-            Size += GetWord(0x1C);
     }
 
     /// <summary>
@@ -1126,9 +1125,11 @@ public class MemoryDevice : InformationBase
     public string SerialNumber { get; }
 
     /// <summary>
-    /// Gets the size of the memory device. If the value is 0, no memory device is installed in the socket.
+    /// Gets the size of the memory device.
+    /// If the value is 0, no memory device is installed in the socket.
+    /// If the value is 0xFFFF, the size is unknown.
     /// </summary>
-    public ushort Size { get; }
+    public uint Size { get; }
 
     /// <summary>
     /// Gets the value that identifies the maximum capable speed of the device, in mega transfers per second (MT/s).


### PR DESCRIPTION
According to the specification v.3.3.0, Chapter 7.18, Table 74, the Size row:

> If the size is 32 GB-1 MB or greater, the
> field value is 7FFFh and the actual size is stored in
> the Extended Size field.

Therefore the Extended Size should replace the value of Size if the latter equals 0x7FFF. The Extended Size should not be added to Size.

Also, since Extended Size is DWORD, Size should not be ushort.