### PR TITLE
#1393 Scale up Sensor column on resize &  Log file rotation method

### DIFF
--- a/LibreHardwareMonitor/UI/MainForm.Designer.cs
+++ b/LibreHardwareMonitor/UI/MainForm.Designer.cs
@@ -93,9 +93,9 @@ namespace LibreHardwareMonitor.UI
             this.splitPanelFixedSensorScalingMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
             this.logSeparatorMenuItem = new System.Windows.Forms.ToolStripSeparator();
             this.logSensorsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.fileRotationMethod = new System.Windows.Forms.ToolStripMenuItem();
-			this.perSessionFileRotationMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
-			this.dailyFileRotationMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.fileRotationMethod = new System.Windows.Forms.ToolStripMenuItem();
+            this.perSessionFileRotationMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+            this.dailyFileRotationMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
             this.loggingIntervalMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.log1sMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
             this.log2sMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
@@ -587,34 +587,34 @@ namespace LibreHardwareMonitor.UI
             this.logSensorsMenuItem.Name = "logSensorsMenuItem";
             this.logSensorsMenuItem.Size = new System.Drawing.Size(221, 22);
             this.logSensorsMenuItem.Text = "Log Sensors";
-			//
-			// fileRotationMethod
-			//
-			this.fileRotationMethod.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            //
+            // fileRotationMethod
+            //
+            this.fileRotationMethod.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.perSessionFileRotationMenuItem,
             this.dailyFileRotationMenuItem});
-			this.fileRotationMethod.Name = "fileRotationMethod";
-			this.fileRotationMethod.Size = new System.Drawing.Size(246, 24);
-			this.fileRotationMethod.Text = "File rotation method";
-			this.fileRotationMethod.ToolTipText = "Determine how the log file should rotate.";
-			//
-			// perSessionFileRotationMenuItem
-			//
-			this.perSessionFileRotationMenuItem.CheckOnClick = true;
-			this.perSessionFileRotationMenuItem.Name = "perSessionFileRotationMenuItem";
-			this.perSessionFileRotationMenuItem.Size = new System.Drawing.Size(198, 24);
-			this.perSessionFileRotationMenuItem.Text = "Per session";
-			this.perSessionFileRotationMenuItem.ToolTipText = "Create a new log file for each logging session";
-			this.perSessionFileRotationMenuItem.Click += new System.EventHandler(this.perSessionFileRotationMenuItem_Click);
-			//
-			// dailyFileRotationMenuItem
-			//
-			this.dailyFileRotationMenuItem.CheckOnClick = true;
-			this.dailyFileRotationMenuItem.Name = "dailyFileRotationMenuItem";
-			this.dailyFileRotationMenuItem.Size = new System.Drawing.Size(198, 24);
-			this.dailyFileRotationMenuItem.Text = "Daily";
-			this.dailyFileRotationMenuItem.ToolTipText = "Create a new log file every day.\n Note: If a file already exists for the current day, the new data will be appended at the end.";
-			this.dailyFileRotationMenuItem.Click += new System.EventHandler(this.dailyFileRotationMenuItem_Click);
+            this.fileRotationMethod.Name = "fileRotationMethod";
+            this.fileRotationMethod.Size = new System.Drawing.Size(246, 24);
+            this.fileRotationMethod.Text = "File rotation method";
+            this.fileRotationMethod.ToolTipText = "Determine how the log file should rotate.";
+            //
+            // perSessionFileRotationMenuItem
+            //
+            this.perSessionFileRotationMenuItem.CheckOnClick = true;
+            this.perSessionFileRotationMenuItem.Name = "perSessionFileRotationMenuItem";
+            this.perSessionFileRotationMenuItem.Size = new System.Drawing.Size(198, 24);
+            this.perSessionFileRotationMenuItem.Text = "Per session";
+            this.perSessionFileRotationMenuItem.ToolTipText = "Create a new log file for each logging session";
+            this.perSessionFileRotationMenuItem.Click += new System.EventHandler(this.perSessionFileRotationMenuItem_Click);
+            //
+            // dailyFileRotationMenuItem
+            //
+            this.dailyFileRotationMenuItem.CheckOnClick = true;
+            this.dailyFileRotationMenuItem.Name = "dailyFileRotationMenuItem";
+            this.dailyFileRotationMenuItem.Size = new System.Drawing.Size(198, 24);
+            this.dailyFileRotationMenuItem.Text = "Daily";
+            this.dailyFileRotationMenuItem.ToolTipText = "Create a new log file every day.\n Note: If a file already exists for the current day, the new data will be appended at the end.";
+            this.dailyFileRotationMenuItem.Click += new System.EventHandler(this.dailyFileRotationMenuItem_Click);
             //
             // loggingIntervalMenuItem
             //

--- a/LibreHardwareMonitor/UI/MainForm.Designer.cs
+++ b/LibreHardwareMonitor/UI/MainForm.Designer.cs
@@ -93,6 +93,9 @@ namespace LibreHardwareMonitor.UI
             this.splitPanelFixedSensorScalingMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
             this.logSeparatorMenuItem = new System.Windows.Forms.ToolStripSeparator();
             this.logSensorsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.fileRotationMethod = new System.Windows.Forms.ToolStripMenuItem();
+			this.perSessionFileRotationMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
+			this.dailyFileRotationMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
             this.loggingIntervalMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.log1sMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
             this.log2sMenuItem = new LibreHardwareMonitor.UI.ToolStripRadioButtonMenuItem();
@@ -146,51 +149,51 @@ namespace LibreHardwareMonitor.UI
             this.splitContainer.Panel1.SuspendLayout();
             this.splitContainer.SuspendLayout();
             this.SuspendLayout();
-            // 
+            //
             // sensor
-            // 
+            //
             this.sensor.Header = "Sensor";
             this.sensor.SortOrder = System.Windows.Forms.SortOrder.None;
             this.sensor.TooltipText = null;
             this.sensor.Width = 250;
-            // 
+            //
             // value
-            // 
+            //
             this.value.Header = "Value";
             this.value.SortOrder = System.Windows.Forms.SortOrder.None;
             this.value.TooltipText = null;
             this.value.Width = 100;
-            // 
+            //
             // min
-            // 
+            //
             this.min.Header = "Min";
             this.min.SortOrder = System.Windows.Forms.SortOrder.None;
             this.min.TooltipText = null;
             this.min.Width = 100;
-            // 
+            //
             // max
-            // 
+            //
             this.max.Header = "Max";
             this.max.SortOrder = System.Windows.Forms.SortOrder.None;
             this.max.TooltipText = null;
             this.max.Width = 100;
-            // 
+            //
             // nodeImage
-            // 
+            //
             this.nodeImage.DataPropertyName = "Image";
             this.nodeImage.LeftMargin = 1;
             this.nodeImage.ParentColumn = this.sensor;
             this.nodeImage.ScaleMode = Aga.Controls.Tree.ImageScaleMode.Fit;
-            // 
+            //
             // nodeCheckBox
