### PR TITLE
Fix for Samsung NVME detection

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Storage/NVMeSamsung.cs
+++ b/LibreHardwareMonitorLib/Hardware/Storage/NVMeSamsung.cs
@@ -36,10 +36,12 @@ internal class NVMeSamsung : INVMeDrive
         buffers.Spt.TargetId = 0;
         buffers.Spt.Lun = 0;
         buffers.Spt.SenseInfoLength = 24;
+        buffers.Spt.DataIn = 1;
         buffers.Spt.DataTransferLength = (uint)buffers.DataBuf.Length;
         buffers.Spt.TimeOutValue = 2;
         buffers.Spt.DataBufferOffset = Marshal.OffsetOf(typeof(Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS), nameof(Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS.DataBuf));
         buffers.Spt.SenseInfoOffset = (uint)Marshal.OffsetOf(typeof(Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS), nameof(Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS.SenseBuf));
+
         buffers.Spt.CdbLength = 16;
         buffers.Spt.Cdb[0] = 0xB5; // SECURITY PROTOCOL IN
         buffers.Spt.Cdb[1] = 0xFE; // Samsung Protocol
@@ -49,7 +51,7 @@ internal class NVMeSamsung : INVMeDrive
         buffers.Spt.DataIn = (byte)Kernel32.SCSI_IOCTL_DATA.SCSI_IOCTL_DATA_OUT;
         buffers.DataBuf[0] = 1;
 
-        int length = Marshal.SizeOf<Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS>();
+        int length = (int)(Marshal.OffsetOf(typeof(Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS), nameof(Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS.DataBuf)).ToInt32() + buffers.Spt.DataTransferLength);
         IntPtr buffer = Marshal.AllocHGlobal(length);
         Marshal.StructureToPtr(buffers, buffer, false);
         bool validTransfer = Kernel32.DeviceIoControl(hDevice, Kernel32.IOCTL.IOCTL_SCSI_PASS_THROUGH, buffer, length, buffer, length, out _, IntPtr.Zero);
@@ -65,34 +67,35 @@ internal class NVMeSamsung : INVMeDrive
             buffers.Spt.Lun = 0;
             buffers.Spt.SenseInfoLength = 24;
             buffers.Spt.DataTransferLength = (uint)buffers.DataBuf.Length;
+            buffers.Spt.DataIn = 1;
             buffers.Spt.TimeOutValue = 2;
             buffers.Spt.DataBufferOffset = Marshal.OffsetOf<Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS>(nameof(Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS.DataBuf));
             buffers.Spt.SenseInfoOffset = (uint)Marshal.OffsetOf<Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS>(nameof(Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS.SenseBuf));
+
             buffers.Spt.CdbLength = 16;
             buffers.Spt.Cdb[0] = 0xA2; // SECURITY PROTOCOL IN
             buffers.Spt.Cdb[1] = 0xFE; // Samsung Protocol
             buffers.Spt.Cdb[3] = 5; // Identify
-            buffers.Spt.Cdb[8] = 2; // Transfer Length (high)
+            buffers.Spt.Cdb[8] = 1; // Transfer Length (high)
             buffers.Spt.Cdb[9] = 0; // Transfer Length (low)
             buffers.Spt.DataIn = (byte)Kernel32.SCSI_IOCTL_DATA.SCSI_IOCTL_DATA_IN;
 
-            length = Marshal.SizeOf<Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS>();
             buffer = Marshal.AllocHGlobal(length);
             Marshal.StructureToPtr(buffers, buffer, false);
 
             validTransfer = Kernel32.DeviceIoControl(hDevice, Kernel32.IOCTL.IOCTL_SCSI_PASS_THROUGH, buffer, length, buffer, length, out _, IntPtr.Zero);
+
+            buffers = Marshal.PtrToStructure<Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS>(buffer);
+
             if (validTransfer && buffers.DataBuf.Any(x => x != 0))
             {
                 IntPtr offset = Marshal.OffsetOf<Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS>(nameof(Kernel32.SCSI_PASS_THROUGH_WITH_BUFFERS.DataBuf));
                 IntPtr newPtr = IntPtr.Add(buffer, offset.ToInt32());
                 data = Marshal.PtrToStructure<Kernel32.NVME_IDENTIFY_CONTROLLER_DATA>(newPtr);
-                Marshal.FreeHGlobal(buffer);
                 result = true;
             }
-            else
-            {
-                Marshal.FreeHGlobal(buffer);
-            }
+
+            Marshal.FreeHGlobal(buffer);
         }
 
         return result;

--- a/LibreHardwareMonitorLib/Interop/Kernel32.cs
+++ b/LibreHardwareMonitorLib/Interop/Kernel32.cs
@@ -1009,9 +1009,7 @@ public class Kernel32
     {
         public SCSI_PASS_THROUGH Spt;
 
-        public uint Filler;
-
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 24)]
         public byte[] SenseBuf;
 
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4096)]


### PR DESCRIPTION
Samsung NVME now being detected properly.
Second call to `Kernel32.DeviceIoControl` failed.

Size of structures was incorrect and some parameters were different to original code from CrystalDiskInfo (CDI).
Also structure was not copied back and `buffers.DataBuf` always had only zeroes (0).

See:
https://github.com/hiyohiyo/CrystalDiskInfo/blob/a26a482810fdf466ad382ef29f7eaf3b77fe8860/AtaSmart.cpp#L8007

This now does same as CDI, has same structure sizes and returns expected data.