### PR TITLE
Fix DimmMemory concatenated identifier

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Memory/MemoryGroup.cs
+++ b/LibreHardwareMonitorLib/Hardware/Memory/MemoryGroup.cs
@@ -184,7 +184,7 @@ internal class MemoryGroup : IGroup, IHardwareChanged
             if (ram.ChangePage(PageData.ModulePartNumber))
                 name = $"{ram.GetModuleManufacturerString()} - {ram.ModulePartNumber()} (#{ram.Index})";
 
-            DimmMemory memory = new(ram, name, new Identifier($"memory/dimm/{ram.Index}"), settings);
+            DimmMemory memory = new(ram, name, new Identifier("memory", "dimm", $"{ram.Index}"), settings);
             additions.Add(memory);
         }
 


### PR DESCRIPTION
Instead of identifiers like `/memory%2Fdimm%2F0`, I'm assuming they are meant to be split up like `/memory/dimm/0`