### PR TITLE
Bugfix: Fan and Temp data missing #780

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -33,6 +33,7 @@ internal class IT87XX : ISuperIO
     private readonly byte _version;
     private readonly float _voltageGain;
     private IGigabyteController _gigabyteController;
+    private readonly bool _requiresBankSelect;  // Fix #780 Set to true for those chips that need a SelectBank(0) to fix dodgy temps and fan speeds
 
     private bool SupportsMultipleBanks => _bankCount > 1;
 
@@ -44,6 +45,7 @@ internal class IT87XX : ISuperIO
         _dataReg = (ushort)(address + DATA_REGISTER_OFFSET);
         _gpioAddress = gpioAddress;
         _gigabyteController = gigabyteController;
+        _requiresBankSelect = false;  // Fix #780
 
         Chip = chip;
 
@@ -161,6 +163,7 @@ internal class IT87XX : ISuperIO
                 Temperatures = new float?[6];
                 Fans = new float?[3];
                 Controls = new float?[3];
+                _requiresBankSelect = true;  // Fix #780
                 break;
 
             case Chip.IT8792E:
@@ -323,6 +326,9 @@ internal class IT87XX : ISuperIO
         if (!Mutexes.WaitIsaBus(100))
             return r.ToString();
 
+        if (_requiresBankSelect)  // Fix #780
+            SelectBank(0);        // Fix #780
+
         // dump memory of all banks if supported by chip
         for (byte b = 0; b < _bankCount; b++)
         {
@@ -400,6 +406,10 @@ internal class IT87XX : ISuperIO
     {
         if (!Mutexes.WaitIsaBus(10))
             return;
+
+        // Is this needed on every update?  Yes, until a way to detect resume from sleep/hibernation is added, as that invalidates the bank select.
+        if (_requiresBankSelect)     // Fix #780
+            SelectBank(0);           // Fix #780
 
         for (int i = 0; i < Voltages.Length; i++)
         {

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -45,7 +45,7 @@ internal class IT87XX : ISuperIO
         _dataReg = (ushort)(address + DATA_REGISTER_OFFSET);
         _gpioAddress = gpioAddress;
         _gigabyteController = gigabyteController;
-        _requiresBankSelect = false;  // Fix #780
+        _requiresBankSelect = false;
 
         Chip = chip;
 
@@ -163,7 +163,7 @@ internal class IT87XX : ISuperIO
                 Temperatures = new float?[6];
                 Fans = new float?[3];
                 Controls = new float?[3];
-                _requiresBankSelect = true;  // Fix #780
+                _requiresBankSelect = true;
                 break;
 
             case Chip.IT8792E:
@@ -326,8 +326,8 @@ internal class IT87XX : ISuperIO
         if (!Mutexes.WaitIsaBus(100))
             return r.ToString();
 
-        if (_requiresBankSelect)  // Fix #780
-            SelectBank(0);        // Fix #780
+        if (_requiresBankSelect)
+            SelectBank(0);
 
         // dump memory of all banks if supported by chip
         for (byte b = 0; b < _bankCount; b++)
@@ -408,8 +408,8 @@ internal class IT87XX : ISuperIO
             return;
 
         // Is this needed on every update?  Yes, until a way to detect resume from sleep/hibernation is added, as that invalidates the bank select.
-        if (_requiresBankSelect)     // Fix #780
-            SelectBank(0);           // Fix #780
+        if (_requiresBankSelect)
+            SelectBank(0);
 
         for (int i = 0; i < Voltages.Length; i++)
         {


### PR DESCRIPTION
This is a fix for #780 IT8655E which shows incorrect/missing information for fans and temps.  Also fixes #614.

I have tested this on my ASUS Prime B350M-A, through a number of restarts, sleeps and hibernates, and I no longer see the incorrect fan speeds, incorrect temperatures or missing temperatures.

Inspiration came from [Linux it87](https://github.com/frankcrawford/it87/blob/14b1de2fb49db4e73b58177bc43daa71ceb8e92f/it87.c#L3870) where the interaction with the IT8655E does a set_bank before every interaction with a port.

In theory this fix can be applied to other IT86 chipsets as per FEAT_BANK_SEL as shown [here](https://github.com/frankcrawford/it87/blob/14b1de2fb49db4e73b58177bc43daa71ceb8e92f/it87.c#L709) for the IT8655.
As I can't test other chipsets I have not made the changes.

Setting _requiresBankSelect to true for other chipsets that have this issue may fix them as well.  
eg. Issue #760 could be fixed as per below.

LibreHardwareMonitorLib\Hardware\Motherboard\Lpc\IT87XX.cs
```
@@ -135,6 +135,7 @@ internal class IT87XX : ISuperIO
                Temperatures = new float?[6];
                Fans = new float?[6];
                Controls = new float?[5];
+                _requiresBankSelect = true;  // Fix #760
                break;

            case Chip.IT8688E:
```