### PR TITLE
Direct3D Bugfix

### DIFF
--- a/LibreHardwareMonitorLib/Interop/D3dkmth.cs
+++ b/LibreHardwareMonitorLib/Interop/D3dkmth.cs
@@ -381,16 +381,16 @@ internal static class D3dkmth
     [StructLayout(LayoutKind.Explicit)]
     internal struct D3DKMT_QUERYSTATISTICS_RESULT
     {
-        [FieldOffset(8)]
+        [FieldOffset(0), MarshalAs(UnmanagedType.Struct)]
         public D3DKMT_QUERYSTATISTICS_ADAPTER_INFORMATION AdapterInformation;
 
-        [FieldOffset(8)]
+        [FieldOffset(0), MarshalAs(UnmanagedType.Struct)]
         public D3DKMT_QUERYSTATISTICS_SEGMENT_INFORMATION SegmentInformation;
 
-        [FieldOffset(8)]
+        [FieldOffset(0), MarshalAs(UnmanagedType.Struct)]
         public D3DKMT_QUERYSTATISTICS_PROCESS_SEGMENT_INFORMATION ProcessSegmentInformation;
 
-        [FieldOffset(8)]
+        [FieldOffset(0), MarshalAs(UnmanagedType.Struct)]
         public D3DKMT_QUERYSTATISTICS_NODE_INFORMATION NodeInformation;
 
         // D3DKMT_QUERYSTATISTICS_PROCESS_INFORMATION ProcessInformation;
@@ -430,7 +430,7 @@ internal static class D3dkmth
     {
         public D3DKMT_QUERYSTATISTICS_TYPE Type;
         public WinNt.LUID AdapterLuid;
-        public uint ProcessHandle;
+        public IntPtr ProcessHandle;
         public D3DKMT_QUERYSTATISTICS_RESULT QueryResult;
         public D3DKMT_QUERYSTATISTICS_QUERY_ELEMENT QueryElement;
     }


### PR DESCRIPTION
https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/issues/1251 
wrong structure definition, only had an effect in 32 bit mode
IntPtr has a different size in a 32 and 64 bit process