### PR TITLE
API endpoints for resetting Min/Max-values

### DIFF
--- a/LibreHardwareMonitor/UI/MainForm.cs
+++ b/LibreHardwareMonitor/UI/MainForm.cs
@@ -244,6 +244,7 @@ public sealed partial class MainForm : Form
         fahrenheitMenuItem.Checked = !celsiusMenuItem.Checked;
 
         Server = new HttpServer(_root,
+                                _computer,
                                 _settings.GetValue("listenerIp", "?"),
                                 _settings.GetValue("listenerPort", 8085),
                                 _settings.GetValue("authenticationEnabled", false),

--- a/LibreHardwareMonitor/Utilities/HttpServer.cs
+++ b/LibreHardwareMonitor/Utilities/HttpServer.cs
@@ -29,11 +29,13 @@ public class HttpServer
 {
     private readonly HttpListener _listener;
     private readonly Node _root;
+    private readonly IElement _rootElement;
     private Thread _listenerThread;
 
-    public HttpServer(Node node, string ip, int port, bool authEnabled = false, string userName = "", string password = "")
+    public HttpServer(Node node, IElement rootElement, string ip, int port, bool authEnabled = false, string userName = "", string password = "")
     {
         _root = node;
+        _rootElement = rootElement;
         ListenerIp = ip;
         ListenerPort = port;
         AuthEnabled = authEnabled;
@@ -392,6 +394,17 @@ public class HttpServer
                             JObject sensorResult = new();
                             HandleSensorRequest(request, sensorResult);
                             SendJsonSensor(context.Response, sensorResult);
+                            return;
+                        }
+
+                        if (requestedFile.Contains("ResetAllMinMax"))
+                        {
+                            _rootElement.Accept(new SensorVisitor(delegate (ISensor sensor)
+                            {
+                                sensor.ResetMin();
+                                sensor.ResetMax();
+                            }));
+                            SendJson(context.Response, request);
                             return;
                         }
 

--- a/LibreHardwareMonitor/Utilities/HttpServer.cs
+++ b/LibreHardwareMonitor/Utilities/HttpServer.cs
@@ -241,6 +241,14 @@ public class HttpServer
                     throw new ArgumentException("Unknown id " + dict["id"] + " specified");
                 }
 
+                if (dict["action"] == "ResetMinMax")
+                {
+                    // Reset Min/Max, then return Sensor values...
+                    sNode.Sensor.ResetMin();
+                    sNode.Sensor.ResetMax();
+                    dict["action"] = "Get";
+                }
+
                 switch (dict["action"])
                 {
                     case "Set" when dict.ContainsKey("value"):


### PR DESCRIPTION
Added handlers for resetting Min/Max values:

1. For all sensors:
GET http://localhost:8085/ResetAllMinMax
-> Returns same as `data.json` (the Min/Max attributes have been updated to `"-"`)

2. For specific sensor:
GET http://localhost:8085/Sensors?action=ResetMinMax&id=/gpu-nvidia/0/temperature/0
-> Returns same as `Sensors?action=Get` (the Min/Max attributes have been updated to `null`)
