### PR TITLE
Fix missing DIMM temperature sensors

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Memory/MemoryGroup.cs
+++ b/LibreHardwareMonitorLib/Hardware/Memory/MemoryGroup.cs
@@ -90,7 +90,7 @@ internal class MemoryGroup : IGroup, IHardwareChanged
             foreach (Hardware ram in _hardware)
                 ram.Close();
 
-            _hardware.Clear();
+            _hardware = [];
             _disposed = true;
         }
     }


### PR DESCRIPTION
Fix dimm temperature sensors missing since merging #1797

The issue was mainly this check:
https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/06b714ae1b1a09fdbe866a5bd718bbdbb8fa5f55/LibreHardwareMonitorLib/Hardware/Memory/MemoryGroup.cs#L106-L109

Since `_opened` is false by default this will return true from `TryAddDimms` and not even attempt to add them. 
And also if `TryAddDimms` returns true the retry task will not be started.

Fixed by changing `_opened` to `_disposed` flag, also simplified `AddDimms` and `HardwareAdded` notification.

---

Might be out of scope of this PR but 
https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/06b714ae1b1a09fdbe866a5bd718bbdbb8fa5f55/LibreHardwareMonitorLib/Hardware/Memory/MemoryGroup.cs#L60
and
https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/blob/06b714ae1b1a09fdbe866a5bd718bbdbb8fa5f55/LibreHardwareMonitorLib/Hardware/Memory/MemoryGroup.cs#L71-L79
can cause "Collection was modified" exception since you can iterate on them outside of the lock.
I can fix this in this PR but `IReadOnlyList<IHardware> Hardware` would probably have to return a copy, or use some concurrent collection.