### PR TITLE
Fix System.ArgumentException: Invalid identifier on Linux (#1434)

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Controller/AeroCool/P7-H1.cs
+++ b/LibreHardwareMonitorLib/Hardware/Controller/AeroCool/P7-H1.cs
@@ -19,7 +19,7 @@ internal sealed class P7H1 : Hardware
     private readonly HidStream _stream;
     private bool _running;
 
-    public P7H1(HidDevice dev, ISettings settings) : base("AeroCool P7-H1", new Identifier(dev.DevicePath), settings)
+    public P7H1(HidDevice dev, ISettings settings) : base("AeroCool P7-H1", new Identifier("aerocool", "p7h1", dev.GetSerialNumber().Replace(" ", "")), settings)
     {
         _device = dev;
         HubNumber = _device.ProductID - 0x1000;

--- a/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/AquastreamUltimate.cs
+++ b/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/AquastreamUltimate.cs
@@ -4,6 +4,7 @@
 // All Rights Reserved.
 
 using System;
+using System.IO;
 using HidSharp;
 
 namespace LibreHardwareMonitor.Hardware.Controller.AquaComputer;
@@ -20,20 +21,20 @@ internal sealed class AquastreamUltimate : Hardware
     private readonly Sensor[] _powers = new Sensor[2];
     private readonly Sensor[] _flows = new Sensor[2];
 
-    public AquastreamUltimate(HidDevice dev, ISettings settings) : base("AquastreamUltimate", new Identifier(dev.DevicePath), settings)
+    public AquastreamUltimate(HidDevice dev, ISettings settings) : base("AquastreamUltimate", new Identifier("aquacomputer", "asultimate", dev.GetSerialNumber().Replace(" ", "")), settings)
     {
         if (dev.TryOpen(out _stream))
         {
             // Reading output report instead of feature report, as the measurements are in the output report.
             _stream.Read(_rawData);
-            
+
             FirmwareVersion = GetConvertedValue(0xD).GetValueOrDefault(0);
-                
+
             Name = "Aquastream ULTIMATE";
 
             _temperatures[0] = new Sensor("Coolant", 0, SensorType.Temperature, this, Array.Empty<ParameterDescription>(), settings);
             ActivateSensor(_temperatures[0]);
-            
+
             _temperatures[1] = new Sensor("External Sensor", 1, SensorType.Temperature, this, Array.Empty<ParameterDescription>(), settings);
             ActivateSensor(_temperatures[1]);
 
@@ -86,22 +87,29 @@ internal sealed class AquastreamUltimate : Hardware
     public override void Update()
     {
         // Reading output report instead of feature report, as the measurements are in the output report
-        _stream.Read(_rawData);
+        try
+        {
+            _stream.Read(_rawData);
+        }
+        catch (IOException)
+        {
+            return;
+        }
 
-        _rpmSensors[0].Value = GetConvertedValue(0x51) ; // Pump speed.
-        _rpmSensors[1].Value = GetConvertedValue(0x41+0x06); // Fan speed.
+        _rpmSensors[0].Value = GetConvertedValue(0x51); // Pump speed.
+        _rpmSensors[1].Value = GetConvertedValue(0x41 + 0x06); // Fan speed.
 
         _temperatures[0].Value = GetConvertedValue(0x2D) / 100f; // Water temp.
         _temperatures[1].Value = GetConvertedValue(0x2F) / 100f; // Ext sensor temp.
 
         _voltages[0].Value = GetConvertedValue(0x3D) / 100f; // Pump input voltage.
-        _voltages[1].Value = GetConvertedValue(0x41+0x02) / 100f; // Fan output voltage.
+        _voltages[1].Value = GetConvertedValue(0x41 + 0x02) / 100f; // Fan output voltage.
 
         _currents[0].Value = GetConvertedValue(0x53) / 1000f; // Pump current.
-        _currents[1].Value = GetConvertedValue(0x41+0x00) / 1000f; // Fan current.
+        _currents[1].Value = GetConvertedValue(0x41 + 0x00) / 1000f; // Fan current.
 
         _powers[0].Value = GetConvertedValue(0x55) / 100f; // Pump power.
-        _powers[1].Value = GetConvertedValue(0x41+0x04) / 100f; // Fan power.
+        _powers[1].Value = GetConvertedValue(0x41 + 0x04) / 100f; // Fan power.
 
         _flows[0].Value = GetConvertedValue(0x37); // Flow.
         _flows[1].Value = GetConvertedValue(0x57) / 1000f; // Pressure.
@@ -111,7 +119,7 @@ internal sealed class AquastreamUltimate : Hardware
     {
         if (_rawData[index] == sbyte.MaxValue)
             return null;
-            
+
         return Convert.ToUInt16(_rawData[index + 1] | (_rawData[index] << 8));
-    }    
+    }
 }

--- a/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/AquastreamXT.cs
+++ b/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/AquastreamXT.cs
@@ -26,7 +26,7 @@ internal sealed class AquastreamXT : Hardware
     private readonly Sensor[] _temperatures = new Sensor[3];
     private readonly Sensor[] _voltages = new Sensor[2];
 
-    public AquastreamXT(HidDevice dev, ISettings settings) : base("Aquastream XT", new Identifier(dev.DevicePath), settings)
+    public AquastreamXT(HidDevice dev, ISettings settings) : base("Aquastream XT", new Identifier("aquacomputer", "asxt", dev.GetSerialNumber().Replace(" ", "")), settings)
     {
         if (dev.TryOpen(out _stream))
         {
@@ -129,7 +129,6 @@ internal sealed class AquastreamXT : Hardware
         {
             return;
         }
-       
 
         if (_rawData[0] != 0x4)
             return;

--- a/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/D5Next.cs
+++ b/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/D5Next.cs
@@ -25,7 +25,7 @@ internal sealed class D5Next : Hardware
     private readonly HidStream _stream;
     private readonly Sensor[] _temperatures = new Sensor[1];
 
-    public D5Next(HidDevice dev, ISettings settings) : base("D5Next", new Identifier(dev.DevicePath), settings)
+    public D5Next(HidDevice dev, ISettings settings) : base("D5Next", new Identifier("aquacomputer", "d5next", dev.GetSerialNumber().Replace(" ", "")), settings)
     {
         if (dev.TryOpen(out _stream))
         {

--- a/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/Farbwerk.cs
+++ b/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/Farbwerk.cs
@@ -27,7 +27,7 @@ internal sealed class Farbwerk : Hardware
     private readonly Sensor[] _temperatures = new Sensor[TEMPERATURE_COUNT];
     private readonly Sensor[] _colors = new Sensor[COLOR_VALUE_COUNT];
 
-    public Farbwerk(HidDevice dev, ISettings settings) : base("Farbwerk", new Identifier(dev.DevicePath), settings)
+    public Farbwerk(HidDevice dev, ISettings settings) : base("Farbwerk", new Identifier("aquacomputer", "farbwerk", dev.GetSerialNumber().Replace(" ", "")), settings)
     {
         if (dev.TryOpen(out _stream))
         {

--- a/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/MPS.cs
+++ b/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/MPS.cs
@@ -23,7 +23,7 @@ internal sealed class MPS : Hardware
 
     private ushort _externalTemperature;
 
-    public MPS(HidDevice dev, ISettings settings) : base("MPS", new Identifier(dev.DevicePath), settings)
+    public MPS(HidDevice dev, ISettings settings) : base("MPS", new Identifier("aquacomputer", "mps", dev.GetSerialNumber().Replace(" ", "")), settings)
     {
         if (dev.TryOpen(out _stream))
         {

--- a/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/Octo.cs
+++ b/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/Octo.cs
@@ -18,30 +18,30 @@ internal sealed class Octo : Hardware
     private readonly Sensor[] _currents = new Sensor[8];
     private readonly Sensor[] _powers = new Sensor[8];
 
-    public Octo(HidDevice dev, ISettings settings) : base("Octo", new Identifier(dev.DevicePath), settings)
+    public Octo(HidDevice dev, ISettings settings) : base("Octo", new Identifier("aquacomputer", "octo", dev.GetSerialNumber().Replace(" ", "")), settings)
     {
         if (dev.TryOpen(out _stream))
         {
             //Reading output report instead of feature report, as the measurements are in the output report
             _stream.Read(_rawData);
-                
+
             Name = "OCTO";
             FirmwareVersion = GetConvertedValue(OctoDataIndexes.FIRMWARE_VERSION).GetValueOrDefault(0);
 
             // Initialize the 4 temperature sensors
             for (int i = 0; i < 4; i++)
             {
-                _temperatures[i] = new Sensor($"Temperature {i+1}", i, SensorType.Temperature, this, Array.Empty<ParameterDescription>(), settings);
+                _temperatures[i] = new Sensor($"Temperature {i + 1}", i, SensorType.Temperature, this, Array.Empty<ParameterDescription>(), settings);
                 ActivateSensor(_temperatures[i]);
             }
 
             // Initialize the 8 fan speed sensors
             for (int i = 0; i < 8; i++)
             {
-                _rpmSensors[i] = new Sensor($"Fan {i+1}", i, SensorType.Fan, this, Array.Empty<ParameterDescription>(), settings);
+                _rpmSensors[i] = new Sensor($"Fan {i + 1}", i, SensorType.Fan, this, Array.Empty<ParameterDescription>(), settings);
                 ActivateSensor(_rpmSensors[i]);
             }
-                
+
             // Initialize the input voltage sensor
             _voltages[0] = new Sensor("Input", 0, SensorType.Voltage, this, Array.Empty<ParameterDescription>(), settings);
             ActivateSensor(_voltages[0]);
@@ -52,18 +52,18 @@ internal sealed class Octo : Hardware
                 _voltages[i] = new Sensor($"Fan {i}", i, SensorType.Voltage, this, Array.Empty<ParameterDescription>(), settings);
                 ActivateSensor(_voltages[i]);
             }
-                
+
             // Initialize the 8 fan current sensors
             for (int i = 0; i < 8; i++)
             {
-                _currents[i] = new Sensor($"Fan {i+1}", i, SensorType.Current, this, Array.Empty<ParameterDescription>(), settings);
+                _currents[i] = new Sensor($"Fan {i + 1}", i, SensorType.Current, this, Array.Empty<ParameterDescription>(), settings);
                 ActivateSensor(_currents[i]);
             }
-                
+
             // Initialize the 8 fan power sensors
             for (int i = 0; i < 8; i++)
             {
-                _powers[i] = new Sensor($"Fan {i+1}", i, SensorType.Power, this, Array.Empty<ParameterDescription>(), settings);
+                _powers[i] = new Sensor($"Fan {i + 1}", i, SensorType.Power, this, Array.Empty<ParameterDescription>(), settings);
                 ActivateSensor(_powers[i]);
             }
         }
@@ -86,7 +86,7 @@ internal sealed class Octo : Hardware
     {
         //Reading output report instead of feature report, as the measurements are in the output report
         _stream.Read(_rawData);
-            
+
         _temperatures[0].Value = GetConvertedValue(OctoDataIndexes.TEMP_1) / 100f; // Temp 1
         _temperatures[1].Value = GetConvertedValue(OctoDataIndexes.TEMP_2) / 100f; // Temp 2
         _temperatures[2].Value = GetConvertedValue(OctoDataIndexes.TEMP_3) / 100f; // Temp 3
@@ -100,7 +100,7 @@ internal sealed class Octo : Hardware
         _rpmSensors[5].Value = GetConvertedValue(OctoDataIndexes.FAN_SPEED_6); // Fan 6 speed
         _rpmSensors[6].Value = GetConvertedValue(OctoDataIndexes.FAN_SPEED_7); // Fan 7 speed
         _rpmSensors[7].Value = GetConvertedValue(OctoDataIndexes.FAN_SPEED_8); // Fan 8 speed
-            
+
         _voltages[0].Value = GetConvertedValue(OctoDataIndexes.VOLTAGE) / 100f; // Input voltage
         _voltages[1].Value = GetConvertedValue(OctoDataIndexes.FAN_VOLTAGE_1) / 100f; // Fan 1 voltage
         _voltages[2].Value = GetConvertedValue(OctoDataIndexes.FAN_VOLTAGE_2) / 100f; // Fan 2 voltage
@@ -110,7 +110,7 @@ internal sealed class Octo : Hardware
         _voltages[6].Value = GetConvertedValue(OctoDataIndexes.FAN_VOLTAGE_6) / 100f; // Fan 6 voltage
         _voltages[7].Value = GetConvertedValue(OctoDataIndexes.FAN_VOLTAGE_7) / 100f; // Fan 7 voltage
         _voltages[8].Value = GetConvertedValue(OctoDataIndexes.FAN_VOLTAGE_8) / 100f; // Fan 8 voltage
-            
+
         _currents[0].Value = GetConvertedValue(OctoDataIndexes.FAN_CURRENT_1) / 1000f; // Fan 1 current
         _currents[1].Value = GetConvertedValue(OctoDataIndexes.FAN_CURRENT_2) / 1000f; // Fan 2 current
         _currents[2].Value = GetConvertedValue(OctoDataIndexes.FAN_CURRENT_3) / 1000f; // Fan 3 current
@@ -119,7 +119,7 @@ internal sealed class Octo : Hardware
         _currents[5].Value = GetConvertedValue(OctoDataIndexes.FAN_CURRENT_6) / 1000f; // Fan 6 current
         _currents[6].Value = GetConvertedValue(OctoDataIndexes.FAN_CURRENT_7) / 1000f; // Fan 7 current
         _currents[7].Value = GetConvertedValue(OctoDataIndexes.FAN_CURRENT_8) / 1000f; // Fan 8 current
-            
+
         _powers[0].Value = GetConvertedValue(OctoDataIndexes.FAN_POWER_1) / 100f; // Fan 1 power
         _powers[1].Value = GetConvertedValue(OctoDataIndexes.FAN_POWER_2) / 100f; // Fan 2 power
         _powers[2].Value = GetConvertedValue(OctoDataIndexes.FAN_POWER_3) / 100f; // Fan 3 power
@@ -133,7 +133,7 @@ internal sealed class Octo : Hardware
     private sealed class OctoDataIndexes
     {
         public const int FIRMWARE_VERSION = 13;
-            
+
         public const int TEMP_1 = 61;
         public const int TEMP_2 = 63;
         public const int TEMP_3 = 65;
@@ -147,7 +147,7 @@ internal sealed class Octo : Hardware
         public const int FAN_SPEED_6 = 198;
         public const int FAN_SPEED_7 = 211;
         public const int FAN_SPEED_8 = 224;
-            
+
         public const int FAN_POWER_1 = 131;
         public const int FAN_POWER_2 = 144;
         public const int FAN_POWER_3 = 157;
@@ -166,7 +166,7 @@ internal sealed class Octo : Hardware
         public const int FAN_VOLTAGE_6 = 192;
         public const int FAN_VOLTAGE_7 = 205;
         public const int FAN_VOLTAGE_8 = 218;
-            
+
         public const int FAN_CURRENT_1 = 129;
         public const int FAN_CURRENT_2 = 142;
         public const int FAN_CURRENT_3 = 155;
@@ -181,7 +181,7 @@ internal sealed class Octo : Hardware
     {
         if (_rawData[index] == sbyte.MaxValue)
             return null;
-            
+
         return Convert.ToUInt16(_rawData[index + 1] | (_rawData[index] << 8));
     }
 }

--- a/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/Quadro.cs
+++ b/LibreHardwareMonitorLib/Hardware/Controller/AquaComputer/Quadro.cs
@@ -20,20 +20,20 @@ internal sealed class Quadro : Hardware
     private readonly Sensor[] _powers = new Sensor[4];
     private readonly Sensor[] _flows = new Sensor[1];
 
-    public Quadro(HidDevice dev, ISettings settings) : base("Quadro", new Identifier(dev.DevicePath), settings)
+    public Quadro(HidDevice dev, ISettings settings) : base("Quadro", new Identifier("aquacomputer", "quadro", dev.GetSerialNumber().Replace(" ", "")), settings)
     {
         if (dev.TryOpen(out _stream))
         {
             //Reading output report instead of feature report, as the measurements are in the output report
             _stream.Read(_rawData);
-                
+
             Name = "QUADRO";
             FirmwareVersion = GetConvertedValue(QuadroDataIndexes.FIRMWARE_VERSION).GetValueOrDefault(0);
 
             // Initialize the 4 temperature sensors
             for (int i = 0; i < 4; i++)
             {
-                _temperatures[i] = new Sensor($"Temperature {i+1}", i, SensorType.Temperature, this, Array.Empty<ParameterDescription>(), settings);
+                _temperatures[i] = new Sensor($"Temperature {i + 1}", i, SensorType.Temperature, this, Array.Empty<ParameterDescription>(), settings);
                 ActivateSensor(_temperatures[i]);
             }
 
@@ -51,18 +51,18 @@ internal sealed class Quadro : Hardware
                 _voltages[i] = new Sensor($"Fan {i}", i, SensorType.Voltage, this, Array.Empty<ParameterDescription>(), settings);
                 ActivateSensor(_voltages[i]);
             }
-                
+
             // Initialize the 4 fan current sensors
             for (int i = 0; i < 4; i++)
             {
-                _currents[i] = new Sensor($"Fan {i+1}", i, SensorType.Current, this, Array.Empty<ParameterDescription>(), settings);
+                _currents[i] = new Sensor($"Fan {i + 1}", i, SensorType.Current, this, Array.Empty<ParameterDescription>(), settings);
                 ActivateSensor(_currents[i]);
             }
-                
+
             // Initialize the 4 fan power sensors
             for (int i = 0; i < 4; i++)
             {
-                _powers[i] = new Sensor($"Fan {i+1}", i, SensorType.Power, this, Array.Empty<ParameterDescription>(), settings);
+                _powers[i] = new Sensor($"Fan {i + 1}", i, SensorType.Power, this, Array.Empty<ParameterDescription>(), settings);
                 ActivateSensor(_powers[i]);
             }
 
@@ -93,7 +93,7 @@ internal sealed class Quadro : Hardware
     {
         //Reading output report instead of feature report, as the measurements are in the output report
         _stream.Read(_rawData);
-            
+
         _temperatures[0].Value = GetConvertedValue(QuadroDataIndexes.TEMP_1) / 100f; // Temp 1
         _temperatures[1].Value = GetConvertedValue(QuadroDataIndexes.TEMP_2) / 100f; // Temp 2
         _temperatures[2].Value = GetConvertedValue(QuadroDataIndexes.TEMP_3) / 100f; // Temp 3
@@ -122,13 +122,13 @@ internal sealed class Quadro : Hardware
         _rpmSensors[1].Value = GetConvertedValue(QuadroDataIndexes.FAN_SPEED_2); // Fan 2 speed
         _rpmSensors[2].Value = GetConvertedValue(QuadroDataIndexes.FAN_SPEED_3); // Fan 3 speed
         _rpmSensors[3].Value = GetConvertedValue(QuadroDataIndexes.FAN_SPEED_4); // Fan 4 speed
-            
+
     }
 
     private sealed class QuadroDataIndexes
     {
         public const int FIRMWARE_VERSION = 13;
-            
+
         public const int TEMP_1 = 52;
         public const int TEMP_2 = 54;
         public const int TEMP_3 = 56;
@@ -164,7 +164,7 @@ internal sealed class Quadro : Hardware
     {
         if (_rawData[index] == sbyte.MaxValue)
             return null;
-            
+
         return Convert.ToUInt16(_rawData[index + 1] | (_rawData[index] << 8));
     }
 }

--- a/LibreHardwareMonitorLib/Hardware/Controller/Razer/RazerFanController.cs
+++ b/LibreHardwareMonitorLib/Hardware/Controller/Razer/RazerFanController.cs
@@ -29,7 +29,7 @@ internal sealed class RazerFanController : Hardware
     private readonly Sensor[] _pwmControls = new Sensor[CHANNEL_COUNT];
     private readonly Sensor[] _rpmSensors = new Sensor[CHANNEL_COUNT];
 
-    public RazerFanController(HidDevice dev, ISettings settings) : base("Razer PWM PC Fan Controller", new Identifier(dev.DevicePath), settings)
+    public RazerFanController(HidDevice dev, ISettings settings) : base("Razer PWM PC Fan Controller", new Identifier("razer", "pwmpcfancontroller", dev.GetSerialNumber().Replace(" ", "")), settings)
     {
         _device = dev;
 


### PR DESCRIPTION
Fix for #1434

This solution is inspired by the nzxt hardware identifier. https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/5476ac16c9e3c4f1e2692515edb86c55a613cefa/LibreHardwareMonitorLib/Hardware/Controller/Nzxt/KrakenV2.cs#L28