### PR TITLE
Fix closing PawnIO with null handle

### DIFF
--- a/LibreHardwareMonitorLib/PawnIo/PawnIo.cs
+++ b/LibreHardwareMonitorLib/PawnIo/PawnIo.cs
@@ -68,7 +68,11 @@ public class PawnIo
         return new PawnIo(null);
     }
 
-    public void Close() => _handle.Close();
+    public void Close()
+    {
+        if (IsLoaded)
+            _handle.Close();
+    }
 
     public long[] Execute(string name, long[] input, int outLength)
     {


### PR DESCRIPTION
This should fix #1914, but there's a reason why the handle was null, either accessing the driver or loading the binary in `PawnIo.LoadModuleFromResource` so those errors need to be made available too.