### PR TITLE
Fix nullref exception in ATAStorage

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Storage/WindowsSmart.cs
+++ b/LibreHardwareMonitorLib/Hardware/Storage/WindowsSmart.cs
@@ -116,7 +116,8 @@ internal class WindowsSmart : ISmart
         }
 
         Marshal.FreeHGlobal(buffer);
-        return null;
+
+        return [];
     }
 
     public unsafe SMART_THRESHOLD[] ReadSmartThresholds()


### PR DESCRIPTION
Fixes https://github.com/Rem0o/FanControl.Releases/issues/3587

The foreach in ATAStorage was called on a possible null array.   Made it so that the smart attributes return an Array.Empty<> instead. 