-            // 
+            //
             this.nodeCheckBox.DataPropertyName = "Plot";
             this.nodeCheckBox.EditEnabled = true;
             this.nodeCheckBox.LeftMargin = 3;
             this.nodeCheckBox.ParentColumn = this.sensor;
-            // 
+            //
             // nodeTextBoxText
-            // 
+            //
             this.nodeTextBoxText.DataPropertyName = "Text";
             this.nodeTextBoxText.EditEnabled = true;
             this.nodeTextBoxText.IncrementalSearchEnabled = true;
@@ -198,36 +201,36 @@ namespace LibreHardwareMonitor.UI
             this.nodeTextBoxText.ParentColumn = this.sensor;
             this.nodeTextBoxText.Trimming = System.Drawing.StringTrimming.EllipsisCharacter;
             this.nodeTextBoxText.UseCompatibleTextRendering = true;
-            // 
+            //
             // nodeTextBoxValue
-            // 
+            //
             this.nodeTextBoxValue.DataPropertyName = "Value";
             this.nodeTextBoxValue.IncrementalSearchEnabled = true;
             this.nodeTextBoxValue.LeftMargin = 3;
             this.nodeTextBoxValue.ParentColumn = this.value;
             this.nodeTextBoxValue.Trimming = System.Drawing.StringTrimming.EllipsisCharacter;
             this.nodeTextBoxValue.UseCompatibleTextRendering = true;
-            // 
+            //
             // nodeTextBoxMin
-            // 
+            //
             this.nodeTextBoxMin.DataPropertyName = "Min";
             this.nodeTextBoxMin.IncrementalSearchEnabled = true;
             this.nodeTextBoxMin.LeftMargin = 3;
             this.nodeTextBoxMin.ParentColumn = this.min;
             this.nodeTextBoxMin.Trimming = System.Drawing.StringTrimming.EllipsisCharacter;
             this.nodeTextBoxMin.UseCompatibleTextRendering = true;
-            // 
+            //
             // nodeTextBoxMax
-            // 
+            //
             this.nodeTextBoxMax.DataPropertyName = "Max";
             this.nodeTextBoxMax.IncrementalSearchEnabled = true;
             this.nodeTextBoxMax.LeftMargin = 3;
             this.nodeTextBoxMax.ParentColumn = this.max;
             this.nodeTextBoxMax.Trimming = System.Drawing.StringTrimming.EllipsisCharacter;
             this.nodeTextBoxMax.UseCompatibleTextRendering = true;
-            // 
+            //
             // mainMenu
-            // 
+            //
             this.mainMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileMenuItem,
             this.viewMenuItem,
@@ -237,9 +240,9 @@ namespace LibreHardwareMonitor.UI
             this.mainMenu.Name = "mainMenu";
             this.mainMenu.Size = new System.Drawing.Size(418, 24);
             this.mainMenu.TabIndex = 1;
-            // 
+            //
             // fileMenuItem
-            // 
+            //
             this.fileMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.saveReportMenuItem,
             this.MenuItem2,
@@ -250,28 +253,28 @@ namespace LibreHardwareMonitor.UI
             this.fileMenuItem.Name = "fileMenuItem";
             this.fileMenuItem.Size = new System.Drawing.Size(37, 20);
             this.fileMenuItem.Text = "File";
-            // 
+            //
             // saveReportMenuItem
-            // 
+            //
             this.saveReportMenuItem.Name = "saveReportMenuItem";
             this.saveReportMenuItem.Size = new System.Drawing.Size(180, 22);
             this.saveReportMenuItem.Text = "Save Report...";
             this.saveReportMenuItem.Click += new System.EventHandler(this.SaveReportMenuItem_Click);
-            // 
+            //
             // MenuItem2
-            // 
+            //
             this.MenuItem2.Name = "MenuItem2";
             this.MenuItem2.Size = new System.Drawing.Size(177, 6);
-            // 
+            //
             // resetMenuItem
-            // 
+            //
             this.resetMenuItem.Name = "resetMenuItem";
             this.resetMenuItem.Size = new System.Drawing.Size(180, 22);
             this.resetMenuItem.Text = "Reset";
             this.resetMenuItem.Click += new System.EventHandler(this.ResetClick);
-            // 
+            //
             // menuItem5
-            // 
+            //
             this.menuItem5.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mainboardMenuItem,
             this.cpuMenuItem,
@@ -285,69 +288,69 @@ namespace LibreHardwareMonitor.UI
             this.menuItem5.Name = "menuItem5";
             this.menuItem5.Size = new System.Drawing.Size(180, 22);
             this.menuItem5.Text = "Hardware";
-            // 
+            //
             // mainboardMenuItem
-            // 
+            //
             this.mainboardMenuItem.Name = "mainboardMenuItem";
             this.mainboardMenuItem.Size = new System.Drawing.Size(180, 22);
             this.mainboardMenuItem.Text = "Motherboard";
-            // 
+            //
             // cpuMenuItem
-            // 
+            //
             this.cpuMenuItem.Name = "cpuMenuItem";
             this.cpuMenuItem.Size = new System.Drawing.Size(180, 22);
             this.cpuMenuItem.Text = "CPU";
-            // 
+            //
             // ramMenuItem
-            // 
+            //
             this.ramMenuItem.Name = "ramMenuItem";
             this.ramMenuItem.Size = new System.Drawing.Size(180, 22);
             this.ramMenuItem.Text = "RAM";
-            // 
+            //
             // gpuMenuItem
-            // 
+            //
             this.gpuMenuItem.Name = "gpuMenuItem";
             this.gpuMenuItem.Size = new System.Drawing.Size(180, 22);
             this.gpuMenuItem.Text = "GPU";
-            // 
+            //
             // fanControllerMenuItem
-            // 
+            //
             this.fanControllerMenuItem.Name = "fanControllerMenuItem";
             this.fanControllerMenuItem.Size = new System.Drawing.Size(180, 22);
             this.fanControllerMenuItem.Text = "Fan Controllers";
-            // 
+            //
             // hddMenuItem
-            // 
+            //
             this.hddMenuItem.Name = "hddMenuItem";
             this.hddMenuItem.Size = new System.Drawing.Size(180, 22);
             this.hddMenuItem.Text = "Storage Devices";
-            // 
+            //
             // nicMenuItem
-            // 
+            //
             this.nicMenuItem.Name = "nicMenuItem";
             this.nicMenuItem.Size = new System.Drawing.Size(180, 22);
             this.nicMenuItem.Text = "Network";
-            // 
+            //
             // psuMenuItem
-            // 
+            //
             this.psuMenuItem.Name = "psuMenuItem";
             this.psuMenuItem.Size = new System.Drawing.Size(180, 22);
             this.psuMenuItem.Text = "Power supplies";
-            // 
+            //
             // menuItem6
-            // 
+            //
             this.menuItem6.Name = "menuItem6";
             this.menuItem6.Size = new System.Drawing.Size(177, 6);
-            // 
+            //
             // exitMenuItem
-            // 
+            //
             this.exitMenuItem.Name = "exitMenuItem";
             this.exitMenuItem.Size = new System.Drawing.Size(180, 22);
             this.exitMenuItem.Text = "Exit";
             this.exitMenuItem.Click += new System.EventHandler(this.ExitClick);
