### PR TITLE
Add 0.0.0.0 to server IP combo box, allow listening on all IPs

### DIFF
--- a/LibreHardwareMonitor/UI/InterfacePortForm.cs
+++ b/LibreHardwareMonitor/UI/InterfacePortForm.cs
@@ -36,16 +36,15 @@ public partial class InterfacePortForm : Form
             if (ip.AddressFamily == AddressFamily.InterNetwork)
                 interfaceComboBox.Items.Add(ip.ToString());
         }
+
+        interfaceComboBox.Items.Add("0.0.0.0");
+
         // select the last one by default to match the existing behavior
         if (interfaceComboBox.Items.Count > 0)
         {
             interfaceComboBox.SelectedIndex = interfaceComboBox.Items.Count - 1;
-        } else
-        {
-            // default to ? just like previous version
-            interfaceComboBox.Items.Add("?");
-            interfaceComboBox.SelectedIndex = 0;
         }
+
         // check to see if the selected listener IP is in our list.
         if (interfaceComboBox.Items.Contains(selectedListenerIp))
         {


### PR DESCRIPTION
Hi, I'm using LibreHardwareMonitor on computer which I'd like to expose via TailScale to my TailScale network.

So I need LibreHardwareMonitor to accept requests on multiple interfaces, from my internal network 192.168.0.x and tailscale network 100.100.52.x

I thought it might be handy to allow listening on all IPs, so I added 0.0.0.0 option.