### PR TITLE
Add support for ASRock Z790 Pro RS

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -531,6 +531,9 @@ internal class Identification
             case var _ when name.Equals("Z690 Extreme WiFi 6E", StringComparison.OrdinalIgnoreCase):
             case var _ when name.Equals("Z690 Extreme", StringComparison.OrdinalIgnoreCase):
                 return Model.Z690_Extreme;
+            case var _ when name.Equals("Z790 Pro RS", StringComparison.OrdinalIgnoreCase):
+            case var _ when name.Equals("Z790 Pro RS WiFi", StringComparison.OrdinalIgnoreCase):
+                return Model.Z790_Pro_RS;
             case var _ when name.Equals("Z790 Taichi", StringComparison.OrdinalIgnoreCase):
             case var _ when name.Equals("Z790 Taichi Carrara", StringComparison.OrdinalIgnoreCase):
                 return Model.Z790_Taichi;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -36,6 +36,7 @@ public enum Model
     X570_Phantom_Gaming_ITX,
     Z690_Extreme,
     Z690_Steel_Legend,
+    Z790_Pro_RS,
     Z790_Taichi,
     H61M_DGS,
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2861,6 +2861,7 @@ internal sealed class SuperIOHardware : Hardware
 
                     case Model.Z690_Extreme:
                     case Model.Z690_Steel_Legend:
+                    case model.Z790_Pro_RS:
                         v.Add(new Voltage("Vcore", 0));
                         v.Add(new Voltage("+5V", 1, 20, 10));
                         v.Add(new Voltage("AVCC", 2, 34, 34));
@@ -2875,6 +2876,7 @@ internal sealed class SuperIOHardware : Hardware
                         v.Add(new Voltage("Chipset 0.82V", 11, 1, 1));
                         v.Add(new Voltage("Chipset 1.0V", 12));
                         v.Add(new Voltage("CPU System Agent", 13, 1, 1));
+                        v.Add(new Voltage("+5V Standby", 14, 2.35f, 1));
 
                         f.Add(new Fan("CPU Fan #1", 1));
                         f.Add(new Fan("CPU Fan #2", 2));

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2861,7 +2861,6 @@ internal sealed class SuperIOHardware : Hardware
 
                     case Model.Z690_Extreme:
                     case Model.Z690_Steel_Legend:
-                    case Model.Z790_Pro_RS:
                         v.Add(new Voltage("Vcore", 0));
                         v.Add(new Voltage("+5V", 1, 20, 10));
                         v.Add(new Voltage("AVCC", 2, 34, 34));
@@ -2871,7 +2870,7 @@ internal sealed class SuperIOHardware : Hardware
                         v.Add(new Voltage("DRAM", 6));
                         v.Add(new Voltage("+3.3V Standby", 7, 34, 34));
                         v.Add(new Voltage("CMOS Battery", 8, 34, 34));
-                        v.Add(new Voltage("CPU Voltage Termination", 9));
+                        v.Add(new Voltage("CPU Voltage Termination", 9, 1, 1));
                         v.Add(new Voltage("CPU 1.05V", 10, 1, 1));
                         v.Add(new Voltage("Chipset 0.82V", 11, 1, 1));
                         v.Add(new Voltage("Chipset 1.0V", 12));
@@ -2897,6 +2896,44 @@ internal sealed class SuperIOHardware : Hardware
                         t.Add(new Temperature("CPU Core", 0));
                         t.Add(new Temperature("Motherboard", 2));
                         break;
+
+                    case Model.Z790_Pro_RS:
+                        v.Add(new Voltage("Vcore", 0));
+                        v.Add(new Voltage("+5V", 1, 20, 10));
+                        v.Add(new Voltage("AVCC", 2, 34, 34));
+                        v.Add(new Voltage("+3.3V", 3, 34, 34));
+                        v.Add(new Voltage("+12V", 4, 110, 10));
+                        v.Add(new Voltage("CPU Input Auxiliary", 5, 1, 1));
+                        v.Add(new Voltage("Integrated Memory Controller", 6));
+                        v.Add(new Voltage("+3.3V Standby", 7, 34, 34));
+                        v.Add(new Voltage("CMOS Battery", 8, 34, 34));
+                        v.Add(new Voltage("CPU Voltage Termination", 9, 1, 1));
+                        v.Add(new Voltage("CPU 1.05V", 10, 1, 1));
+                        v.Add(new Voltage("Chipset 0.82V", 11, 1, 1));
+                        v.Add(new Voltage("Chipset 1.0V", 12));
+                        v.Add(new Voltage("CPU System Agent", 13, 1, 1));
+                        v.Add(new Voltage("+5V Standby", 14, 2.35f, 1));
+
+                        f.Add(new Fan("CPU Fan #1", 1));
+                        f.Add(new Fan("CPU Fan #2", 2));
+                        f.Add(new Fan("Chassis Fan #1", 3));
+                        f.Add(new Fan("Chassis Fan #2", 4));
+                        f.Add(new Fan("Chassis Fan #3", 0));
+                        f.Add(new Fan("Chassis Fan #4", 5));
+                        f.Add(new Fan("Chassis Fan #5", 6));
+
+                        c.Add(new Control("CPU Fan #1", 1)); // CPU_FAN1
+                        c.Add(new Control("CPU Fan #2", 2)); // CPU_FAN2/WP
+                        c.Add(new Control("Chassis Fan #1", 3)); // CHA_FAN1/WP
+                        c.Add(new Control("Chassis Fan #2", 4)); // CHA_FAN2/WP
+                        c.Add(new Control("Chassis Fan #3", 0)); // CHA_FAN3/WP
+                        c.Add(new Control("Chassis Fan #4", 5)); // CHA_FAN4/WP
+                        c.Add(new Control("Chassis Fan #5", 6)); // CHA_FAN5/WP
+
+                        t.Add(new Temperature("CPU Core", 0));
+                        t.Add(new Temperature("Motherboard", 2));
+                        break;
+
                     case Model.Z790_Taichi:
                         v.Add(new Voltage("CPU 1.8V", 0));
                         v.Add(new Voltage("Chipset 0.82V", 1));

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2861,7 +2861,7 @@ internal sealed class SuperIOHardware : Hardware
 
                     case Model.Z690_Extreme:
                     case Model.Z690_Steel_Legend:
-                    case model.Z790_Pro_RS:
+                    case Model.Z790_Pro_RS:
                         v.Add(new Voltage("Vcore", 0));
                         v.Add(new Voltage("+5V", 1, 20, 10));
                         v.Add(new Voltage("AVCC", 2, 34, 34));


### PR DESCRIPTION
For the most part, this dataset is similar to #1343. 

Since this is a DDR5 board and not DDR4, value DRAM would be an incorrect representation. For this reason, the dataset needed to be split to represent the IMC value. 

Before:
![image](https://github.com/user-attachments/assets/328dca49-7b02-4be6-b9dd-f7366a097aa9)

After (The screenshot will show DRAM as the name, but that was quickly changed after, as well as correcting the VTT value):
![image](https://github.com/user-attachments/assets/4c879cea-d00c-4830-b6d7-c709bb71f516)