-            // 
+            //
             // viewMenuItem
-            // 
+            //
             this.viewMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.resetMinMaxMenuItem,
             this.resetPlotMenuItem,
@@ -360,51 +363,51 @@ namespace LibreHardwareMonitor.UI
             this.viewMenuItem.Name = "viewMenuItem";
             this.viewMenuItem.Size = new System.Drawing.Size(44, 20);
             this.viewMenuItem.Text = "View";
-            // 
+            //
             // resetMinMaxMenuItem
-            // 
+            //
             this.resetMinMaxMenuItem.Name = "resetMinMaxMenuItem";
             this.resetMinMaxMenuItem.Size = new System.Drawing.Size(188, 22);
             this.resetMinMaxMenuItem.Text = "Reset Min/Max";
             this.resetMinMaxMenuItem.Click += new System.EventHandler(this.ResetMinMaxMenuItem_Click);
-            // 
+            //
             // resetPlotMenuItem
-            // 
+            //
             this.resetPlotMenuItem.Name = "resetPlotMenuItem";
             this.resetPlotMenuItem.Size = new System.Drawing.Size(188, 22);
             this.resetPlotMenuItem.Text = "Reset Plot";
             this.resetPlotMenuItem.Click += new System.EventHandler(this.resetPlotMenuItem_Click);
-            // 
+            //
             // MenuItem3
-            // 
+            //
             this.MenuItem3.Name = "MenuItem3";
             this.MenuItem3.Size = new System.Drawing.Size(185, 6);
-            // 
+            //
             // hiddenMenuItem
-            // 
+            //
             this.hiddenMenuItem.Name = "hiddenMenuItem";
             this.hiddenMenuItem.Size = new System.Drawing.Size(188, 22);
             this.hiddenMenuItem.Text = "Show Hidden Sensors";
-            // 
+            //
             // plotMenuItem
-            // 
+            //
             this.plotMenuItem.Name = "plotMenuItem";
             this.plotMenuItem.Size = new System.Drawing.Size(188, 22);
             this.plotMenuItem.Text = "Show Plot";
-            // 
+            //
             // gadgetMenuItem
-            // 
+            //
             this.gadgetMenuItem.Name = "gadgetMenuItem";
             this.gadgetMenuItem.Size = new System.Drawing.Size(188, 22);
             this.gadgetMenuItem.Text = "Show Gadget";
-            // 
+            //
             // MenuItem1
-            // 
+            //
             this.MenuItem1.Name = "MenuItem1";
             this.MenuItem1.Size = new System.Drawing.Size(185, 6);
-            // 
+            //
             // columnsMenuItem
-            // 
+            //
             this.columnsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.valueMenuItem,
             this.minMenuItem,
@@ -412,27 +415,27 @@ namespace LibreHardwareMonitor.UI
             this.columnsMenuItem.Name = "columnsMenuItem";
             this.columnsMenuItem.Size = new System.Drawing.Size(188, 22);
             this.columnsMenuItem.Text = "Columns";
-            // 
+            //
             // valueMenuItem
-            // 
+            //
             this.valueMenuItem.Name = "valueMenuItem";
             this.valueMenuItem.Size = new System.Drawing.Size(180, 22);
             this.valueMenuItem.Text = "Value";
-            // 
+            //
             // minMenuItem
-            // 
+            //
             this.minMenuItem.Name = "minMenuItem";
             this.minMenuItem.Size = new System.Drawing.Size(180, 22);
             this.minMenuItem.Text = "Min";
-            // 
+            //
             // maxMenuItem
-            // 
+            //
             this.maxMenuItem.Name = "maxMenuItem";
             this.maxMenuItem.Size = new System.Drawing.Size(180, 22);
             this.maxMenuItem.Text = "Max";
-            // 
+            //
             // optionsMenuItem
-            // 
+            //
             this.optionsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.startMinMenuItem,
             this.minTrayMenuItem,
@@ -446,69 +449,70 @@ namespace LibreHardwareMonitor.UI
             this.logSensorsMenuItem,
             this.loggingIntervalMenuItem,
             this.updateIntervalMenuItem,
+            this.fileRotationMethod,
             this.sensorValuesTimeWindowMenuItem,
             this.webMenuItemSeparator,
             this.webMenuItem});
             this.optionsMenuItem.Name = "optionsMenuItem";
             this.optionsMenuItem.Size = new System.Drawing.Size(61, 20);
             this.optionsMenuItem.Text = "Options";
-            // 
+            //
             // startMinMenuItem
-            // 
+            //
             this.startMinMenuItem.Name = "startMinMenuItem";
             this.startMinMenuItem.Size = new System.Drawing.Size(221, 22);
             this.startMinMenuItem.Text = "Start Minimized";
-            // 
+            //
             // minTrayMenuItem
-            // 
+            //
             this.minTrayMenuItem.Name = "minTrayMenuItem";
             this.minTrayMenuItem.Size = new System.Drawing.Size(221, 22);
             this.minTrayMenuItem.Text = "Minimize To Tray";
-            // 
+            //
             // minCloseMenuItem
-            // 
+            //
             this.minCloseMenuItem.Name = "minCloseMenuItem";
             this.minCloseMenuItem.Size = new System.Drawing.Size(221, 22);
             this.minCloseMenuItem.Text = "Minimize On Close";
-            // 
+            //
             // startupMenuItem
-            // 
+            //
             this.startupMenuItem.Name = "startupMenuItem";
             this.startupMenuItem.Size = new System.Drawing.Size(221, 22);
             this.startupMenuItem.Text = "Run On Windows Startup";
-            // 
+            //
             // separatorMenuItem
-            // 
+            //
             this.separatorMenuItem.Name = "separatorMenuItem";
             this.separatorMenuItem.Size = new System.Drawing.Size(218, 6);
-            // 
+            //
             // temperatureUnitsMenuItem
-            // 
+            //
             this.temperatureUnitsMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.celsiusMenuItem,
             this.fahrenheitMenuItem});
             this.temperatureUnitsMenuItem.Name = "temperatureUnitsMenuItem";
             this.temperatureUnitsMenuItem.Size = new System.Drawing.Size(221, 22);
             this.temperatureUnitsMenuItem.Text = "Temperature Unit";
-            // 
+            //
             // celsiusMenuItem
-            // 
+            //
             this.celsiusMenuItem.CheckOnClick = true;
             this.celsiusMenuItem.Name = "celsiusMenuItem";
             this.celsiusMenuItem.Size = new System.Drawing.Size(130, 22);
             this.celsiusMenuItem.Text = "Celsius";
             this.celsiusMenuItem.Click += new System.EventHandler(this.CelsiusMenuItem_Click);
-            // 
+            //
             // fahrenheitMenuItem
-            // 
+            //
             this.fahrenheitMenuItem.CheckOnClick = true;
             this.fahrenheitMenuItem.Name = "fahrenheitMenuItem";
             this.fahrenheitMenuItem.Size = new System.Drawing.Size(130, 22);
             this.fahrenheitMenuItem.Text = "Fahrenheit";
             this.fahrenheitMenuItem.Click += new System.EventHandler(this.FahrenheitMenuItem_Click);
