### PR TITLE
Sensors on Framework Laptops

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -52,6 +52,8 @@ internal class Identification
                 return Manufacturer.FIC;
             case var _ when name.Equals("Foxconn", StringComparison.OrdinalIgnoreCase):
                 return Manufacturer.Foxconn;
+            case var _ when name.StartsWith("Framework", StringComparison.OrdinalIgnoreCase):
+                return Manufacturer.Framework;
             case var _ when name.StartsWith("Fujitsu", StringComparison.OrdinalIgnoreCase):
                 return Manufacturer.Fujitsu;
             case var _ when name.StartsWith("Gigabyte", StringComparison.OrdinalIgnoreCase):
@@ -621,6 +623,8 @@ internal class Identification
                 return Model.ROG_CROSSHAIR_X870E_HERO;
             case var _ when name.Equals("X11SWN-E", StringComparison.OrdinalIgnoreCase):
                 return Model.X11SWN_E;
+            case var _ when name.Equals("FRANMDCP07", StringComparison.OrdinalIgnoreCase):
+                return Model.FRANMDCP07;
             case var _ when name.Equals("Base Board Product Name", StringComparison.OrdinalIgnoreCase):
             case var _ when name.Equals("To be filled by O.E.M.", StringComparison.OrdinalIgnoreCase):
                 return Model.Unknown;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
@@ -274,6 +274,9 @@ public abstract class EmbeddedController : Hardware
             ECSensor.CurrCPU,
             ECSensor.FanCPUOpt,
             ECSensor.FanWaterFlow),
+        new(Model.FRANMDCP07,
+            BoardFamily.CrOS,
+            ECSensor.TempTSensor)
     };
 
     private static readonly Dictionary<BoardFamily, Dictionary<ECSensor, EmbeddedControllerSource>> _knownSensors = new()
@@ -378,6 +381,39 @@ public abstract class EmbeddedController : Hardware
                 { ECSensor.TempWaterOut, new EmbeddedControllerSource("Water Out", SensorType.Temperature, 0x0101, blank: -40) },
                 { ECSensor.FanWaterFlow, new EmbeddedControllerSource("Water Flow", SensorType.Flow, 0x00be, 2, factor: 1.0f / 42f * 60f) } // todo: need validation for this calculation
             }
+        },
+        {
+            BoardFamily.CrOS, new Dictionary<ECSensor, EmbeddedControllerSource>
+            {
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 1", SensorType.Temperature, 0x0020, offset: 200f - 274.15f, blank: 0xff) },
+                /* { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 2", SensorType.Temperature, 0x0021, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 3", SensorType.Temperature, 0x0022, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 4", SensorType.Temperature, 0x0023, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 5", SensorType.Temperature, 0x0024, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 6", SensorType.Temperature, 0x0025, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 7", SensorType.Temperature, 0x0026, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 8", SensorType.Temperature, 0x0027, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 9", SensorType.Temperature, 0x0028, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 10", SensorType.Temperature, 0x0029, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 11", SensorType.Temperature, 0x002a, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 12", SensorType.Temperature, 0x002b, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 13", SensorType.Temperature, 0x002c, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 14", SensorType.Temperature, 0x002d, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 15", SensorType.Temperature, 0x002e, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 16", SensorType.Temperature, 0x002f, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.FanSystem, new EmbeddedControllerSource("System Fan 1", SensorType.Fan, 0x0030, 2, blank: 0xffff) },
+                { ECSensor.FanSystem, new EmbeddedControllerSource("System Fan 2", SensorType.Fan, 0x0032, 2, blank: 0xffff) },
+                { ECSensor.FanSystem, new EmbeddedControllerSource("System Fan 3", SensorType.Fan, 0x0034, 2, blank: 0xffff) },
+                { ECSensor.FanSystem, new EmbeddedControllerSource("System Fan 4", SensorType.Fan, 0x0036, 2, blank: 0xffff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 17", SensorType.Temperature, 0x0038, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 18", SensorType.Temperature, 0x0039, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 19", SensorType.Temperature, 0x003a, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 20", SensorType.Temperature, 0x003b, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 21", SensorType.Temperature, 0x003c, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 22", SensorType.Temperature, 0x003d, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 23", SensorType.Temperature, 0x003e, offset: 200f - 274.15f, blank: 0xff) },
+                { ECSensor.TempTSensor, new EmbeddedControllerSource("Temp 24", SensorType.Temperature, 0x003f, offset: 200f - 274.15f, blank: 0xff) } */
+            }
         }
     };
 
