### PR TITLE
Add ASRock B650M-C(W)(X)

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -555,6 +555,8 @@ internal class Identification
             case var _ when name.Equals("Z790 Taichi", StringComparison.OrdinalIgnoreCase):
             case var _ when name.Equals("Z790 Taichi Carrara", StringComparison.OrdinalIgnoreCase):
                 return Model.Z790_Taichi;
+            case var _ when name.Equals("B650M-C", StringComparison.OrdinalIgnoreCase):
+                return Model.B650M_C;
             case var _ when name.Equals("B660 DS3H DDR4-Y1",StringComparison.OrdinalIgnoreCase):
             case var _ when name.Equals("B660 DS3H DDR4",StringComparison.OrdinalIgnoreCase):
                 return Model.B660_DS3H_DDR4;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -556,6 +556,9 @@ internal class Identification
             case var _ when name.Equals("Z790 Taichi Carrara", StringComparison.OrdinalIgnoreCase):
                 return Model.Z790_Taichi;
             case var _ when name.Equals("B650M-C", StringComparison.OrdinalIgnoreCase):
+            case var _ when name.Equals("B650M-CW", StringComparison.OrdinalIgnoreCase):
+            case var _ when name.Equals("B650M-CX", StringComparison.OrdinalIgnoreCase):
+            case var _ when name.Equals("B650M-CWX", StringComparison.OrdinalIgnoreCase):
                 return Model.B650M_C;
             case var _ when name.Equals("B660 DS3H DDR4-Y1",StringComparison.OrdinalIgnoreCase):
             case var _ when name.Equals("B660 DS3H DDR4",StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -38,6 +38,7 @@ public enum Model
     Z690_Steel_Legend,
     Z790_Pro_RS,
     Z790_Taichi,
+    B650M_C,
     H61M_DGS,
 
     // ASUS

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -3044,6 +3044,37 @@ internal sealed class SuperIOHardware : Hardware
                         c.Add(new Control("Chassis Fan #3", 6));
                         break;
 
+                    case Model.B650M_C: // NCT6799D
+                        v.Add(new Voltage("Vcore", 0));
+                        v.Add(new Voltage("+12V", 1, 56, 10));
+                        v.Add(new Voltage("AVCC", 2, 34, 34));
+                        v.Add(new Voltage("+3.3V", 3, 34, 34));
+                        v.Add(new Voltage("+5V", 4, 20, 10));
+                        v.Add(new Voltage("+1.05V ALW", 5));
+                        v.Add(new Voltage("+3.3V Standby", 7, 34, 34));
+                        v.Add(new Voltage("CMOS Battery", 8, 34, 34));
+                        v.Add(new Voltage("CPU Voltage Termination", 9, 1, 1));
+                        v.Add(new Voltage("Vcore SoC", 10, 1, 1));
+                        v.Add(new Voltage("Vcore Misc", 11, 1, 1));
+                        v.Add(new Voltage("+1.8V", 13, 1, 1));
+                        v.Add(new Voltage("DRAM", 14));
+
+                        t.Add(new Temperature("CPU Core", 9));
+                        t.Add(new Temperature("Motherboard", 2));
+
+                        f.Add(new Fan("CPU Fan #1", 1)); // CPU_FAN1
+                        f.Add(new Fan("CPU Fan #2", 0)); // CPU_FAN2/WP
+                        f.Add(new Fan("Chassis Fan #1", 3)); // CHA_FAN1/WP
+                        f.Add(new Fan("Chassis Fan #2", 4)); // CHA_FAN2/WP
+                        f.Add(new Fan("Chassis Fan #3", 6)); // CHA_FAN3/WP
+                        
+                        c.Add(new Control("CPU Fan #1", 1)); // CPU_FAN1
+                        c.Add(new Control("CPU Fan #2", 0)); // CPU_FAN2/WP
+                        c.Add(new Control("Chassis Fan #1", 3)); // CHA_FAN1/WP
+                        c.Add(new Control("Chassis Fan #2", 4)); // CHA_FAN2/WP
+                        c.Add(new Control("Chassis Fan #3", 6)); // CHA_FAN3/WP
+                        break;
+
                     default:
                         v.Add(new Voltage("Vcore", 0, 10, 10));
                         v.Add(new Voltage("Voltage #2", 1, true));


### PR DESCRIPTION
1. Voltage sensors are primarily mirroring HWiNFO64.
2. Fan Index 2 seems to be meant for Chassis Fan 4 apparently, however that fan doesn't exist hence why in the before screenshot Fan `#3` shows 0%. There is only CPU Fan 1-2, and Chassis Fan 1-3 - https://www.asrock.com/MB/AMD/B650M-C/index.us.asp
3. There is also a white variant and WiFi 6e model, which are essentially the same model with either a different color scheme or WiFi module accordingly

Before
![image](https://github.com/user-attachments/assets/2f584e4e-e4f4-4352-b266-fe070d26ed33)

After (+1.8V and DRAM were on one index lower so the values were incorrect. I fixed this after this screenshot was taken)
![image](https://github.com/user-attachments/assets/5b2a4f26-e210-4fd6-a83c-a4cdcd1e23dc)
