### PR TITLE
Add Gigabyte X870E AORUS PRO (ICE) (ITE IT8696E, ITE IT87952E)

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -599,6 +599,10 @@ internal class Identification
                 return Model.ROG_MAXIMUS_Z790_FORMULA;
             case var _ when name.Equals("ROG MAXIMUS XII HERO (WI-FI)", StringComparison.OrdinalIgnoreCase):
                 return Model.ROG_MAXIMUS_XII_HERO_WIFI;
+            case var _ when name.Equals("X870E AORUS PRO", StringComparison.OrdinalIgnoreCase):
+                return Model.X870E_AORUS_PRO;
+            case var _ when name.Equals("X870E AORUS PRO ICE", StringComparison.OrdinalIgnoreCase):
+                return Model.X870E_AORUS_PRO_ICE;
             case var _ when name.Equals("Base Board Product Name", StringComparison.OrdinalIgnoreCase):
             case var _ when name.Equals("To be filled by O.E.M.", StringComparison.OrdinalIgnoreCase):
                 return Model.Unknown;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Chip.cs
@@ -37,6 +37,7 @@ internal enum Chip : ushort
     IT8686E = 0x8686,
     IT8688E = 0x8688,
     IT8689E = 0x8689,
+    IT8696E = 0x8696,
     IT8705F = 0x8705,
     IT8712F = 0x8712,
     IT8716F = 0x8716,
@@ -109,6 +110,7 @@ internal class ChipName
             case Chip.IT8686E: return "ITE IT8686E";
             case Chip.IT8688E: return "ITE IT8688E";
             case Chip.IT8689E: return "ITE IT8689E";
+            case Chip.IT8696E: return "ITE IT8696E";
             case Chip.IT8705F: return "ITE IT8705F";
             case Chip.IT8712F: return "ITE IT8712F";
             case Chip.IT8716F: return "ITE IT8716F";

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -98,7 +98,8 @@ internal class IT87XX : ISuperIO
             Chip.IT8613E or
             Chip.IT8792E or
             Chip.IT8655E or