-            // 
+            //
             // plotLocationMenuItem
-            // 
+            //
             this.plotLocationMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.plotWindowMenuItem,
             this.plotBottomMenuItem,
@@ -516,30 +520,30 @@ namespace LibreHardwareMonitor.UI
             this.plotLocationMenuItem.Name = "plotLocationMenuItem";
             this.plotLocationMenuItem.Size = new System.Drawing.Size(221, 22);
             this.plotLocationMenuItem.Text = "Plot Location";
-            // 
+            //
             // plotWindowMenuItem
-            // 
+            //
             this.plotWindowMenuItem.CheckOnClick = true;
             this.plotWindowMenuItem.Name = "plotWindowMenuItem";
             this.plotWindowMenuItem.Size = new System.Drawing.Size(118, 22);
             this.plotWindowMenuItem.Text = "Window";
-            // 
+            //
             // plotBottomMenuItem
-            // 
+            //
             this.plotBottomMenuItem.CheckOnClick = true;
             this.plotBottomMenuItem.Name = "plotBottomMenuItem";
             this.plotBottomMenuItem.Size = new System.Drawing.Size(118, 22);
             this.plotBottomMenuItem.Text = "Bottom";
-            // 
+            //
             // plotRightMenuItem
-            // 
+            //
             this.plotRightMenuItem.CheckOnClick = true;
             this.plotRightMenuItem.Name = "plotRightMenuItem";
             this.plotRightMenuItem.Size = new System.Drawing.Size(118, 22);
             this.plotRightMenuItem.Text = "Right";
-            // 
+            //
             // attachedPlotPanelScalingMenuItem
-            // 
+            //
             this.splitPlotPanelScalingMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.splitPanelPercentageScalingMenuItem,
             this.splitPanelFixedPlotScalingMenuItem,
@@ -547,41 +551,69 @@ namespace LibreHardwareMonitor.UI
             this.splitPlotPanelScalingMenuItem.Name = "attachedPlotPanelScalingMenuItem";
             this.splitPlotPanelScalingMenuItem.Size = new System.Drawing.Size(221, 22);
             this.splitPlotPanelScalingMenuItem.Text = "Split Panel Scaling Mode";
-            // 
+            //
             // attachedPanelPercentageScalingMenuItem
-            // 
+            //
             this.splitPanelPercentageScalingMenuItem.CheckOnClick = true;
             this.splitPanelPercentageScalingMenuItem.Name = "attachedPlotPanelPercentageScalingMenuItem";
             this.splitPanelPercentageScalingMenuItem.Size = new System.Drawing.Size(118, 22);
             this.splitPanelPercentageScalingMenuItem.Text = "Percentage Scaling";
-            // 
+            //
             // attachedPanelFixedWidthPlotPanelScalingMenuItem
-            // 
+            //
             this.splitPanelFixedPlotScalingMenuItem.CheckOnClick = true;
             this.splitPanelFixedPlotScalingMenuItem.Name = "attachedBottomMenuItem";
             this.splitPanelFixedPlotScalingMenuItem.Size = new System.Drawing.Size(118, 22);
             this.splitPanelFixedPlotScalingMenuItem.Text = "Fixed Size Plot Panel";
-            // 
+            //
             // attachedPanelFixedWidthSensorPanelScalingMenuItem
-            // 
+            //
             this.splitPanelFixedSensorScalingMenuItem.CheckOnClick = true;
             this.splitPanelFixedSensorScalingMenuItem.Name = "attachedRightMenuItem";
             this.splitPanelFixedSensorScalingMenuItem.Size = new System.Drawing.Size(118, 22);
             this.splitPanelFixedSensorScalingMenuItem.Text = "Fixed Size Sensor Panel";
-            // 
+            //
             // logSeparatorMenuItem
-            // 
+            //
             this.logSeparatorMenuItem.Name = "logSeparatorMenuItem";
             this.logSeparatorMenuItem.Size = new System.Drawing.Size(218, 6);
-            // 
+            //
             // logSensorsMenuItem
-            // 
+            //
             this.logSensorsMenuItem.Name = "logSensorsMenuItem";
             this.logSensorsMenuItem.Size = new System.Drawing.Size(221, 22);
             this.logSensorsMenuItem.Text = "Log Sensors";
-            // 
+			//
+			// fileRotationMethod
+			//
+			this.fileRotationMethod.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.perSessionFileRotationMenuItem,
+            this.dailyFileRotationMenuItem});
+			this.fileRotationMethod.Name = "fileRotationMethod";
+			this.fileRotationMethod.Size = new System.Drawing.Size(246, 24);
+			this.fileRotationMethod.Text = "File rotation method";
+			this.fileRotationMethod.ToolTipText = "Determine how the log file should rotate.";
+			//
+			// perSessionFileRotationMenuItem
+			//
+			this.perSessionFileRotationMenuItem.CheckOnClick = true;
+			this.perSessionFileRotationMenuItem.Name = "perSessionFileRotationMenuItem";
+			this.perSessionFileRotationMenuItem.Size = new System.Drawing.Size(198, 24);
+			this.perSessionFileRotationMenuItem.Text = "Per session";
+			this.perSessionFileRotationMenuItem.ToolTipText = "Create a new log file for each logging session";
+			this.perSessionFileRotationMenuItem.Click += new System.EventHandler(this.perSessionFileRotationMenuItem_Click);
+			//
+			// dailyFileRotationMenuItem
+			//
+			this.dailyFileRotationMenuItem.CheckOnClick = true;
+			this.dailyFileRotationMenuItem.Name = "dailyFileRotationMenuItem";
+			this.dailyFileRotationMenuItem.Size = new System.Drawing.Size(198, 24);
+			this.dailyFileRotationMenuItem.Text = "Daily";
+			this.dailyFileRotationMenuItem.ToolTipText = "Create a new log file every day.\n Note: If a file already exists for the current day, the new data will be appended at the end.";
+			this.dailyFileRotationMenuItem.Click += new System.EventHandler(this.dailyFileRotationMenuItem_Click);
+            //
             // loggingIntervalMenuItem
-            // 
+            //
             this.loggingIntervalMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.log1sMenuItem,
             this.log2sMenuItem,
@@ -599,100 +631,100 @@ namespace LibreHardwareMonitor.UI
             this.loggingIntervalMenuItem.Name = "loggingIntervalMenuItem";
             this.loggingIntervalMenuItem.Size = new System.Drawing.Size(221, 22);
             this.loggingIntervalMenuItem.Text = "Logging Interval";
-            // 
+            //
             // log1sMenuItem
-            // 
+            //
             this.log1sMenuItem.CheckOnClick = true;
             this.log1sMenuItem.Name = "log1sMenuItem";
             this.log1sMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log1sMenuItem.Text = "1s";
-            // 
+            //
             // log2sMenuItem
