### PR TITLE
Fix ADL PMLog sensor, ignore invalid values

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Gpu/AmdGpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Gpu/AmdGpu.cs
@@ -503,6 +503,9 @@ internal sealed class AmdGpu : GenericGpu
             {
                 for (int k = 0; k < adlPMLogData.ulValues.Length - 1; k += 2)
                 {
+                    if (adlPMLogData.ulValues[k] == (ushort)AtiAdlxx.ADLPMLogSensors.ADL_SENSOR_MAXTYPES)
+                        break;
+
                     if (adlPMLogData.ulValues[k] == i)
                     {
                         sensor.Value = adlPMLogData.ulValues[k + 1] * factor;
@@ -935,6 +938,9 @@ internal sealed class AmdGpu : GenericGpu
                     {
                         for (int k = 0; k < adlPMLogData.ulValues.Length - 1; k += 2)
                         {
+                            if (adlPMLogData.ulValues[k] == (ushort)AtiAdlxx.ADLPMLogSensors.ADL_SENSOR_MAXTYPES)
+                                break;
+
                             if (adlPMLogData.ulValues[k] == i)
                             {
                                 r.AppendFormat(" Sensor[{0}].Value: {1}{2}", st, adlPMLogData.ulValues[k + 1], Environment.NewLine);


### PR DESCRIPTION
Some cards report multiple values, we need to discard the rest.

```
 Sensor[ADL_PMLOG_CLK_GFXCLK].Value: 192
 Sensor[ADL_PMLOG_CLK_GFXCLK].Value: 2
 Sensor[ADL_PMLOG_CLK_GFXCLK].Value: 4
 Sensor[ADL_PMLOG_CLK_GFXCLK].Value: 16842753
 Sensor[ADL_PMLOG_CLK_GFXCLK].Supported: True
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 2178
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 32762
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 32762
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 32762
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 32762
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 32762
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 32762
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 32762
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 32762
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 32762
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 32762
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 32762
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 32762
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 32762
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 32762
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 3
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 1
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 4
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 7
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 17
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 20
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 21
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 37
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 19
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 12
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 14
 Sensor[ADL_PMLOG_CLK_MEMCLK].Value: 13
 Sensor[ADL_PMLOG_CLK_MEMCLK].Supported: True
```