### PR TITLE
Multi-platform build process

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -5,18 +5,22 @@ on:
     branches: [master]
 
 jobs:
-  set-version:
+  build:
     runs-on: windows-2022
-    outputs:
-      version: ${{ steps.props.outputs.version }}
     steps:
       - uses: actions/checkout@v4
+      - uses: nuget/setup-nuget@v2
+      - uses: microsoft/setup-msbuild@v1.1
+        with:
+          msbuild-architecture: x64
+
       - uses: dorny/paths-filter@v2
         id: changes
         with:
           filters: |
             buildprops:
               - 'Directory.Build.props'
+
       - name: Update version
         if: steps.changes.outputs.buildprops == 'false'
         run: |
@@ -25,74 +29,48 @@ jobs:
               if(!$m.Success -or $m.Groups[4].Success -or $m.Groups[5].Success) { $_; }
               else { $_ -replace $m.Value, ("<Version>{0}.{1}.{2}-pre${{ github.run_number }}</Version>" -f $m.Groups[1].Value,$m.Groups[2].Value,([convert]::ToInt32($m.Groups[3].Value)+1)); }
           } | Set-Content Directory.Build.props
-      - name: Output build props
-        id: props
-        run: |
-          "version=$(([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version)" >> $env:GITHUB_OUTPUT
 