-            // 
+            //
             this.log2sMenuItem.CheckOnClick = true;
             this.log2sMenuItem.Name = "log2sMenuItem";
             this.log2sMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log2sMenuItem.Text = "2s";
-            // 
+            //
             // log5sMenuItem
-            // 
+            //
             this.log5sMenuItem.CheckOnClick = true;
             this.log5sMenuItem.Name = "log5sMenuItem";
             this.log5sMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log5sMenuItem.Text = "5s";
-            // 
+            //
             // log10sMenuItem
-            // 
+            //
             this.log10sMenuItem.CheckOnClick = true;
             this.log10sMenuItem.Name = "log10sMenuItem";
             this.log10sMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log10sMenuItem.Text = "10s";
-            // 
+            //
             // log30sMenuItem
-            // 
+            //
             this.log30sMenuItem.CheckOnClick = true;
             this.log30sMenuItem.Name = "log30sMenuItem";
             this.log30sMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log30sMenuItem.Text = "30s";
-            // 
+            //
             // log1minMenuItem
-            // 
+            //
             this.log1minMenuItem.CheckOnClick = true;
             this.log1minMenuItem.Name = "log1minMenuItem";
             this.log1minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log1minMenuItem.Text = "1min";
-            // 
+            //
             // log2minMenuItem
-            // 
+            //
             this.log2minMenuItem.CheckOnClick = true;
             this.log2minMenuItem.Name = "log2minMenuItem";
             this.log2minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log2minMenuItem.Text = "2min";
-            // 
+            //
             // log5minMenuItem
-            // 
+            //
             this.log5minMenuItem.CheckOnClick = true;
             this.log5minMenuItem.Name = "log5minMenuItem";
             this.log5minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log5minMenuItem.Text = "5min";
-            // 
+            //
             // log10minMenuItem
-            // 
+            //
             this.log10minMenuItem.CheckOnClick = true;
             this.log10minMenuItem.Name = "log10minMenuItem";
             this.log10minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log10minMenuItem.Text = "10min";
-            // 
+            //
             // log30minMenuItem
-            // 
+            //
             this.log30minMenuItem.CheckOnClick = true;
             this.log30minMenuItem.Name = "log30minMenuItem";
             this.log30minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log30minMenuItem.Text = "30min";
-            // 
+            //
             // log1hMenuItem
-            // 
+            //
             this.log1hMenuItem.CheckOnClick = true;
             this.log1hMenuItem.Name = "log1hMenuItem";
             this.log1hMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log1hMenuItem.Text = "1h";
-            // 
+            //
             // log2hMenuItem
-            // 
+            //
             this.log2hMenuItem.CheckOnClick = true;
             this.log2hMenuItem.Name = "log2hMenuItem";
             this.log2hMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log2hMenuItem.Text = "2h";
-            // 
+            //
             // log6hMenuItem
-            // 
+            //
             this.log6hMenuItem.CheckOnClick = true;
             this.log6hMenuItem.Name = "log6hMenuItem";
             this.log6hMenuItem.Size = new System.Drawing.Size(107, 22);
             this.log6hMenuItem.Text = "6h";
             //
             // updateIntervalMenuItem
-            // 
+            //
             this.updateIntervalMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.updateInterval250msMenuItem,
             this.updateInterval500msMenuItem,
@@ -703,51 +735,51 @@ namespace LibreHardwareMonitor.UI
             this.updateIntervalMenuItem.Name = "updateIntervalMenuItem";
             this.updateIntervalMenuItem.Size = new System.Drawing.Size(221, 22);
             this.updateIntervalMenuItem.Text = "Update Interval";
-            // 
+            //
             // updateInterval250msMenuItem
-            // 
+            //
             this.updateInterval250msMenuItem.CheckOnClick = true;
             this.updateInterval250msMenuItem.Name = "updateInterval250msMenuItem";
             this.updateInterval250msMenuItem.Size = new System.Drawing.Size(107, 22);
             this.updateInterval250msMenuItem.Text = "250ms";
-            // 
+            //
             // updateInterval500msMenuItem
-            // 
+            //
             this.updateInterval500msMenuItem.CheckOnClick = true;
             this.updateInterval500msMenuItem.Name = "updateInterval500msMenuItem";
             this.updateInterval500msMenuItem.Size = new System.Drawing.Size(107, 22);
             this.updateInterval500msMenuItem.Text = "500ms";
-            // 
+            //
             // updateInterval1sMenuItem
-            // 
+            //
             this.updateInterval1sMenuItem.CheckOnClick = true;
             this.updateInterval1sMenuItem.Name = "updateInterval1sMenuItem";
             this.updateInterval1sMenuItem.Size = new System.Drawing.Size(107, 22);
             this.updateInterval1sMenuItem.Text = "1s";
-            // 
+            //
             // updateInterval2sMenuItem
-            // 
+            //
             this.updateInterval2sMenuItem.CheckOnClick = true;
             this.updateInterval2sMenuItem.Name = "updateInterval2sMenuItem";
             this.updateInterval2sMenuItem.Size = new System.Drawing.Size(107, 22);
             this.updateInterval2sMenuItem.Text = "2s";
-            // 
+            //
             // updateInterval5sMenuItem
-            // 
+            //
             this.updateInterval5sMenuItem.CheckOnClick = true;
             this.updateInterval5sMenuItem.Name = "updateInterval5sMenuItem";
             this.updateInterval5sMenuItem.Size = new System.Drawing.Size(107, 22);
             this.updateInterval5sMenuItem.Text = "5s";
-            // 
+            //
             // updateInterval10sMenuItem
-            // 
+            //
             this.updateInterval10sMenuItem.CheckOnClick = true;
             this.updateInterval10sMenuItem.Name = "updateInterval10sMenuItem";
             this.updateInterval10sMenuItem.Size = new System.Drawing.Size(107, 22);
             this.updateInterval10sMenuItem.Text = "10s";
-            // 
+            //
             // sensorValuesTimeWindowMenuItem
-            // 
+            //
             this.sensorValuesTimeWindowMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.timeWindow30sMenuItem,
             this.timeWindow1minMenuItem,
@@ -763,91 +795,91 @@ namespace LibreHardwareMonitor.UI
             this.sensorValuesTimeWindowMenuItem.Name = "sensorValuesTimeWindowMenuItem";
             this.sensorValuesTimeWindowMenuItem.Size = new System.Drawing.Size(221, 22);
             this.sensorValuesTimeWindowMenuItem.Text = "Sensor Values Time Window";
-            // 
+            //
             // timeWindow30sMenuItem
-            // 
+            //
             this.timeWindow30sMenuItem.CheckOnClick = true;
             this.timeWindow30sMenuItem.Name = "timeWindow30sMenuItem";
             this.timeWindow30sMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow30sMenuItem.Text = "30s";
-            // 
+            //
             // timeWindow1minMenuItem
-            // 
+            //
             this.timeWindow1minMenuItem.CheckOnClick = true;
             this.timeWindow1minMenuItem.Name = "timeWindow1minMenuItem";
             this.timeWindow1minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow1minMenuItem.Text = "1min";
