### PR TITLE
X670 aorus elite ax

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -607,6 +607,8 @@ internal class Identification
                 return Model.X870E_AORUS_PRO;
             case var _ when name.Equals("X870E AORUS PRO ICE", StringComparison.OrdinalIgnoreCase):
                 return Model.X870E_AORUS_PRO_ICE;
+            case var _ when name.Equals("X670 AORUS ELITE AX", StringComparison.OrdinalIgnoreCase):
+               return Model.X670_AORUS_ELITE_AX;
             case var _ when name.Equals("Base Board Product Name", StringComparison.OrdinalIgnoreCase):
             case var _ when name.Equals("To be filled by O.E.M.", StringComparison.OrdinalIgnoreCase):
                 return Model.Unknown;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -252,6 +252,7 @@ public enum Model
     B650M_AORUS_ELITE_AX,
     X870E_AORUS_PRO,
     X870E_AORUS_PRO_ICE,
+    X670_AORUS_ELITE_AX,
 
     // Shuttle
     FH67,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2202,6 +2202,38 @@ internal sealed class SuperIOHardware : Hardware
 
                         break;
 
+                    case Model.X670_AORUS_ELITE_AX:
+                       v.Add(new Voltage("Vcore", 0, 0, 1));
+                       v.Add(new Voltage("+3.3V", 1, 6.49F, 10));
+                       v.Add(new Voltage("+12V", 2, 5, 1));
+                       v.Add(new Voltage("+5V", 3, 1.5F, 1));
+                       v.Add(new Voltage("Vcore SoC", 4, 0, 1));
+                       v.Add(new Voltage("Vcore Misc", 5, 0, 1));
+                       v.Add(new Voltage("CPU VDDIO Memory", 6, 0, 1));
+                       v.Add(new Voltage("+3V Standby", 7, 10, 10, 0));
+                       v.Add(new Voltage("CMOS Battery", 8, 10, 10));
+
+                       t.Add(new Temperature("System #1", 0));
+                       t.Add(new Temperature("PCH", 1));
+                       t.Add(new Temperature("CPU", 2));
+                       t.Add(new Temperature("PCIe x16", 3));
+                       t.Add(new Temperature("VRM MOS", 4));
+
+                       f.Add(new Fan("CPU Fan", 0));
+                       f.Add(new Fan("System Fan #1", 1));
+                       f.Add(new Fan("System Fan #2", 2));
+                       f.Add(new Fan("System Fan #3", 3));
+                       f.Add(new Fan("CPU Optional Fan", 4));
+
+                       c.Add(new Control("CPU Fan", 0));
+                       c.Add(new Control("System Fan #1", 1));
+                       c.Add(new Control("System Fan #2", 2));
+                       c.Add(new Control("System Fan #3", 3));
+                       c.Add(new Control("CPU Optional Fan", 4));
+
+                       break;
+
+
                     default:
                         v.Add(new Voltage("Voltage #1", 0, true));
                         v.Add(new Voltage("Voltage #2", 1, true));


### PR DESCRIPTION
Added support for Gigabyte X670 Aorus Elite AX - Names and Voltages corrections. I may be missing Gigabyte embedded controller.