### PR TITLE
Close lmsensors+lpcIO after hardware.close()

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Motherboard.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Motherboard.cs
@@ -196,13 +196,13 @@ public class Motherboard : IHardware
     /// </summary>
     public void Close()
     {
-        _lmSensors?.Close();
-        _lpcIO?.Close();
-
         foreach (IHardware iHardware in SubHardware)
         {
             if (iHardware is Hardware hardware)
                 hardware.Close();
         }
+
+        _lmSensors?.Close();
+        _lpcIO?.Close();
     }
 }


### PR DESCRIPTION
internally hardware.close() may use lpcIO like SuperIOHardware which does SetControl(index, null).