### PR TITLE
Add option to disable Ring0 driver installation

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Computer.cs
+++ b/LibreHardwareMonitorLib/Hardware/Computer.cs
@@ -46,6 +46,7 @@ public class Computer : IComputer
     private bool _psuEnabled;
     private SMBios _smbios;
     private bool _storageEnabled;
+    private bool _ring0Enabled = true;
 
     /// <summary>
     /// Creates a new <see cref="IComputer" /> instance with basic initial <see cref="Settings" />.
@@ -279,6 +280,16 @@ public class Computer : IComputer
         }
     }
 
+    /// <inheritdoc />
+    public bool IsRing0Enabled
+    {
+        get { return _ring0Enabled; }
+        set
+        {
+            _ring0Enabled = value;
+        }
+    }
+
     /// <summary>
     /// Contains computer information table read in accordance with <see href="https://www.dmtf.org/standards/smbios">System Management BIOS (SMBIOS) Reference Specification</see>.
     /// </summary>
@@ -489,7 +500,10 @@ public class Computer : IComputer
 
         _smbios = new SMBios();
 
-        Ring0.Open();
+        if (IsRing0Enabled)
+        {
+            Ring0.Open();
+        }
         Mutexes.Open();
         OpCode.Open();
 

--- a/LibreHardwareMonitorLib/Hardware/Computer.cs
+++ b/LibreHardwareMonitorLib/Hardware/Computer.cs
@@ -501,9 +501,8 @@ public class Computer : IComputer
         _smbios = new SMBios();
 
         if (IsRing0Enabled)
-        {
             Ring0.Open();
-        }
+
         Mutexes.Open();
         OpCode.Open();
 

--- a/LibreHardwareMonitorLib/Hardware/IComputer.cs
+++ b/LibreHardwareMonitorLib/Hardware/IComputer.cs
@@ -109,6 +109,13 @@ public interface IComputer : IElement
     bool IsStorageEnabled { get; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the Ring0 driver should be installed if user privileges is sufficient.
+    /// </summary>
+    /// <returns><see langword="true" /> if Ring0 driver installation is enabled</returns>
+    /// <remarks>Default value is <see langword="true" />. Only affects Windows.</remarks>
+    bool IsRing0Enabled { get; }
+
+    /// <summary>
     /// Generates full LibreHardwareMonitor report for devices that have been enabled.
     /// </summary>
     /// <returns>A formatted text string with library, OS and hardware information.</returns>


### PR DESCRIPTION
Discussed in issue #1765 here is my proposal for users of the library to opt out of Ring0 driver installation on Windows.

As stated in the issue, an alternative way to solve this is to add a default parameter to Computer.Open, but this was chosen due to following the existing pattern.

This change does not break API since the default behavior is the same.