### PR TITLE
Fix custom battery name getting changed back to the original name

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Battery/Battery.cs
+++ b/LibreHardwareMonitorLib/Hardware/Battery/Battery.cs
@@ -36,7 +36,6 @@ internal sealed class Battery : Hardware
         ISettings settings) :
         base(name, new Identifier("battery", $"{name.Replace(' ', '-')}_{batteryTag}"), settings)
     {
-        Name = name;
         Manufacturer = manufacturer;
 
         _batteryTag = batteryTag;


### PR DESCRIPTION
Fixes #1786