-            Chip.IT8631E;
+            Chip.IT8631E or
+            Chip.IT8696E;
 
         switch (chip)
         {
@@ -158,8 +159,15 @@ internal class IT87XX : ISuperIO
                 Controls = new float?[6];
                 break;
 
+            case Chip.IT8696E:
+                Voltages = new float?[10];
+                Temperatures = new float?[5];
+                Fans = new float?[5];
+                Controls = new float?[5];
+                break;
+
             case Chip.IT87952E:
-                Voltages = new float?[6];
+                Voltages = new float?[10];
                 Temperatures = new float?[3];
                 Fans = new float?[3];
                 Controls = new float?[3];
@@ -208,7 +216,7 @@ internal class IT87XX : ISuperIO
         // Conflicting reports on IT8792E: either 0.0109 in linux drivers or 0.011 comparing with Gigabyte board & SIV SW.
         _voltageGain = chip switch
         {
-            Chip.IT8613E or Chip.IT8620E or Chip.IT8628E or Chip.IT8631E or Chip.IT8721F or Chip.IT8728F or Chip.IT8771E or Chip.IT8772E or Chip.IT8686E or Chip.IT8688E or Chip.IT8689E => 0.012f,
+            Chip.IT8613E or Chip.IT8620E or Chip.IT8628E or Chip.IT8631E or Chip.IT8721F or Chip.IT8728F or Chip.IT8771E or Chip.IT8772E or Chip.IT8686E or Chip.IT8688E or Chip.IT8689E or Chip.IT8696E => 0.012f,
             Chip.IT8625E or Chip.IT8792E or Chip.IT87952E => 0.011f,
             Chip.IT8655E or Chip.IT8665E => 0.0109f,
             _ => 0.016f

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
@@ -557,6 +557,7 @@ internal class LpcIO
             0x8686 => Chip.IT8686E,
             0x8688 => Chip.IT8688E,
             0x8689 => Chip.IT8689E,
+            0x8696 => Chip.IT8696E,
             0x8705 => Chip.IT8705F,
             0x8712 => Chip.IT8712F,
             0x8716 => Chip.IT8716F,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -248,6 +248,8 @@ public enum Model
     B650M_AORUS_PRO_AX,
     B650M_AORUS_ELITE,
     B650M_AORUS_ELITE_AX,
+    X870E_AORUS_PRO,
+    X870E_AORUS_PRO_ICE,
 
     // Shuttle
     FH67,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -226,6 +226,7 @@ internal sealed class SuperIOHardware : Hardware
             case Chip.IT8686E:
             case Chip.IT8688E:
             case Chip.IT8689E:
+            case Chip.IT8696E:
             case Chip.IT8721F:
             case Chip.IT8728F:
             case Chip.IT8771E:
@@ -2023,6 +2024,8 @@ internal sealed class SuperIOHardware : Hardware
                     case Model.B550_UD_AC:
                     case Model.B550M_AORUS_PRO:
                     case Model.B550M_AORUS_PRO_AX:
+                    case Model.X870E_AORUS_PRO: // ITE IT8696E
+                    case Model.X870E_AORUS_PRO_ICE: // ITE IT8696E
                         v.Add(new Voltage("Vcore", 0, 0, 1));
                         v.Add(new Voltage("+3.3V", 1, 6.5F, 10));
                         v.Add(new Voltage("+12V", 2, 5, 1));
@@ -2404,6 +2407,27 @@ internal sealed class SuperIOHardware : Hardware
                         f.Add(new Fan("System Fan #5 / Pump", 0));
                         f.Add(new Fan("System Fan #6 / Pump", 1));
                         f.Add(new Fan("System Fan #4", 2));
+                        c.Add(new Control("System Fan #5 / Pump", 0));
+                        c.Add(new Control("System Fan #6 / Pump", 1));
+                        c.Add(new Control("System Fan #4", 2));
+                        break;
+
+                    case Model.X870E_AORUS_PRO:
+                    case Model.X870E_AORUS_PRO_ICE: // ITE IT87952E
+                        v.Add(new Voltage("VIN0", 0));
+                        v.Add(new Voltage("Voltage #2", 1, true));
+                        v.Add(new Voltage("PM_VCC18", 2));
+                        v.Add(new Voltage("VIN3", 3));
+                        v.Add(new Voltage("CPU VDD18", 4));
+                        v.Add(new Voltage("PM_VDD1V", 5));
+                        v.Add(new Voltage("VIN6", 6));
+                        v.Add(new Voltage("+3V Standby", 7, 1, 1));
+                        v.Add(new Voltage("CMOS Battery", 8, 1, 1));
+                        t.Add(new Temperature("PCIe x4", 0));
+                        t.Add(new Temperature("System #2", 1));
+                        f.Add(new Fan("System Fan #5 / Pump", 0));
+                        f.Add(new Fan("System Fan #6 / Pump", 1));
+                        f.Add(new Fan("System Fan #4 ", 2));
                         c.Add(new Control("System Fan #5 / Pump", 0));
                         c.Add(new Control("System Fan #6 / Pump", 1));
                         c.Add(new Control("System Fan #4", 2));


### PR DESCRIPTION
This PR adds support for the Gigabyte X870E AORUS PRO and X870E AORUS PRO ICE models (both models share identical configurations, differing only in color).

I've checked values using HWInfo.

![2024-11-18 22 34 07](https://github.com/user-attachments/assets/7c1a6d58-5854-4e89-8204-74d9c8874cc6)

Fan control via LHM works well, and so does Rem0o's Fan Control.

It is likely that this implementation will also work for other Gigabyte X870(E) models with the same IO chip, but I am unable to confirm as I do not own those boards. I will add support for them if their functionality is confirmed.