-            // 
+            //
             // timeWindow2minMenuItem
-            // 
+            //
             this.timeWindow2minMenuItem.CheckOnClick = true;
             this.timeWindow2minMenuItem.Name = "timeWindow2minMenuItem";
             this.timeWindow2minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow2minMenuItem.Text = "2min";
-            // 
+            //
             // timeWindow5minMenuItem
-            // 
+            //
             this.timeWindow5minMenuItem.CheckOnClick = true;
             this.timeWindow5minMenuItem.Name = "timeWindow5minMenuItem";
             this.timeWindow5minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow5minMenuItem.Text = "5min";
-            // 
+            //
             // timeWindow10minMenuItem
-            // 
+            //
             this.timeWindow10minMenuItem.CheckOnClick = true;
             this.timeWindow10minMenuItem.Name = "timeWindow10minMenuItem";
             this.timeWindow10minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow10minMenuItem.Text = "10min";
-            // 
+            //
             // timeWindow30minMenuItem
-            // 
+            //
             this.timeWindow30minMenuItem.CheckOnClick = true;
             this.timeWindow30minMenuItem.Name = "timeWindow30minMenuItem";
             this.timeWindow30minMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow30minMenuItem.Text = "30min";
-            // 
+            //
             // timeWindow1hMenuItem
-            // 
+            //
             this.timeWindow1hMenuItem.CheckOnClick = true;
             this.timeWindow1hMenuItem.Name = "timeWindow1hMenuItem";
             this.timeWindow1hMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow1hMenuItem.Text = "1h";
-            // 
+            //
             // timeWindow2hMenuItem
-            // 
+            //
             this.timeWindow2hMenuItem.CheckOnClick = true;
             this.timeWindow2hMenuItem.Name = "timeWindow2hMenuItem";
             this.timeWindow2hMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow2hMenuItem.Text = "2h";
-            // 
+            //
             // timeWindow6hMenuItem
-            // 
+            //
             this.timeWindow6hMenuItem.CheckOnClick = true;
             this.timeWindow6hMenuItem.Name = "timeWindow6hMenuItem";
             this.timeWindow6hMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow6hMenuItem.Text = "6h";
-            // 
+            //
             // timeWindow12hMenuItem
-            // 
+            //
             this.timeWindow12hMenuItem.CheckOnClick = true;
             this.timeWindow12hMenuItem.Name = "timeWindow12hMenuItem";
             this.timeWindow12hMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow12hMenuItem.Text = "12h";
-            // 
+            //
             // timeWindow24hMenuItem
-            // 
+            //
             this.timeWindow24hMenuItem.CheckOnClick = true;
             this.timeWindow24hMenuItem.Name = "timeWindow24hMenuItem";
             this.timeWindow24hMenuItem.Size = new System.Drawing.Size(107, 22);
             this.timeWindow24hMenuItem.Text = "24h";
-            // 
+            //
             // webMenuItemSeparator
-            // 
+            //
             this.webMenuItemSeparator.Name = "webMenuItemSeparator";
             this.webMenuItemSeparator.Size = new System.Drawing.Size(218, 6);
-            // 
+            //
             // webMenuItem
-            // 
+            //
             this.webMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.runWebServerMenuItem,
             this.serverPortMenuItem,
@@ -855,83 +887,83 @@ namespace LibreHardwareMonitor.UI
             this.webMenuItem.Name = "webMenuItem";
             this.webMenuItem.Size = new System.Drawing.Size(221, 22);
             this.webMenuItem.Text = "Remote Web Server";
-            // 
+            //
             // runWebServerMenuItem
-            // 
+            //
             this.runWebServerMenuItem.Name = "runWebServerMenuItem";
             this.runWebServerMenuItem.Size = new System.Drawing.Size(153, 22);
             this.runWebServerMenuItem.Text = "Run";
-            // 
+            //
             // serverPortMenuItem
-            // 
+            //
             this.serverPortMenuItem.Name = "serverPortMenuItem";
             this.serverPortMenuItem.Size = new System.Drawing.Size(153, 22);
             this.serverPortMenuItem.Text = "Port";
             this.serverPortMenuItem.Click += new System.EventHandler(this.ServerPortMenuItem_Click);
-            // 
+            //
             // authWebServerMenuItem
-            // 
+            //
             this.authWebServerMenuItem.Name = "authWebServerMenuItem";
             this.authWebServerMenuItem.Size = new System.Drawing.Size(153, 22);
             this.authWebServerMenuItem.Text = "Authentication";
             this.authWebServerMenuItem.Click += new System.EventHandler(this.AuthWebServerMenuItem_Click);
-            // 
+            //
             // helpMenuItem
-            // 
+            //
             this.helpMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.aboutMenuItem});
             this.helpMenuItem.Name = "helpMenuItem";
             this.helpMenuItem.Size = new System.Drawing.Size(44, 20);
             this.helpMenuItem.Text = "Help";
-            // 
+            //
             // aboutMenuItem
-            // 
+            //
             this.aboutMenuItem.Name = "aboutMenuItem";
             this.aboutMenuItem.Size = new System.Drawing.Size(107, 22);
             this.aboutMenuItem.Text = "About";
             this.aboutMenuItem.Click += new System.EventHandler(this.AboutMenuItem_Click);
-            // 
+            //
             // treeContextMenu
-            // 
+            //
             this.treeContextMenu.Name = "treeContextMenu";
             this.treeContextMenu.Size = new System.Drawing.Size(61, 4);
-            // 
+            //
             // saveFileDialog
-            // 
+            //
             this.saveFileDialog.DefaultExt = "txt";
             this.saveFileDialog.FileName = "LibreHardwareMonitor.Report.txt";
             this.saveFileDialog.Filter = "Text Documents|*.txt|All Files|*.*";
             this.saveFileDialog.RestoreDirectory = true;
             this.saveFileDialog.Title = "Save Report As";
-            // 
+            //
             // timer
-            // 
+            //
             this.timer.Interval = 1000;
             this.timer.Tick += new System.EventHandler(this.Timer_Tick);
-            // 
+            //
             // splitContainer
-            // 
+            //
             this.splitContainer.Border3DStyle = System.Windows.Forms.Border3DStyle.Raised;
             this.splitContainer.Color = System.Drawing.SystemColors.Control;
             this.splitContainer.Cursor = System.Windows.Forms.Cursors.Default;
             this.splitContainer.Location = new System.Drawing.Point(12, 12);
             this.splitContainer.Name = "splitContainer";
             this.splitContainer.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            // 
+            //
             // splitContainer.Panel1
-            // 
+            //
             this.splitContainer.Panel1.Controls.Add(this.treeView);
-            // 
+            //
             // splitContainer.Panel2
-            // 
+            //
             this.splitContainer.Panel2.Cursor = System.Windows.Forms.Cursors.Default;
             this.splitContainer.Size = new System.Drawing.Size(386, 483);
             this.splitContainer.SplitterDistance = 354;
             this.splitContainer.SplitterWidth = 5;
             this.splitContainer.TabIndex = 3;
-            // 
+            //
             // treeView
