### PR TITLE
Persist “File rotation method” across Windows reboot + SDK9 build fix

### DIFF
--- a/Aga.Controls/Aga.Controls.csproj
+++ b/Aga.Controls/Aga.Controls.csproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+  </PropertyGroup>
+  <PropertyGroup>
     <ProductVersion>9.0.30729</ProductVersion>
     <TargetFramework>net472</TargetFramework>
     <AssemblyTitle>Aga.Controls</AssemblyTitle>
@@ -117,5 +120,8 @@
   <ItemGroup>
     <Compile Remove="Tree\ColumnCollection.cs" />
     <Compile Remove="Tree\NativeMethods.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/LibreHardwareMonitor/LibreHardwareMonitor.csproj
+++ b/LibreHardwareMonitor/LibreHardwareMonitor.csproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
+  </PropertyGroup>
+  <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net472</TargetFramework>
     <AssemblyName>LibreHardwareMonitor</AssemblyName>
@@ -22,6 +25,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
     <PackageReference Include="TaskScheduler" Version="2.12.2" />
     <PackageReference Include="OxyPlot.Core" Version="2.2.0" />
     <PackageReference Include="OxyPlot.WindowsForms" Version="2.2.0" />

--- a/LibreHardwareMonitor/UI/MainForm.cs
+++ b/LibreHardwareMonitor/UI/MainForm.cs
@@ -159,11 +159,10 @@ public sealed partial class MainForm : Form
         nodeTextBoxText.ToolTipProvider = tooltipProvider;
         nodeTextBoxValue.ToolTipProvider = tooltipProvider;
         _logger = new Logger(_computer);
-        var saved = _settings.GetValue("logger.fileRotation", 0); // 0=PerSession, 1=Daily
+        var saved = _settings.GetValue("logger.fileRotation", 0); // 0 = PerSession, 1 = Daily.
         _logger.FileRotationMethod = (LoggerFileRotation)Math.Max(0, Math.Min(saved, 1));
         perSessionFileRotationMenuItem.Checked = _logger.FileRotationMethod == LoggerFileRotation.PerSession;
-        dailyFileRotationMenuItem.Checked      = _logger.FileRotationMethod == LoggerFileRotation.Daily;
-
+        dailyFileRotationMenuItem.Checked = _logger.FileRotationMethod == LoggerFileRotation.Daily;
 
         _computer.HardwareAdded += HardwareAdded;
         _computer.HardwareRemoved += HardwareRemoved;

--- a/LibreHardwareMonitor/UI/MainForm.cs
+++ b/LibreHardwareMonitor/UI/MainForm.cs
@@ -159,6 +159,11 @@ public sealed partial class MainForm : Form
         nodeTextBoxText.ToolTipProvider = tooltipProvider;
         nodeTextBoxValue.ToolTipProvider = tooltipProvider;
         _logger = new Logger(_computer);
+        var saved = _settings.GetValue("logger.fileRotation", 0); // 0=PerSession, 1=Daily
+        _logger.FileRotationMethod = (LoggerFileRotation)Math.Max(0, Math.Min(saved, 1));
+        perSessionFileRotationMenuItem.Checked = _logger.FileRotationMethod == LoggerFileRotation.PerSession;
+        dailyFileRotationMenuItem.Checked      = _logger.FileRotationMethod == LoggerFileRotation.Daily;
+
 
         _computer.HardwareAdded += HardwareAdded;
         _computer.HardwareRemoved += HardwareRemoved;
@@ -1341,6 +1346,7 @@ public sealed partial class MainForm : Form
         dailyFileRotationMenuItem.Checked = false;
         perSessionFileRotationMenuItem.Checked = true;
         _logger.FileRotationMethod = LoggerFileRotation.PerSession;
+        _settings.SetValue("logger.fileRotation", (int)LoggerFileRotation.PerSession);
     }
 
     private void dailyFileRotationMenuItem_Click(object sender, EventArgs e)
@@ -1348,5 +1354,6 @@ public sealed partial class MainForm : Form
         dailyFileRotationMenuItem.Checked = true;
         perSessionFileRotationMenuItem.Checked = false;
         _logger.FileRotationMethod = LoggerFileRotation.Daily;
+        _settings.SetValue("logger.fileRotation", (int)LoggerFileRotation.Daily);
     }
 }


### PR DESCRIPTION
**Bug:** "File rotation method" resets to *Per Session* after a Windows reboot.

**Changes:**
- Save `logger.fileRotation` to PersistentSettings when toggled.
- Restore saved rotation method at startup and update menu check marks.
- Added `System.Resources.Extensions` and `<GenerateResourceUsePreserializedResources>` 
  to Aga.Controls.csproj and LibreHardwareMonitor.csproj to fix MSB3823/MSB3822 errors on .NET SDK 9.

**Testing:**
1. Enable "Run On Windows Startup" from Options.
2. Set rotation to "Daily" in Options → File rotation method.
3. Reboot the system.
4. Confirm "Daily" remains selected and daily log file continues without reset.

Related: #1589, #1628, #1802