@@ -461,7 +497,7 @@ public abstract class EmbeddedController : Hardware
 
             readRegister += _sources[si].Size;
 
-            _sensors[si].Value = val != _sources[si].Blank ? val * _sources[si].Factor : null;
+            _sensors[si].Value = val != _sources[si].Blank ? (val * _sources[si].Factor) + _sources[si].Offset : null;
         }
     }
 
@@ -551,6 +587,9 @@ public abstract class EmbeddedController : Hardware
         /// <summary>CPU_Opt fan [RPM]</summary>
         FanCPUOpt,
 
+        /// <summary>System fan [RPM]</summary>
+        FanSystem,
+
         /// <summary>VRM heat sink fan [RPM]</summary>
         FanVrmHS,
 
@@ -586,7 +625,8 @@ public abstract class EmbeddedController : Hardware
         Intel300,
         Intel400,
         Intel600,
-        Intel700
+        Intel700,
+        CrOS
     }
 
     private struct BoardInfo

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedControllerSource.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedControllerSource.cs
@@ -7,7 +7,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard.Lpc.EC;
 
 public class EmbeddedControllerSource
 {
-    public EmbeddedControllerSource(string name, SensorType type, ushort register, byte size = 1, float factor = 1.0f, int blank = int.MaxValue)
+    public EmbeddedControllerSource(string name, SensorType type, ushort register, byte size = 1, float factor = 1.0f, float offset = 0.0f, int blank = int.MaxValue)
     {
         Name = name;
 
@@ -15,6 +15,7 @@ public class EmbeddedControllerSource
         Size = size;
         Type = type;
         Factor = factor;
+        Offset = offset;
         Blank = blank;
     }
 
@@ -22,6 +23,7 @@ public class EmbeddedControllerSource
     public ushort Register { get; }
     public byte Size { get; }
     public float Factor { get; }
+    public float Offset { get; }
 
     public int Blank { get; }
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Manufacturer.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Manufacturer.cs
@@ -30,6 +30,7 @@ public enum Manufacturer
     EVGA,
     FIC,
     Foxconn,
+    Framework,
     Fujitsu,
     Gateway,
     Gigabyte,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -265,6 +265,9 @@ public enum Model
     //Supermicro
     X11SWN_E,
 
+    // Framework
+    FRANMDCP07,
+
     // Unknown
     Unknown
 }


### PR DESCRIPTION
Hi, I'm attempting to implement ACPI support for the ChromeOS ECs commonly found in Framework Laptops (and Chromebooks). However `TryUpdateData` is taking ages and rarely actually reads the register correctly (usually returning `0`), but `GetReport` works fine? Reading more than one sensor also crashes LibreHardwareMonitor too.

I was wondering if anyone had any feedback/advice?

I have also considered reading straight off the EC memmap at port `0x900` (or `0xE00` on AMD), but I'm not sure how to integrate it with LibreHardwareMonitor.

EC registers in report:

```
EC WindowsEmbeddedController
Embedded Controller Registers

      00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F

 00   00 00 00 00 FF FF FF FF FF 02 AE E6 47 02 07 00
 10   00 00 FF FF FF FF FF FF FF FF FF FF FF FF FF FF
 20   72 71 71 73 FF FF FF FF FF FF FF FF FF FF FF FF
 30   C4 08 FF FF FF FF FF FF FF FF FF FF FF FF FF FF
 40   45 43 01 02 02 01 01 01 03 00 00 00 00 00 00 00
 50   05 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 60   00 43 00 00 DE 09 00 00 AF 09 09 00 0B 01 00 00
 70   4B 0F 00 00 78 3C 3C 00 38 0E 0E 00 8B 00 00 00
 80   4E 56 54 00 00 00 00 00 46 52 41 4E 47 57 41 00
 90   30 34 46 33 00 00 00 00 4C 49 4F 4E 00 00 00 00
 A0   07 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 B0   00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 C0   00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 D0   00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 E0   00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 F0   00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
```

Thanks,
Steve