### PR TITLE
Fix incorrect CPU Voltage Termination value on Z690 Extreme/Steel Legend

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2870,7 +2870,7 @@ internal sealed class SuperIOHardware : Hardware
                         v.Add(new Voltage("DRAM", 6));
                         v.Add(new Voltage("+3.3V Standby", 7, 34, 34));
                         v.Add(new Voltage("CMOS Battery", 8, 34, 34));
-                        v.Add(new Voltage("CPU Voltage Termination", 9));
+                        v.Add(new Voltage("CPU Voltage Termination", 9, 1, 1));
                         v.Add(new Voltage("CPU 1.05V", 10, 1, 1));
                         v.Add(new Voltage("Chipset 0.82V", 11, 1, 1));
                         v.Add(new Voltage("Chipset 1.0V", 12));


### PR DESCRIPTION
The CPU Voltage Termination value used was incorrect, an oversight on my part when initially adding the board. I have corrected this.

Before (Left) | After (Right)
![image](https://github.com/user-attachments/assets/5c6453f8-2bc3-4f30-9ad5-38f4a082d4cc)
