### PR TITLE
LPC/EC: fix signess of the sensor readings

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
@@ -419,7 +419,7 @@ public abstract class EmbeddedController : Hardware
         {
             int val = _sources[si].Size switch
             {
-                1 => unchecked((sbyte)_data[readRegister]),
+                1 => _sources[si].Type switch { SensorType.Temperature => unchecked((sbyte)_data[readRegister]), _ => _data[readRegister] },
                 2 => unchecked((short)((_data[readRegister] << 8) + _data[readRegister + 1])),
                 _ => 0
             };


### PR DESCRIPTION
Only the temperture single-byte ones seem to be signed, the rest of them seem to be unsigned.