### PR TITLE
Add Gigabyte 970A-DS3P (and FX rev 2.1 model) support

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -226,6 +226,9 @@ internal class Identification
                 return Model.G41MT_S2;
             case var _ when name.Equals("G41MT-S2P", StringComparison.OrdinalIgnoreCase):
                 return Model.G41MT_S2P;
+            case var _ when name.Equals("970A-DS3P", StringComparison.OrdinalIgnoreCase):
+            case var _ when name.Equals("970A-DS3P FX", StringComparison.OrdinalIgnoreCase):
+                return Model._970A_DS3P;
             case var _ when name.Equals("GA-970A-UD3", StringComparison.OrdinalIgnoreCase):
                 return Model._970A_UD3;
             case var _ when name.Equals("GA-MA770T-UD3", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -125,6 +125,7 @@ public enum Model
 
     // Gigabyte
     _965P_S3,
+    _970A_DS3P,
     _970A_UD3,
     AB350_Gaming_3,
     AX370_Gaming_5,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1221,7 +1221,7 @@ internal sealed class SuperIOHardware : Hardware
                         v.Add(new Voltage("+5V", 3, 1.5f, 1));
                         v.Add(new Voltage("+3.3V", 4, 6.5f, 10));
                         v.Add(new Voltage("+3V Standby", 7, 10, 10));
-                        v.Add(new Voltage("VBat", 8));
+                        v.Add(new Voltage("CMOS Battery", 8, 10, 10));
                         t.Add(new Temperature("System", 0));
                         t.Add(new Temperature("CPU Package", 1));
                         t.Add(new Temperature("CPU Cores", 2));

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1214,6 +1214,27 @@ internal sealed class SuperIOHardware : Hardware
 
                         break;
 
+                    case Model._970A_DS3P: // IT8620E
+                        v.Add(new Voltage("Vcore", 0));
+                        v.Add(new Voltage("DIMM", 1));
+                        v.Add(new Voltage("+12V", 2, 5, 1));
+                        v.Add(new Voltage("+5V", 3, 1.5f, 1));
+                        v.Add(new Voltage("+3.3V", 4, 6.5f, 10));
+                        v.Add(new Voltage("+3V Standby", 7, 10, 10));
+                        v.Add(new Voltage("VBat", 8));
+                        t.Add(new Temperature("System", 0));
+                        t.Add(new Temperature("CPU Package", 1));
+                        t.Add(new Temperature("CPU Cores", 2));
+                        f.Add(new Fan("CPU Fan", 0));
+                        f.Add(new Fan("System Fan #1", 1));
+                        f.Add(new Fan("System Fan #2", 2));
+                        f.Add(new Fan("Power Fan", 4));
+                        c.Add(new Control("CPU Fan", 0));
+                        c.Add(new Control("System Fan #1", 1));
+                        c.Add(new Control("System Fan #2", 2));
+
+                        break;
+
                     case Model.H81M_HD3: //IT8620E
                         v.Add(new Voltage("Vcore", 0));
                         v.Add(new Voltage("Voltage #2", 1, true));


### PR DESCRIPTION
> [!NOTE]
> 1. The Power Fan simply will read RPM. There is no way to control the header as it is intentional by design to run at full speed.
> 2. The `CPU Cores` value is identical to another temperature value that the CPU reports, which is also named `CPU Cores`.

Left: Before | Right: After
![Screenshot 2024-06-15 165920](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/assets/59412384/fb63f4dd-e6c6-4d9e-a071-608e13e76419)
