### PR TITLE
Add 16th voltage input for NCT67xxD chips

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
@@ -140,14 +140,14 @@ internal class Nct677X : ISuperIO
                 Temperatures = new float?[4];
                 break;
 
-            case Chip.NCT6779D:
-            case Chip.NCT6791D:
+            case Chip.NCT6779D: // 15 voltages
+            case Chip.NCT6791D: // 15 voltages
             case Chip.NCT6792D:
             case Chip.NCT6792DA:
-            case Chip.NCT6793D:
+            case Chip.NCT6793D: // 14 voltages
             case Chip.NCT6795D:
-            case Chip.NCT6796D:
-            case Chip.NCT6796DR:
+            case Chip.NCT6796D: // 16 voltages
+            case Chip.NCT6796DR: // 16 voltages
             case Chip.NCT6797D:
             case Chip.NCT6798D:
             case Chip.NCT6799D:
@@ -180,8 +180,8 @@ internal class Nct677X : ISuperIO
                 // min value that could be transferred to 16-bit RPM registers
                 _minFanCount = 0x15;
 
-                Voltages = new float?[15];
-                _voltageRegisters = new ushort[] { 0x480, 0x481, 0x482, 0x483, 0x484, 0x485, 0x486, 0x487, 0x488, 0x489, 0x48A, 0x48B, 0x48C, 0x48D, 0x48E };
+                Voltages = new float?[16];
+                _voltageRegisters = new ushort[] { 0x480, 0x481, 0x482, 0x483, 0x484, 0x485, 0x486, 0x487, 0x488, 0x489, 0x48A, 0x48B, 0x48C, 0x48D, 0x48E, 0x48F };
                 _voltageVBatRegister = 0x488;
                 var temperaturesSources = new List<TemperatureSourceData>();
 


### PR DESCRIPTION
The NCT6796D and NCT6796D-R have 16 voltage inputs.

I attempted to check the other chips, but couldn't find datasheets for them all.