### PR TITLE
Multi-platform build process with fix to uploading to Nuget feed

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -30,39 +30,47 @@ jobs:
               else { $_ -replace $m.Value, ("<Version>{0}.{1}.{2}-pre${{ github.run_number }}</Version>" -f $m.Groups[1].Value,$m.Groups[2].Value,([convert]::ToInt32($m.Groups[3].Value)+1)); }
           } | Set-Content Directory.Build.props
 
-      - name: NuGet restore
-        run: dotnet restore LibreHardwareMonitor.sln
+      - name: Restore application packages
+        run: dotnet restore LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj 
 
-      - name: Build
-        run: dotnet build LibreHardwareMonitor.sln --configuration Release --no-restore
+      - name: Build application
+        run: dotnet build LibreHardwareMonitor\LibreHardwareMonitor.csproj -c Release -p:Platform=x64
 
-      - name: Publish net472
+      - name: Publish application
         uses: actions/upload-artifact@v4
         with:
-          name: LibreHardwareMonitor-net472
+          name: LibreHardwareMonitor
           path: |
             bin/Release/net472
 
-      - name: Publish netstandard20
-        uses: actions/upload-artifact@v4
-        with:
-          name: LibreHardwareMonitorLib-netstandard20
-          path: |
-            bin/Release/netstandard2.0
+      - name: Restore library packages
+        run: dotnet restore LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj 
 
-      - name: Publish net80
-        uses: actions/upload-artifact@v4
-        with:
-          name: LibreHardwareMonitorLib-net80
-          path: |
-            bin/Release/net8.0
+      - name: Build x64 libraries
+        run: dotnet build LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release --no-restore -p:Platform=x64
 
-      - name: Publish net90
+      - name: Publish x64 libraries
         uses: actions/upload-artifact@v4
         with:
-          name: LibreHardwareMonitorLib-net90
+          name: LibreHardwareMonitorLib (x64)
           path: |
-            bin/Release/net9.0
+            bin/Release/x64
+
+      - name: Build x86 libraries
+        run: dotnet build LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release --no-restore -p:Platform=x86
+
+      - name: Publish x86 libraries
+        uses: actions/upload-artifact@v4
+        with:
+          name: LibreHardwareMonitorLib (x86)
+          path: |
+            bin/Release/x86
+
+      - name: Build reference libraries
+        run: dotnet build LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release --no-restore -p:BuildOnlyRefs=true
+
+      - name: Pack main nupkg
+        run: dotnet pack LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release -p:PackMainNuget=true --no-build --output bin\Release
 
       - name: Publish nupkg
         uses: actions/upload-artifact@v4
@@ -72,4 +80,4 @@ jobs:
             bin/Release/LibreHardwareMonitorLib.*.nupkg
 
       - name: Publish to NuGet
-        run: nuget push **\*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}
+        run: nuget push bin/Release/LibreHardwareMonitorLib.*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}

--- a/.github/workflows/pull requests.yml
+++ b/.github/workflows/pull requests.yml
@@ -30,39 +30,47 @@ jobs:
               else { $_ -replace $m.Value, ("<Version>{0}.{1}.{2}-ci${{ github.run_number }}</Version>" -f $m.Groups[1].Value,$m.Groups[2].Value,([convert]::ToInt32($m.Groups[3].Value)+1)); }
           } | Set-Content Directory.Build.props
 
-      - name: Restore packages
-        run: dotnet restore LibreHardwareMonitor.sln
+      - name: Restore application packages
+        run: dotnet restore LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj 
 
-      - name: Build
-        run: dotnet build LibreHardwareMonitor.sln --configuration Release --no-restore
+      - name: Build application
+        run: dotnet build LibreHardwareMonitor\LibreHardwareMonitor.csproj -c Release -p:Platform=x64
 
-      - name: Publish net472
+      - name: Publish application
         uses: actions/upload-artifact@v4
         with:
-          name: LibreHardwareMonitor-net472
+          name: LibreHardwareMonitor
           path: |
             bin/Release/net472
 
