### PR TITLE
Fix: Fix fan and temp data for IT8665E chip motherboards, fixes #737 and more

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -130,6 +130,13 @@ internal class IT87XX : ISuperIO
                 break;
 
             case Chip.IT8665E:
+                Voltages = new float?[9];
+                Temperatures = new float?[6];
+                Fans = new float?[3];
+                Controls = new float?[3];
+                _requiresBankSelect = true;
+                break;
+
             case Chip.IT8686E:
                 Voltages = new float?[10];
                 Temperatures = new float?[6];


### PR DESCRIPTION
This adds the same fix from #1438 to IT8665E chips, fixing a bug where speeds and other sensor data is incorrectly reported/not shown at all. Fixes #737 and a few other issues.