-            // 
+            //
             this.treeView.BackColor = System.Drawing.SystemColors.Window;
             this.treeView.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.treeView.Columns.Add(this.sensor);
@@ -963,15 +995,15 @@ namespace LibreHardwareMonitor.UI
             this.treeView.MouseDown += new System.Windows.Forms.MouseEventHandler(this.TreeView_MouseDown);
             this.treeView.MouseMove += new System.Windows.Forms.MouseEventHandler(this.TreeView_MouseMove);
             this.treeView.MouseUp += new System.Windows.Forms.MouseEventHandler(this.TreeView_MouseUp);
-            // 
+            //
             // batteryMenuItem
-            // 
+            //
             this.batteryMenuItem.Name = "batteryMenuItem";
             this.batteryMenuItem.Size = new System.Drawing.Size(180, 22);
             this.batteryMenuItem.Text = "Batteries";
-            // 
+            //
             // MainForm
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(418, 533);
@@ -1101,6 +1133,9 @@ namespace LibreHardwareMonitor.UI
         private System.Windows.Forms.ToolStripMenuItem psuMenuItem;
         private System.Windows.Forms.ToolStripMenuItem batteryMenuItem;
         private System.ComponentModel.BackgroundWorker backgroundUpdater;
+        private System.Windows.Forms.ToolStripMenuItem fileRotationMethod;
+        private ToolStripRadioButtonMenuItem perSessionFileRotationMenuItem;
+        private ToolStripRadioButtonMenuItem dailyFileRotationMenuItem;
     }
 }
 

--- a/LibreHardwareMonitor/UI/MainForm.Designer.cs
+++ b/LibreHardwareMonitor/UI/MainForm.Designer.cs
@@ -995,6 +995,7 @@ namespace LibreHardwareMonitor.UI
             this.treeView.MouseDown += new System.Windows.Forms.MouseEventHandler(this.TreeView_MouseDown);
             this.treeView.MouseMove += new System.Windows.Forms.MouseEventHandler(this.TreeView_MouseMove);
             this.treeView.MouseUp += new System.Windows.Forms.MouseEventHandler(this.TreeView_MouseUp);
+            this.treeView.SizeChanged += new System.EventHandler(this.TreeView_SizeChanged);
             //
             // batteryMenuItem
             //

--- a/LibreHardwareMonitor/UI/MainForm.Designer.cs
+++ b/LibreHardwareMonitor/UI/MainForm.Designer.cs
@@ -156,6 +156,7 @@ namespace LibreHardwareMonitor.UI
             this.sensor.SortOrder = System.Windows.Forms.SortOrder.None;
             this.sensor.TooltipText = null;
             this.sensor.Width = 250;
+            this.sensor.WidthChanged += delegate { TreeView_ColumnWidthChanged(this.sensor); };
             //
             // value
             //
@@ -163,6 +164,7 @@ namespace LibreHardwareMonitor.UI
             this.value.SortOrder = System.Windows.Forms.SortOrder.None;
             this.value.TooltipText = null;
             this.value.Width = 100;
+            this.value.WidthChanged += delegate { TreeView_ColumnWidthChanged(this.value); };
             //
             // min
             //
@@ -170,6 +172,7 @@ namespace LibreHardwareMonitor.UI
             this.min.SortOrder = System.Windows.Forms.SortOrder.None;
             this.min.TooltipText = null;
             this.min.Width = 100;
+            this.min.WidthChanged += delegate { TreeView_ColumnWidthChanged(this.min); };
             //
             // max
             //
@@ -177,6 +180,7 @@ namespace LibreHardwareMonitor.UI
             this.max.SortOrder = System.Windows.Forms.SortOrder.None;
             this.max.TooltipText = null;
             this.max.Width = 100;
+            this.max.WidthChanged += delegate { TreeView_ColumnWidthChanged(this.max); };
             //
             // nodeImage
             //

--- a/LibreHardwareMonitor/UI/MainForm.cs
+++ b/LibreHardwareMonitor/UI/MainForm.cs
@@ -387,8 +387,8 @@ public sealed partial class MainForm : Form
                                                      },
                                                      _settings);
 
-        perSessionFileRotationMenuItem.Checked = _logger.FileRotationMethod == LoggerFileRotationMethod.PerSession;
-        dailyFileRotationMenuItem.Checked = _logger.FileRotationMethod == LoggerFileRotationMethod.Daily;
+        perSessionFileRotationMenuItem.Checked = _logger.FileRotationMethod == LoggerFileRotation.PerSession;
+        dailyFileRotationMenuItem.Checked = _logger.FileRotationMethod == LoggerFileRotation.Daily;
 
         _sensorValuesTimeWindow.Changed += (sender, e) =>
         {
@@ -1193,6 +1193,7 @@ public sealed partial class MainForm : Form
         int nextColumnIndex = index + 1;
         while (nextColumnIndex < treeView.Columns.Count && treeView.Columns[nextColumnIndex].IsVisible == false)
             nextColumnIndex++;
+
         if (nextColumnIndex < treeView.Columns.Count) {
             int diff = treeView.Width - columnsWidth;
             treeView.Columns[nextColumnIndex].Width = Math.Max(20, treeView.Columns[nextColumnIndex].Width + diff);
@@ -1211,14 +1212,15 @@ public sealed partial class MainForm : Form
 
     private void perSessionFileRotationMenuItem_Click(object sender, EventArgs e)
     {
-        this.dailyFileRotationMenuItem.Checked = false;
-        this.perSessionFileRotationMenuItem.Checked = true;
-        this._logger.FileRotationMethod = LoggerFileRotationMethod.PerSession;
+        dailyFileRotationMenuItem.Checked = false;
+        perSessionFileRotationMenuItem.Checked = true;
+        _logger.FileRotationMethod = LoggerFileRotation.PerSession;
     }
+
     private void dailyFileRotationMenuItem_Click(object sender, EventArgs e)
     {
-        this.dailyFileRotationMenuItem.Checked = true;
-        this.perSessionFileRotationMenuItem.Checked = false;
-        this._logger.FileRotationMethod = LoggerFileRotationMethod.Daily;
+        dailyFileRotationMenuItem.Checked = true;
+        perSessionFileRotationMenuItem.Checked = false;
+        _logger.FileRotationMethod = LoggerFileRotation.Daily;
     }
 }

--- a/LibreHardwareMonitor/UI/MainForm.cs
+++ b/LibreHardwareMonitor/UI/MainForm.cs
@@ -98,8 +98,11 @@ public sealed partial class MainForm : Form
         nodeTextBoxMax.DrawText += NodeTextBoxText_DrawText;
         nodeTextBoxText.EditorShowing += NodeTextBoxText_EditorShowing;
 
-        foreach (TreeColumn column in treeView.Columns)
+        for (int i = 1; i < treeView.Columns.Count; i++)
+        {
+            TreeColumn column = treeView.Columns[i];
             column.Width = Math.Max(20, Math.Min(400, _settings.GetValue("treeView.Columns." + column.Header + ".Width", column.Width)));
+        }
 
         TreeModel treeModel = new();
         _root = new Node(Environment.MachineName) { Image = EmbeddedResources.GetImage("computer.png") };
@@ -1164,6 +1167,14 @@ public sealed partial class MainForm : Form
     private void TreeView_MouseUp(object sender, MouseEventArgs e)
     {
         _selectionDragging = false;
+    }
+
+    private void TreeView_SizeChanged(object sender, EventArgs e)
+    {
+        int newWidth = treeView.Width;
+        for (int i = 1; i < treeView.Columns.Count; i++)
+            newWidth -= treeView.Columns[i].Width;
+        treeView.Columns[0].Width = newWidth;
     }
 
     private void ServerPortMenuItem_Click(object sender, EventArgs e)

--- a/LibreHardwareMonitor/UI/MainForm.cs
+++ b/LibreHardwareMonitor/UI/MainForm.cs
@@ -384,6 +384,9 @@ public sealed partial class MainForm : Form
                                                      },
                                                      _settings);
 