-  build:
-    strategy:
-      matrix:
-        platform: [x64, x86]
-        framework: [net472, netstandard2.0, net8.0, net9.0]
-    runs-on: windows-2022
-    needs: set-version
-    env:
-      LHM_VER: ${{ needs.set-version.outputs.version }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: nuget/setup-nuget@v2
-      - uses: microsoft/setup-msbuild@v1.1
-        with:
-          msbuild-architecture: x64
-
-      - name: Build library ${{ matrix.framework }} ${{ matrix.platform }}
-        run: dotnet build LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release -p:Platform=${{ matrix.platform }} -f ${{ matrix.framework }} -p:Version=$env:LHM_VER
-
-      - name: Publish library ${{ matrix.framework }} ${{ matrix.platform }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: LibreHardwareMonitorLib-${{ matrix.framework }}-${{ matrix.platform }}
-          path: |
-            bin/Release/
+      - name: Restore application packages
+        run: dotnet restore LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj 
 
       - name: Build application
-        if: matrix.platform == 'x64' && matrix.framework == 'net472'
-        run: dotnet build LibreHardwareMonitor\LibreHardwareMonitor.csproj -c Release -p:Platform=${{ matrix.platform }} -p:Version=$Env:LHM_VER
+        run: dotnet build LibreHardwareMonitor\LibreHardwareMonitor.csproj -c Release -p:Platform=x64
 
       - name: Publish application
-        if: matrix.platform == 'x64' && matrix.framework == 'net472'
         uses: actions/upload-artifact@v4
         with:
           name: LibreHardwareMonitor
           path: |
             bin/Release/net472
 
-  pack:
-    runs-on: windows-2022
-    needs: [set-version, build]
-    env:
-      LHM_VER: ${{ needs.set-version.outputs.version }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: nuget/setup-nuget@v2
-      - uses: microsoft/setup-msbuild@v1.1
-        with:
-          msbuild-architecture: x64
+      - name: Restore library packages
+        run: dotnet restore LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj 
 
-      - name: restore
-        run: dotnet restore LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj
+      - name: Build x64 libraries
+        run: dotnet build LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release --no-restore -p:Platform=x64
 
-      - uses: actions/download-artifact@v5
+      - name: Publish x64 libraries
+        uses: actions/upload-artifact@v4
         with:
-          path: bin/Release
-          merge-multiple: true
+          name: LibreHardwareMonitorLib (x64)
+          path: |
+            bin/Release/x64
+
+      - name: Build x86 libraries
+        run: dotnet build LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release --no-restore -p:Platform=x86
+
+      - name: Publish x86 libraries
+        uses: actions/upload-artifact@v4
+        with:
+          name: LibreHardwareMonitorLib (x86)
+          path: |
+            bin/Release/x86
 
       - name: Build reference libraries
-        run: dotnet build LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release -p:Platform=AnyCPU -p:Version=$env:LHM_VER
+        run: dotnet build LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release --no-restore -p:BuildOnlyRefs=true
 
-      - name: Pack nuget package
-        run: dotnet pack LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release --no-build --output bin\Release -p:Version=$Env:LHM_VER
+      - name: Pack main nupkg
+        run: dotnet pack LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release -p:PackMainNuget=true --no-build --output bin\Release
 
       - name: Publish nupkg
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pull requests.yml
+++ b/.github/workflows/pull requests.yml
@@ -5,18 +5,22 @@ on:
     branches: [master]
 
 jobs:
-  set-version:
+  build:
     runs-on: windows-2022
-    outputs:
-      version: ${{ steps.props.outputs.version }}
     steps:
       - uses: actions/checkout@v4
+      - uses: nuget/setup-nuget@v2
+      - uses: microsoft/setup-msbuild@v1.1
+        with:
+          msbuild-architecture: x64
+
       - uses: dorny/paths-filter@v2
         id: changes
         with:
           filters: |
             buildprops:
               - 'Directory.Build.props'
+
       - name: Update version
         if: steps.changes.outputs.buildprops == 'false'
         run: |
@@ -25,74 +29,48 @@ jobs:
               if(!$m.Success -or $m.Groups[4].Success -or $m.Groups[5].Success) { $_; }
               else { $_ -replace $m.Value, ("<Version>{0}.{1}.{2}-ci${{ github.run_number }}</Version>" -f $m.Groups[1].Value,$m.Groups[2].Value,([convert]::ToInt32($m.Groups[3].Value)+1)); }
           } | Set-Content Directory.Build.props
-      - name: Output build props
-        id: props
-        run: |
-          "version=$(([xml](Get-Content Directory.Build.props)).Project.PropertyGroup.Version)" >> $env:GITHUB_OUTPUT
 
-  build:
-    strategy:
-      matrix:
-        platform: [x64, x86]
-        framework: [net472, netstandard2.0, net8.0, net9.0]
-    runs-on: windows-2022
-    needs: set-version
-    env:
-      LHM_VER: ${{ needs.set-version.outputs.version }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: nuget/setup-nuget@v2
-      - uses: microsoft/setup-msbuild@v1.1
-        with:
-          msbuild-architecture: x64
-
-      - name: Build library ${{ matrix.framework }} ${{ matrix.platform }}
-        run: dotnet build LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release -p:Platform=${{ matrix.platform }} -f ${{ matrix.framework }} -p:Version=$env:LHM_VER
-
-      - name: Publish library ${{ matrix.framework }} ${{ matrix.platform }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: LibreHardwareMonitorLib-${{ matrix.framework }}-${{ matrix.platform }}
-          path: |
-            bin/Release/
+      - name: Restore application packages
+        run: dotnet restore LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj 
 
       - name: Build application
-        if: matrix.platform == 'x64' && matrix.framework == 'net472'
-        run: dotnet build LibreHardwareMonitor\LibreHardwareMonitor.csproj -c Release -p:Platform=${{ matrix.platform }} -p:Version=$Env:LHM_VER
+        run: dotnet build LibreHardwareMonitor\LibreHardwareMonitor.csproj -c Release -p:Platform=x64
 
       - name: Publish application
-        if: matrix.platform == 'x64' && matrix.framework == 'net472'
         uses: actions/upload-artifact@v4
         with:
           name: LibreHardwareMonitor
           path: |
             bin/Release/net472
 
-  pack:
-    runs-on: windows-2022
-    needs: [set-version, build]
-    env:
-      LHM_VER: ${{ needs.set-version.outputs.version }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: nuget/setup-nuget@v2
-      - uses: microsoft/setup-msbuild@v1.1
-        with:
-          msbuild-architecture: x64
+      - name: Restore library packages
+        run: dotnet restore LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj 
 
-      - name: restore
-        run: dotnet restore LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj
+      - name: Build x64 libraries
+        run: dotnet build LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release --no-restore -p:Platform=x64
 
-      - uses: actions/download-artifact@v5
+      - name: Publish x64 libraries
+        uses: actions/upload-artifact@v4
         with:
-          path: bin/Release
-          merge-multiple: true
+          name: LibreHardwareMonitorLib (x64)
+          path: |
+            bin/Release/x64
+
+      - name: Build x86 libraries
+        run: dotnet build LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release --no-restore -p:Platform=x86
+
+      - name: Publish x86 libraries
+        uses: actions/upload-artifact@v4
+        with:
+          name: LibreHardwareMonitorLib (x86)
+          path: |
+            bin/Release/x86
 
       - name: Build reference libraries
-        run: dotnet build LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release -p:Platform=AnyCPU -p:Version=$env:LHM_VER
+        run: dotnet build LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release --no-restore -p:BuildOnlyRefs=true
 
-      - name: Pack nuget package
-        run: dotnet pack LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release --no-build --output bin\Release -p:Version=$Env:LHM_VER
+      - name: Pack main nupkg
+        run: dotnet pack LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release -p:PackMainNuget=true --no-build --output bin\Release
 
       - name: Publish nupkg
         uses: actions/upload-artifact@v4

--- a/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
+++ b/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>LibreHardwareMonitorLib</AssemblyName>
     <RootNamespace>LibreHardwareMonitor</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageId>$(AssemblyName)</PackageId>
     <Description>Monitor the temperature sensors, fan speeds, voltages, load and clock speeds of your computer.</Description>
@@ -18,20 +18,20 @@
     <LangVersion>latest</LangVersion>
     <PackageIcon>packageicon.png</PackageIcon>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
-    <Platforms>x64;x86;AnyCPU</Platforms>
+    <Platforms>x64;x86</Platforms>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
-    <NoWarn>$(NoWarn);CA1416;NU5131</NoWarn>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(BuildOnlyRefs)'=='true'">
+    <Platform>AnyCPU</Platform>
+    <ProduceOnlyReferenceAssembly>true</ProduceOnlyReferenceAssembly>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <OutputPath>..\bin\Debug\$(Platform)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <OutputPath>..\bin\Release\$(Platform)\</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Platform)'=='AnyCPU'">
-    <OutputPath>..\bin\refs\</OutputPath>
-    <ProduceOnlyReferenceAssembly>true</ProduceOnlyReferenceAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -65,28 +65,10 @@
     <PackageReference Include="System.Memory" Version="4.6.3" Condition="'$(TargetFramework)' == 'net472'" />
     <PackageReference Include="System.Threading.AccessControl" Version="9.0.9" />
   </ItemGroup>
-  <!-- Nuget package content -->
   <ItemGroup>
     <None Include="Resources\packageicon.png" PackagePath="">
       <Pack>True</Pack>
     </None>
-    <None Include="..\bin\$(Configuration)\x64\**\LibreHardwareMonitorLib.dll" Pack="true">
-      <PackagePath>runtimes\win-x64\lib\</PackagePath>
-    </None>
-    <None Include="..\bin\$(Configuration)\x64\**\LibreHardwareMonitorLib.xml" Pack="true">
-      <PackagePath>runtimes\win-x64\lib\</PackagePath>
-    </None>
-    <None Include="..\bin\$(Configuration)\x86\**\LibreHardwareMonitorLib.dll" Pack="true">
-      <PackagePath>runtimes\win-x86\lib\</PackagePath>
-    </None>
-    <None Include="..\bin\$(Configuration)\x86\**\LibreHardwareMonitorLib.xml" Pack="true">
-      <PackagePath>runtimes\win-x86\lib\</PackagePath>
-    </None>
-    <None Include="..\bin\refs\**\LibreHardwareMonitorLib.dll" Pack="true">
-      <PackagePath>ref\</PackagePath>
-    </None>
-    <None Include="..\bin\refs\**\LibreHardwareMonitorLib.xml" Pack="true">
-      <PackagePath>ref\</PackagePath>
-    </None>
   </ItemGroup>
+  <Import Project="main.nuget.target" Condition="'$(PackMainNuget)' == 'true'" />
 </Project>

--- a/LibreHardwareMonitorLib/main.nuget.target
+++ b/LibreHardwareMonitorLib/main.nuget.target
@@ -1,0 +1,27 @@
+<!-- For packing the multi-platform nuget after building x64, x86 and reference libs -->
+<Project>
+  <PropertyGroup>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NoWarn>$(NoWarn);NU5131</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\bin\$(Configuration)\x64\**\LibreHardwareMonitorLib.dll" Pack="true">
+      <PackagePath>runtimes\win-x64\lib\</PackagePath>
+    </None>
+    <None Include="..\bin\$(Configuration)\x64\**\LibreHardwareMonitorLib.xml" Pack="true">
+      <PackagePath>runtimes\win-x64\lib\</PackagePath>
+    </None>
+    <None Include="..\bin\$(Configuration)\x86\**\LibreHardwareMonitorLib.dll" Pack="true">
+      <PackagePath>runtimes\win-x86\lib\</PackagePath>
+    </None>
+    <None Include="..\bin\$(Configuration)\x86\**\LibreHardwareMonitorLib.xml" Pack="true">
+      <PackagePath>runtimes\win-x86\lib\</PackagePath>
+    </None>
+    <None Include="..\bin\$(Configuration)\AnyCPU\**\LibreHardwareMonitorLib.dll" Pack="true">
+      <PackagePath>ref\</PackagePath>
+    </None>
+    <None Include="..\bin\$(Configuration)\AnyCPU\**\LibreHardwareMonitorLib.xml" Pack="true">
+      <PackagePath>ref\</PackagePath>
+    </None>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This is to address issue #1920 

For the LibreHardwareMonitorLib nuget to work in both x64 and x86 projects, it needs to contain both assemblies in certain folder structure as laid out in [Microsoft documentation](https://learn.microsoft.com/en-us/nuget/create-packages/supporting-multiple-target-frameworks#architecture-specific-folders). Since there's only one .dll and .xml per platform and framework, it was easiest to exclude automatic packaging of build output and define the contents (the .csproj changes).

The build process is modified to build libraries in both platforms and application in x64, leaving out .sln-based building. Nuget is created in a explicit packing step. Matrix is used to reduce repetition.

I also suppressed warning CA1416 because this is Windows only (?) with plenty of calls to win32 api.

This all changes a bit what artifacts are generated and there is more building happening, I hope to get some feedback if there's need to go in another direction with something.

### Update

I got the build pipeline working after some studying of Github workflows, it's now split into three parts:
- Setting version number into a variable for next jobs.
- Building the libraries for each platform/framework combination.
  - Application is built with x64/net472 job.
- Building reference libraries, packing and publishing the nuget.

_It can be made into one long job if that is preferred instead._

The AnyCPU platform is back in the form of reference libraries. When a project using the nuget is compiling the reference library is used. During runtime either x64 or x86 version is used accordingly.

I've tested this with my project and few test projects with different platform / framework combinations and as far as I can tell, it now functions properly.