### PR TITLE
Add support for Gigabyte H97-D3H

### DIFF
--- a/.github/workflows/pull requests.yml
+++ b/.github/workflows/pull requests.yml
@@ -1,6 +1,7 @@
 name: pull requests
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [master]
 

--- a/.github/workflows/pull requests.yml
+++ b/.github/workflows/pull requests.yml
@@ -1,7 +1,6 @@
 name: pull requests
 
 on:
-  workflow_dispatch:
   pull_request:
     branches: [master]
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -257,6 +257,8 @@ internal class Identification
                 return Model.H67A_UD3H_B3;
             case var _ when name.Equals("H67A-USB3-B3", StringComparison.OrdinalIgnoreCase):
                 return Model.H67A_USB3_B3;
+            case var _ when name.Equals("H97-D3H-CF", StringComparison.OrdinalIgnoreCase):
+                return Model.H97_D3H;
             case var _ when name.Equals("H81M-HD3", StringComparison.OrdinalIgnoreCase):
                 return Model.H81M_HD3;
             case var _ when name.Equals("B75M-D3H", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -176,6 +176,13 @@ internal class IT87XX : ISuperIO
                 Fans = new float?[3];
                 Controls = new float?[3];
                 break;
+            
+            case Chip.IT8620E:
+                Voltages = new float?[9];
+                Temperatures = new float?[3];
+                Fans = new float?[5];
+                Controls = new float?[5];
+                break;
 
             default:
                 Voltages = new float?[9];

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -172,6 +172,7 @@ public enum Model
     H61M_USB3_B3_REV_2_0,
     H67A_UD3H_B3,
     H67A_USB3_B3,
+    H97_D3H,
     H81M_HD3,
     B75M_D3H,
     MA770T_UD3,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1281,7 +1281,7 @@ internal sealed class SuperIOHardware : Hardware
                         v.Add(new Voltage("+12V", 2, 5, 1));
                         v.Add(new Voltage("+5V", 3, 1.5f, 1));
                         v.Add(new Voltage("iGPU", 4));
-                        v.Add(new Voltage("CPU VRIN", 5));
+                        v.Add(new Voltage("CPU Input Auxiliary", 5));
                         v.Add(new Voltage("DIMM", 6));
                         v.Add(new Voltage("+3V Standby", 7, 10, 10));
                         v.Add(new Voltage("CMOS Battery", 8, 10, 10));
@@ -1300,7 +1300,7 @@ internal sealed class SuperIOHardware : Hardware
                         v.Add(new Voltage("+12V", 2, 5, 1));
                         v.Add(new Voltage("+5V", 3, 1.5f, 1));
                         v.Add(new Voltage("iGPU", 4));
-                        v.Add(new Voltage("CPU VRIN", 5));
+                        v.Add(new Voltage("CPU Input Auxiliary", 5));
                         v.Add(new Voltage("DIMM", 6));
                         v.Add(new Voltage("+3V Standby", 7, 10, 10));
                         v.Add(new Voltage("CMOS Battery", 8, 10, 10));

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1277,9 +1277,9 @@ internal sealed class SuperIOHardware : Hardware
 
                     case Model.H81M_HD3: //IT8620E
                         v.Add(new Voltage("Vcore", 0));
-                        v.Add(new Voltage("Voltage #2", 1, true));
-                        v.Add(new Voltage("Voltage #3", 2, true));
-                        v.Add(new Voltage("Voltage #4", 3, true));
+                        v.Add(new Voltage("+3.3V", 1, 6.5f, 10));
+                        v.Add(new Voltage("+12V", 2, 5, 1));
+                        v.Add(new Voltage("+5V", 3, 1.5f, 1));
                         v.Add(new Voltage("iGPU", 4));
                         v.Add(new Voltage("CPU VRIN", 5));
                         v.Add(new Voltage("DIMM", 6));
@@ -1295,24 +1295,30 @@ internal sealed class SuperIOHardware : Hardware
                         break;
 
                     case Model.H97_D3H: //IT8620E
-                        v.Add(new Voltage("Voltage #1", 0, true));
-                        v.Add(new Voltage("Voltage #2", 1, true));
-                        v.Add(new Voltage("Voltage #3", 2, true));
-                        v.Add(new Voltage("Voltage #4", 3, true));
-                        v.Add(new Voltage("Voltage #5", 4, true));
-                        v.Add(new Voltage("Voltage #6", 5, true));
-                        v.Add(new Voltage("Voltage #7", 6, true));
+                        v.Add(new Voltage("Vcore", 0));
+                        v.Add(new Voltage("+3.3V", 1, 6.5f, 10));
+                        v.Add(new Voltage("+12V", 2, 5, 1));
+                        v.Add(new Voltage("+5V", 3, 1.5f, 1));
+                        v.Add(new Voltage("iGPU", 4));
+                        v.Add(new Voltage("CPU VRIN", 5));
+                        v.Add(new Voltage("DIMM", 6));
                         v.Add(new Voltage("+3V Standby", 7, 10, 10));
                         v.Add(new Voltage("CMOS Battery", 8, 10, 10));
 
-                        for (int i = 0; i < 50; i++)
-                            t.Add(new Temperature("Temperature #" + (i + 1), i));
+                        t.Add(new Temperature("CPU", 2));
+                        t.Add(new Temperature("System", 0));
 
-                        for (int i = 0; i < superIO.Fans.Length; i++)
-                            f.Add(new Fan("Fan #" + (i + 1), i));
+                        f.Add(new Fan("CPU Fan", 0));
+                        f.Add(new Fan("CPU Optional Fan", 1));
+                        f.Add(new Fan("System Fan #1", 4));
+                        f.Add(new Fan("System Fan #2", 2));
+                        f.Add(new Fan("System Fan #3", 3));
 
-                        for (int i = 0; i < superIO.Fans.Length; i++)
-                            c.Add(new Control("Fan #" + (i + 1), i));
+                        c.Add(new Control("CPU Fan", 0));
+                        c.Add(new Control("CPU Optional Fan", 1));
+                        c.Add(new Control("System Fan #1", 4));
+                        c.Add(new Control("System Fan #2", 2));
+                        c.Add(new Control("System Fan #3", 3));
 
                         break;
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1294,6 +1294,28 @@ internal sealed class SuperIOHardware : Hardware
 
                         break;
 
+                    case Model.H97_D3H: //IT8620E
+                        v.Add(new Voltage("Voltage #1", 0, true));
+                        v.Add(new Voltage("Voltage #2", 1, true));
+                        v.Add(new Voltage("Voltage #3", 2, true));
+                        v.Add(new Voltage("Voltage #4", 3, true));
+                        v.Add(new Voltage("Voltage #5", 4, true));
+                        v.Add(new Voltage("Voltage #6", 5, true));
+                        v.Add(new Voltage("Voltage #7", 6, true));
+                        v.Add(new Voltage("+3V Standby", 7, 10, 10));
+                        v.Add(new Voltage("CMOS Battery", 8, 10, 10));
+
+                        for (int i = 0; i < 50; i++)
+                            t.Add(new Temperature("Temperature #" + (i + 1), i));
+
+                        for (int i = 0; i < superIO.Fans.Length; i++)
+                            f.Add(new Fan("Fan #" + (i + 1), i));
+
+                        for (int i = 0; i < superIO.Fans.Length; i++)
+                            c.Add(new Control("Fan #" + (i + 1), i));
+
+                        break;
+
                     case Model.Z170N_WIFI: // ITE IT8628E
                         v.Add(new Voltage("Vcore", 0, 0, 1));
                         v.Add(new Voltage("+3.3V", 1, 6.5F, 10));


### PR DESCRIPTION
This PR mainly addresses #1411, which tackles:

1. Separates the ITE-IT8620E chip SuperIO definition lengths, allowing for the fan controls to be increased to 5
2. Adds specific definition/data entry for the Gigabyte GA-H97-D3H, identifying all sensors appropriately
3. Rename CPU VRIN to CPU Input Auxiliary for ITE-IT8620E boards accordingly
4. H81M-HD3 is also modified, but just for naming schemes and renaming the hidden voltages

Verification was done through #1411 