+        perSessionFileRotationMenuItem.Checked = _logger.FileRotationMethod == LoggerFileRotationMethod.PerSession;
+        dailyFileRotationMenuItem.Checked = _logger.FileRotationMethod == LoggerFileRotationMethod.Daily;
+
         _sensorValuesTimeWindow.Changed += (sender, e) =>
         {
             TimeSpan timeWindow = TimeSpan.Zero;
@@ -1171,5 +1174,18 @@ public sealed partial class MainForm : Form
     private void AuthWebServerMenuItem_Click(object sender, EventArgs e)
     {
         new AuthForm(this).ShowDialog();
+    }
+
+    private void perSessionFileRotationMenuItem_Click(object sender, EventArgs e)
+    {
+        this.dailyFileRotationMenuItem.Checked = false;
+        this.perSessionFileRotationMenuItem.Checked = true;
+        this._logger.FileRotationMethod = LoggerFileRotationMethod.PerSession;
+    }
+    private void dailyFileRotationMenuItem_Click(object sender, EventArgs e)
+    {
+        this.dailyFileRotationMenuItem.Checked = true;
+        this.perSessionFileRotationMenuItem.Checked = false;
+        this._logger.FileRotationMethod = LoggerFileRotationMethod.Daily;
     }
 }

--- a/LibreHardwareMonitor/UI/MainForm.cs
+++ b/LibreHardwareMonitor/UI/MainForm.cs
@@ -1173,8 +1173,30 @@ public sealed partial class MainForm : Form
     {
         int newWidth = treeView.Width;
         for (int i = 1; i < treeView.Columns.Count; i++)
-            newWidth -= treeView.Columns[i].Width;
+        {
+            if (treeView.Columns[i].IsVisible)
+                newWidth -= treeView.Columns[i].Width;
+        }
         treeView.Columns[0].Width = newWidth;
+    }
+
+    private void TreeView_ColumnWidthChanged(TreeColumn column)
+    {
+        int index = treeView.Columns.IndexOf(column);
+        int columnsWidth = 0;
+        foreach (TreeColumn treeColumn in treeView.Columns)
+        {
+            if (treeColumn.IsVisible)
+                columnsWidth += treeColumn.Width;
+        }
+
+        int nextColumnIndex = index + 1;
+        while (nextColumnIndex < treeView.Columns.Count && treeView.Columns[nextColumnIndex].IsVisible == false)
+            nextColumnIndex++;
+        if (nextColumnIndex < treeView.Columns.Count) {
+            int diff = treeView.Width - columnsWidth;
+            treeView.Columns[nextColumnIndex].Width = Math.Max(20, treeView.Columns[nextColumnIndex].Width + diff);
+        }
     }
 
     private void ServerPortMenuItem_Click(object sender, EventArgs e)

--- a/LibreHardwareMonitor/Utilities/Logger.cs
+++ b/LibreHardwareMonitor/Utilities/Logger.cs
@@ -12,14 +12,6 @@ using System.Linq;
 using LibreHardwareMonitor.Hardware;
 
 namespace LibreHardwareMonitor.Utilities;
-public enum LoggerFileRotationMethod
-{
-    // Keep the same file for the entire record session
-    PerSession = 0,
-
-    // Create a new file every day
-    Daily,
-}
 
 public class Logger
 {
@@ -33,7 +25,7 @@ public class Logger
     private ISensor[] _sensors;
     private DateTime _lastLoggedTime = DateTime.MinValue;
 
-    public LoggerFileRotationMethod FileRotationMethod = LoggerFileRotationMethod.PerSession;
+    public LoggerFileRotation FileRotationMethod = LoggerFileRotation.PerSession;
 
     public Logger(IComputer computer)
     {
@@ -183,11 +175,11 @@ public class Logger
 
         switch (FileRotationMethod)
         {
-            case LoggerFileRotationMethod.PerSession:
+            case LoggerFileRotation.PerSession:
                 // Create file if it does not exist or the logging interval has passed (+ some margin)
                 if (!File.Exists(_fileName) || now - _lastLoggedTime > (LoggingInterval + TimeSpan.FromMilliseconds(100)))
                 {
-                    uint sessionNumber = 0;
+                    uint sessionNumber = 1;
                     do {
                         _fileName = GetFileName(DateTime.Now, sessionNumber);
                         sessionNumber++;
@@ -195,7 +187,7 @@ public class Logger
                     CreateNewLogFile();
                 }
                 break;
-            case LoggerFileRotationMethod.Daily:
+            case LoggerFileRotation.Daily:
                 // Create a new file if the day has changed or the file does not exist
                 if (_day != now.Date || !File.Exists(_fileName))
                 {

--- a/LibreHardwareMonitor/Utilities/LoggerFileRotation.cs
+++ b/LibreHardwareMonitor/Utilities/LoggerFileRotation.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LibreHardwareMonitor.Utilities
+{
+    public enum LoggerFileRotation
+    {
+        // Keep the same file for the entire record session
+        PerSession = 0,
+
+        // Create a new file every day
+        Daily,
+    }
+}

--- a/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
+++ b/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <AssemblyName>LibreHardwareMonitorLib</AssemblyName>
     <RootNamespace>LibreHardwareMonitor</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Originate from issue #1393 

# Scale up
Due to the hierarchy and the length of the sensors name.
I've changed so that **when the TreeView is being resized the new available space goes to the first column** _(aka "Sensor")_
Before it was scaling up the last _("Max")_ column.
I've also swap how column where resized, because it you could overflow the total tree view width, and the last column was hard to resize _(due to the separator being either overflowed or on the edge)_.
So now the column separators a resizing the column to the right instead of the left. (feel much more natural)
Except for the first column which is resized by the total width of the tree view as mentioned above.

# Log file rotation
Before the CSV file was rotated daily, and if a new log session was being started the same day it would had append the new data to the end of this file.
This is a bit annoying in certain situation, and required the user to always make sure the last file is deleted.
So I've added an extra option to the logger that allow the user to specify the desired behaviour
#####  Daily
Rotate every day, just like before
##### Per session _(default)_
Rotate each time a new logging session is started.