### PR TITLE
Add support for Gigabyte B360M H

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -395,6 +395,8 @@ internal class Identification
                 return Model.TUF_X470_PLUS_GAMING;
             case var _ when name.Equals("B360M PRO-VDH (MS-7B24)", StringComparison.OrdinalIgnoreCase):
                 return Model.B360M_PRO_VDH;
+            case var _ when name.Equals("B360M H", StringComparison.OrdinalIgnoreCase):
+                return Model.B360M_H;
             case var _ when name.Equals("B550-A PRO (MS-7C56)", StringComparison.OrdinalIgnoreCase):
             case var _ when name.Equals("PRO B550-VC (MS-7C56)", StringComparison.OrdinalIgnoreCase):
                 return Model.B550A_PRO;

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -168,6 +168,7 @@ public enum Model
     AB350_Gaming_3,
     AX370_Gaming_5,
     AX370_Gaming_K7,
+    B360M_H,
     B360_AORUS_GAMING_3_WIFI_CF,
     B550_AORUS_MASTER,
     B550_AORUS_PRO,

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1819,14 +1819,14 @@ internal sealed class SuperIOHardware : Hardware
                         v.Add(new Voltage("+3.3V", 1, 29.4f, 45.3f));
                         v.Add(new Voltage("+12V", 2, 10f, 2f));
                         v.Add(new Voltage("+5V", 3, 15f, 10f));
-                        v.Add(new Voltage("VCCSA", 4));
+                        v.Add(new Voltage("VCCSA", 5));
                         v.Add(new Voltage("DIMM A/B", 6));
-                        v.Add(new Voltage("+3V Standby", 7));
-                        v.Add(new Voltage("CMOS Battery", 8));
+                        v.Add(new Voltage("+3V Standby", 7, 1, 1));
+                        v.Add(new Voltage("CMOS Battery", 8, 1, 1));
                         t.Add(new Temperature("System", 0));
                         t.Add(new Temperature("PCH", 1));
                         t.Add(new Temperature("CPU", 2));
-                        t.Add(new Temperature("VRM MOS", 3));
+                        t.Add(new Temperature("VRM MOS", 4));
                         f.Add(new Fan("CPU Fan", 0));
                         f.Add(new Fan("System Fan", 1));
                         c.Add(new Control("CPU Fan", 0));

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -1814,6 +1814,26 @@ internal sealed class SuperIOHardware : Hardware
 
                         break;
 
+                    case Model.B360M_H: // IT8686E
+                        v.Add(new Voltage("Vcore", 0));
+                        v.Add(new Voltage("+3.3V", 1, 29.4f, 45.3f));
+                        v.Add(new Voltage("+12V", 2, 10f, 2f));
+                        v.Add(new Voltage("+5V", 3, 15f, 10f));
+                        v.Add(new Voltage("VCCSA", 4));
+                        v.Add(new Voltage("DIMM A/B", 6));
+                        v.Add(new Voltage("+3V Standby", 7));
+                        v.Add(new Voltage("CMOS Battery", 8));
+                        t.Add(new Temperature("System", 0));
+                        t.Add(new Temperature("PCH", 1));
+                        t.Add(new Temperature("CPU", 2));
+                        t.Add(new Temperature("VRM MOS", 3));
+                        f.Add(new Fan("CPU Fan", 0));
+                        f.Add(new Fan("System Fan", 1));
+                        c.Add(new Control("CPU Fan", 0));
+                        c.Add(new Control("System Fan", 1));
+
+                        break;
+
                     case Model.B360_AORUS_GAMING_3_WIFI_CF: // IT8688E
                         v.Add(new Voltage("Vcore", 0));
                         v.Add(new Voltage("+3.3V", 1, 29.4f, 45.3f));


### PR DESCRIPTION
Values are the same of similar gigabyte boards, just needed to identify all the temperature and fan sensors.