### PR TITLE
Restore fan control for IT8696E + make the 0 values array specific to the X870 Aorus elite WIFI7

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -75,7 +75,7 @@ internal class IT87XX : ISuperIO
         {
             Chip.IT8665E or Chip.IT8625E => new byte[] { 0x15, 0x16, 0x17, 0x1e, 0x1f, 0x92 },
             Chip.IT8792E => new byte[] { 0x15, 0x16, 0x17 },
-            Chip.IT8696E when motherboard.Model == Model.X870_AORUS_ELITE_WIFI7 => new byte[] { 0,0,0,0,0 }, // No fan control registers on this board
+            Chip.IT8696E when motherboard.Model == Model.X870_AORUS_ELITE_WIFI7 => new byte[] { 0, 0, 0, 0, 0 },
             _ => new byte[] { 0x15, 0x16, 0x17, 0x7f, 0xa7, 0xaf }
         };
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -75,7 +75,7 @@ internal class IT87XX : ISuperIO
         {
             Chip.IT8665E or Chip.IT8625E => new byte[] { 0x15, 0x16, 0x17, 0x1e, 0x1f, 0x92 },
             Chip.IT8792E => new byte[] { 0x15, 0x16, 0x17 },
-            Chip.IT8696E => new byte[] { 0, 0, 0, 0, 0 },
+            Chip.IT8696E when motherboard.Model == Model.X870_AORUS_ELITE_WIFI7 => new byte[] { 0,0,0,0,0 }, // No fan control registers on this board
             _ => new byte[] { 0x15, 0x16, 0x17, 0x7f, 0xa7, 0xaf }
         };
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -75,7 +75,7 @@ internal class IT87XX : ISuperIO
         {
             Chip.IT8665E or Chip.IT8625E => new byte[] { 0x15, 0x16, 0x17, 0x1e, 0x1f, 0x92 },
             Chip.IT8792E => new byte[] { 0x15, 0x16, 0x17 },
-            Chip.IT8696E when motherboard.Model == Model.X870_AORUS_ELITE_WIFI7 => new byte[] { 0, 0, 0, 0, 0 },
+            Chip.IT8696E when motherboard.Model == Model.X870_AORUS_ELITE_WIFI7 => new byte[] { 0, 0, 0, 0, 0, 0 },
             _ => new byte[] { 0x15, 0x16, 0x17, 0x7f, 0xa7, 0xaf }
         };
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -162,8 +162,8 @@ internal class IT87XX : ISuperIO
             case Chip.IT8696E:
                 Voltages = new float?[10];
                 Temperatures = new float?[6];
-                Fans = new float?[5];
-                Controls = new float?[5];
+                Fans = new float?[6];
+                Controls = new float?[6];
                 break;
 
             case Chip.IT87952E:


### PR DESCRIPTION
As per https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/pull/1510, this 0 valued array is supposed to be "specific" to the X870 Aorus elite WIFI7.  However it was added in for all IT8696E, which broke compatibility since that switch case went to the default case before, which has valid registers.  Some users reported in that PR that it broke support on other boards, but somehow it still got through.   

This 0 value array has to go and the logic specific for external register probably made more specific in the update method to address the underlying problem, but I don't have this board to test any of that. So,  as part of this PR I want to isolate this "hack" to the specific board the original user tested with, and restore the default registers for everybody else.