### PR TITLE
Add Support for MSI B840 PRO WIFI

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -635,6 +635,8 @@ internal class Identification
                 return Model.Z890_EDGE_TI_WIFI;
             case var _ when name.Equals("X11SWN-E", StringComparison.OrdinalIgnoreCase):
                 return Model.X11SWN_E;
+            case var _ when name.Equals("PRO B840-P WIFI (MS-7E57)", StringComparison.OrdinalIgnoreCase):
+                return Model.B840P_PRO_WIFI;
             case var _ when name.Equals("PRO B850-P WIFI (MS-7E56)", StringComparison.OrdinalIgnoreCase):
                 return Model.B850P_PRO_WIFI;
             case var _ when name.Equals("B850 GAMING PLUS WIFI (MS-7E56)", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
@@ -392,6 +392,7 @@ internal class LpcIO
                     case 0x92:                                
                         switch (motherboard.Model)
                         {
+                            case Model.B840P_PRO_WIFI:
                             case Model.B850_GAMING_PLUS_WIFI:
                             case Model.B850P_PRO_WIFI:
                             case Model.B850_TOMAHAWK_MAX_WIFI:

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/Nct677X.cs
@@ -1013,7 +1013,7 @@ internal class Nct677X : ISuperIO
             else
             {
                 // Write 7-point fan curve
-                for (int count = 0; count < 14; count = count + 2)
+                for (int count = 0; count < 14; count += 2)
                 {
                     targetFanCurveAddr = initFanCurveReg+count;
                     targetFanCurveReg = Convert.ToUInt16(targetFanCurveAddr);

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -139,6 +139,7 @@ public enum Model
     Z68_MS7672,
     X570_Gaming_Plus,
     B850_GAMING_PLUS_WIFI,
+    B840P_PRO_WIFI,
     B850_TOMAHAWK_MAX_WIFI,
     B650M_PROJECT_ZERO,
     B850P_PRO_WIFI,


### PR DESCRIPTION
Adds support for the MSI B840 PRO WIFI motherboard as it has the MSI flavored Nuvoton NCT6687D-R SIO Controller. Also touched up some code on my part, purely syntactical. 