### PR TITLE
Adds .vscode folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 [Oo]bj/
 .idea/
 .vs/
+.vscode/
 packages/


### PR DESCRIPTION
I am using Visual Studio Code, so I added the .vscode folder to the .gitignore file.
Diff shows changes on all lines, because, for some reason the .gitignore file was committed previously with CRLF line ending.