-      - name: Publish netstandard20
-        uses: actions/upload-artifact@v4
-        with:
-          name: LibreHardwareMonitorLib-netstandard20
-          path: |
-            bin/Release/netstandard2.0
+      - name: Restore library packages
+        run: dotnet restore LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj 
 
-      - name: Publish net80
-        uses: actions/upload-artifact@v4
-        with:
-          name: LibreHardwareMonitorLib-net80
-          path: |
-            bin/Release/net8.0
+      - name: Build x64 libraries
+        run: dotnet build LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release --no-restore -p:Platform=x64
 
-      - name: Publish net90
+      - name: Publish x64 libraries
         uses: actions/upload-artifact@v4
         with:
-          name: LibreHardwareMonitorLib-net90
+          name: LibreHardwareMonitorLib (x64)
           path: |
-            bin/Release/net9.0
+            bin/Release/x64
+
+      - name: Build x86 libraries
+        run: dotnet build LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release --no-restore -p:Platform=x86
+
+      - name: Publish x86 libraries
+        uses: actions/upload-artifact@v4
+        with:
+          name: LibreHardwareMonitorLib (x86)
+          path: |
+            bin/Release/x86
+
+      - name: Build reference libraries
+        run: dotnet build LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release --no-restore -p:BuildOnlyRefs=true
+
+      - name: Pack main nupkg
+        run: dotnet pack LibreHardwareMonitorLib\LibreHardwareMonitorLib.csproj -c Release -p:PackMainNuget=true --no-build --output bin\Release
 
       - name: Publish nupkg
         uses: actions/upload-artifact@v4

--- a/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
+++ b/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
@@ -19,12 +19,19 @@
     <PackageIcon>packageicon.png</PackageIcon>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <Platforms>x64;x86</Platforms>
+    <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(BuildOnlyRefs)'=='true'">
+    <Platform>AnyCPU</Platform>
+    <ProduceOnlyReferenceAssembly>true</ProduceOnlyReferenceAssembly>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <OutputPath>..\bin\Debug\</OutputPath>
+    <OutputPath>..\bin\Debug\$(Platform)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
-    <OutputPath>..\bin\Release\</OutputPath>
+    <OutputPath>..\bin\Release\$(Platform)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -63,4 +70,5 @@
       <Pack>True</Pack>
     </None>
   </ItemGroup>
+  <Import Project="main.nuget.target" Condition="'$(PackMainNuget)' == 'true'" />
 </Project>

--- a/LibreHardwareMonitorLib/main.nuget.target
+++ b/LibreHardwareMonitorLib/main.nuget.target
@@ -1,0 +1,27 @@
+<!-- For packing the multi-platform nuget after building x64, x86 and reference libs -->
+<Project>
+  <PropertyGroup>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NoWarn>$(NoWarn);NU5131</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\bin\$(Configuration)\x64\**\LibreHardwareMonitorLib.dll" Pack="true">
+      <PackagePath>runtimes\win-x64\lib\</PackagePath>
+    </None>
+    <None Include="..\bin\$(Configuration)\x64\**\LibreHardwareMonitorLib.xml" Pack="true">
+      <PackagePath>runtimes\win-x64\lib\</PackagePath>
+    </None>
+    <None Include="..\bin\$(Configuration)\x86\**\LibreHardwareMonitorLib.dll" Pack="true">
+      <PackagePath>runtimes\win-x86\lib\</PackagePath>
+    </None>
+    <None Include="..\bin\$(Configuration)\x86\**\LibreHardwareMonitorLib.xml" Pack="true">
+      <PackagePath>runtimes\win-x86\lib\</PackagePath>
+    </None>
+    <None Include="..\bin\$(Configuration)\AnyCPU\**\LibreHardwareMonitorLib.dll" Pack="true">
+      <PackagePath>ref\</PackagePath>
+    </None>
+    <None Include="..\bin\$(Configuration)\AnyCPU\**\LibreHardwareMonitorLib.xml" Pack="true">
+      <PackagePath>ref\</PackagePath>
+    </None>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This has the same changes as #1928 but the glob pattern of selecting the nupkg to push into Nuget feed is now specific to a folder.

`**/*.nupkg` => `bin/Release/LibreHardwareMonitorLib.*.nupkg`