### PR TITLE
Fix possible collection was modified exception in MemoryGroup

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Memory/MemoryGroup.cs
+++ b/LibreHardwareMonitorLib/Hardware/Memory/MemoryGroup.cs
@@ -176,6 +176,8 @@ internal class MemoryGroup : IGroup, IHardwareChanged
 
     private void AddDimms(List<SPDAccessor> accessors, ISettings settings)
     {
+        List<Hardware> additions = [];
+
         foreach (SPDAccessor ram in accessors)
         {
             //Default value
@@ -186,9 +188,11 @@ internal class MemoryGroup : IGroup, IHardwareChanged
                 name = $"{ram.GetModuleManufacturerString()} - {ram.ModulePartNumber()} (#{ram.Index})";
 
             DimmMemory memory = new(ram, name, new Identifier($"memory/dimm/{ram.Index}"), settings);
-
-            _hardware.Add(memory);
-            HardwareAdded?.Invoke(memory);
+            additions.Add(memory);
         }
+
+        _hardware = [.. _hardware, .. additions];
+        foreach (Hardware hardware in additions)
+            HardwareAdded?.Invoke(hardware);
     }
 }


### PR DESCRIPTION
Alternatively the list could be recreated for each memory added:

```csharp
        foreach (SPDAccessor ram in accessors)
        {
            //Default value
            string name = $"DIMM #{ram.Index}";

            //Check if we can switch to the correct page
            if (ram.ChangePage(PageData.ModulePartNumber))
                name = $"{ram.GetModuleManufacturerString()} - {ram.ModulePartNumber()} (#{ram.Index})";

            DimmMemory memory = new(ram, name, new Identifier($"memory/dimm/{ram.Index}"), settings);
            _hardware = [.. _hardware, memory];
            HardwareAdded?.Invoke(memory);
        }
```
