### PR TITLE
Add HardwareId property to hardware devices in data.json

### DIFF
--- a/LibreHardwareMonitor/Utilities/HttpServer.cs
+++ b/LibreHardwareMonitor/Utilities/HttpServer.cs
@@ -643,6 +643,7 @@ public class HttpServer
                 jsonNode["ImageURL"] = "images/transparent.png";
                 break;
             case HardwareNode hardwareNode:
+                jsonNode["HardwareId"] = hardwareNode.Hardware.Identifier.ToString();
                 jsonNode["ImageURL"] = "images_icon/" + GetHardwareImageFile(hardwareNode);
                 break;
             case TypeNode typeNode:

--- a/LibreHardwareMonitor/Utilities/HttpServer.cs
+++ b/LibreHardwareMonitor/Utilities/HttpServer.cs
@@ -625,7 +625,7 @@ public class HttpServer
     {
         JObject jsonNode = new()
         {
-            ["id"] = nodeIndex++,
+            ["Id"] = nodeIndex++,
             ["Text"] = n.Text,
             ["Min"] = string.Empty,
             ["Value"] = string.Empty,


### PR DESCRIPTION
Implements https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/issues/1757

As for the October release of Home Assistant there will be a new integration for Libre Hardware Monitor, the `HardwareId` will make it easier to parse into unique devices there (currently has to be parsed from sensors).

If desired I can also adapt `TestScripts/basicrest.py` to print out all Hardware IDs.