### PR TITLE
Added MS-7C35 motherboards support

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -597,6 +597,11 @@ internal class Identification
                 return Model.ROG_STRIX_Z790_E_GAMING_WIFI;
             case var _ when name.Equals("MPG X570 GAMING PLUS (MS-7C37)",StringComparison.OrdinalIgnoreCase):
                 return Model.X570_Gaming_Plus;
+            case var _ when name.Equals("MEG X570 UNIFY", StringComparison.OrdinalIgnoreCase):
+            case var _ when name.Equals("MEG X570 UNIFY (MS-7C35)", StringComparison.OrdinalIgnoreCase):
+            case var _ when name.Equals("MEG X570 ACE", StringComparison.OrdinalIgnoreCase):
+            case var _ when name.Equals("MEG X570 ACE (MS-7C35)", StringComparison.OrdinalIgnoreCase):
+                return Model.X570_MS7C35;
             case var _ when name.Equals("ROG MAXIMUS Z790 FORMULA", StringComparison.OrdinalIgnoreCase):
                 return Model.ROG_MAXIMUS_Z790_FORMULA;
             case var _ when name.Equals("Z790 Nova WiFi", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Management;
 using System.Text;
 using System.Threading;
 using LibreHardwareMonitor.Hardware.Cpu;
@@ -75,7 +76,7 @@ internal class LpcIO
         }
     }
 
-    public string GetReport()
+        public string GetReport()
     {
         if (_report.Length > 0)
         {
@@ -747,5 +748,6 @@ internal class LpcIO
 
     private readonly ushort[] REGISTER_PORTS = { 0x2E, 0x4E };
     private readonly ushort[] VALUE_PORTS = { 0x2F, 0x4F };
+
     // ReSharper restore InconsistentNaming
 }

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -132,6 +132,7 @@ public enum Model
     Z77_MS7751,
     Z68_MS7672,
     X570_Gaming_Plus,
+    X570_MS7C35,
 
     // EVGA
     X58_SLI_Classified,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -4541,6 +4541,54 @@ internal sealed class SuperIOHardware : Hardware
 
                         break;
 
+                    case Model.X570_MS7C35:
+                        // NCT6797D
+                        // NCT7802Y (on SMBus): SYS_FAN5, CPU 1.8V, Chipset SOC, Chipset CLDO - not supported
+                        // Unknown: PCIE 1, PCIE 3, M.2_1
+
+                        v.Add(new Voltage("Vcore", 0));           // CPUVCORE
+                        v.Add(new Voltage("+5V", 1, 12, 3));      // VIN1
+                        v.Add(new Voltage("AVCC", 2, 34, 34));    // AVSB, +3.3V analog power
+                        v.Add(new Voltage("+3.3V", 3, 34, 34));   // 3VCC
+                        v.Add(new Voltage("+12V", 4,  220, 20));  // VIN0
+                        //v.Add(new Voltage("Voltage #6", 5));    // VIN8, no pin for 6797D
+                        v.Add(new Voltage("CPUMOSTIN", 6, true)); // VIN4, temperature input
+                        v.Add(new Voltage("+3.3V Standby", 7, 34, 34));   // 3VSB, +3.3V digital power
+                        v.Add(new Voltage("CMOS Battery", 8, 34, 34, 0)); // VBAT
+                        v.Add(new Voltage("CPU 1.8V", 9));        // VTT, CPU_1P8
+                        v.Add(new Voltage("CPU VDDP", 10));       // VIN5  
+                        v.Add(new Voltage("PMTIN", 11, true));    // VIN6, temperature input
+                        v.Add(new Voltage("CPU NB/SoC", 12));     // VIN2, VCCP_NB
+                        v.Add(new Voltage("DIMM", 13, 1, 1));     // VIN3
+                        v.Add(new Voltage("+5V Standby", 14, 768, 330));  // VIN7, ATX_5VSB
+                        //v.Add(new Voltage("Voltage #16", 15));  // VIN9, no pin for 6797D
+
+                        t.Add(new Temperature("CPU Socket", 1));  // CPUTIN, 10k at top side of the socket
+                        t.Add(new Temperature("System", 2));      // SYSTIN, P-3906
+                        t.Add(new Temperature("VRM MOS", 3));     // AUXTIN0, CPUMOSTIN, 10k at left side of cpu vrm
+                        //t.Add(new Temperature("CPU_VDDP", 4));  // AUXTIN1, CPU_VDDP voltage input
+                        t.Add(new Temperature("Chipset", 5));     // AUXTIN2, 10k at back side of the chipset
+                        //t.Add(new Temperature("ATX 5VSB", 6));  // AUXTIN3, ATX_5VSB voltage input
+                        t.Add(new Temperature("CPU", 24));
+
+                        f.Add(new Fan("Pump Fan", 0));
+                        f.Add(new Fan("CPU Fan", 1));
+                        f.Add(new Fan("System Fan #1", 2));
+                        f.Add(new Fan("System Fan #2", 3));
+                        f.Add(new Fan("System Fan #3", 4));
+                        f.Add(new Fan("System Fan #4", 5));
+                        f.Add(new Fan("Chipset Fan", 6));
+
+                        c.Add(new Control("Pump Fan", 0));
+                        c.Add(new Control("CPU Fan", 1));
+                        c.Add(new Control("System Fan #1", 2));
+                        c.Add(new Control("System Fan #2", 3));
+                        c.Add(new Control("System Fan #3", 4));
+                        c.Add(new Control("System Fan #4", 5));
+                        c.Add(new Control("Chipset Fan", 6));
+
+                        break;
+
                     default:
                         v.Add(new Voltage("Vcore", 0));
                         v.Add(new Voltage("Voltage #2", 1, true));


### PR DESCRIPTION
Adds MSI MS-7C35 boards like X570 Unify and X570 Ace. Probably this will also work for the MS-7C34 but can't test it (not added by this PR).
NCT7802Y smbus hardware monitor chip is still unsupported (no system fan 5 and 3 voltages).
Used boardview, schematics, datasheets and so on. Tested on X570 Ace board.

![image](https://github.com/user-attachments/assets/e5a209e7-38bf-4f9a-b12f-7fb74c7a295a)
