### PR TITLE
Added support for Lunar Lake CPUs

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Cpu/IntelCpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/IntelCpu.cs
@@ -227,6 +227,11 @@ internal sealed class IntelCpu : GenericCpu
                             tjMax = GetTjMaxFromMsr();
                             break;
 
+                        case 0xBD: // Intel Core Ultra 7 200 Series ArrowLake
+                            _microArchitecture = MicroArchitecture.LunarLake;
+                            tjMax = GetTjMaxFromMsr();
+                            break;
+
                         default:
                             _microArchitecture = MicroArchitecture.Unknown;
                             tjMax = Floats(100);
@@ -284,6 +289,7 @@ internal sealed class IntelCpu : GenericCpu
             case MicroArchitecture.IvyBridge:
             case MicroArchitecture.JasperLake:
             case MicroArchitecture.KabyLake:
+            case MicroArchitecture.LunarLake:
             case MicroArchitecture.Nehalem:
             case MicroArchitecture.MeteorLake:
             case MicroArchitecture.RaptorLake:
@@ -399,6 +405,7 @@ internal sealed class IntelCpu : GenericCpu
             MicroArchitecture.IvyBridge or
             MicroArchitecture.JasperLake or
             MicroArchitecture.KabyLake or
+            MicroArchitecture.LunarLake or
             MicroArchitecture.MeteorLake or
             MicroArchitecture.RaptorLake or
             MicroArchitecture.RocketLake or
@@ -602,6 +609,7 @@ internal sealed class IntelCpu : GenericCpu
                         case MicroArchitecture.IvyBridge:
                         case MicroArchitecture.JasperLake:
                         case MicroArchitecture.KabyLake:
+                        case MicroArchitecture.LunarLake:
                         case MicroArchitecture.MeteorLake:
                         case MicroArchitecture.RaptorLake:
                         case MicroArchitecture.RocketLake:
@@ -690,6 +698,7 @@ internal sealed class IntelCpu : GenericCpu
         IvyBridge,
         JasperLake,
         KabyLake,
+        LunarLake,
         Nehalem,
         NetBurst,
         MeteorLake,

--- a/LibreHardwareMonitorLib/Hardware/Cpu/IntelCpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/IntelCpu.cs
@@ -227,7 +227,7 @@ internal sealed class IntelCpu : GenericCpu
                             tjMax = GetTjMaxFromMsr();
                             break;
 
-                        case 0xBD: // Intel Core Ultra 7 200 Series ArrowLake
+                        case 0xBD: // Intel Core Ultra 5/7 200 Series LunarLake
                             _microArchitecture = MicroArchitecture.LunarLake;
                             tjMax = GetTjMaxFromMsr();
                             break;


### PR DESCRIPTION
Tested on ASUS Zenbook S 14 2024 (UX5406SA) with Intel Core 7 Ultra 7 258V Lunar Lake CPU
![image](https://github.com/user-attachments/assets/8bbac5f3-9d73-479b-a5fe-3977596afd07)
