### PR TITLE
Intel Ultra 9 200 Series ArrowLake Added

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Cpu/IntelCpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/IntelCpu.cs
@@ -222,6 +222,7 @@ internal sealed class IntelCpu : GenericCpu
                             tjMax = GetTjMaxFromMsr();
                             break;
 
+                        case 0xC5: // Intel Core Ultra 9 200 Series ArrowLake
                         case 0xC6: // Intel Core Ultra 7 200 Series ArrowLake
                             _microArchitecture = MicroArchitecture.ArrowLake;
                             tjMax = GetTjMaxFromMsr();


### PR DESCRIPTION
Temperature, powers, clocks  support for Intel Arrow Lake Ultra 9 200 Series.
Tested on Intel(R) Core(TM) Ultra 9 285H on ASUS Zenbook 14 2025 (UX3405CA) 