### PR TITLE
Add support for MSI PRO B850-S WIFI6E

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -660,6 +660,8 @@ internal class Identification
                 return Model.B840P_PRO_WIFI;
             case var _ when name.Equals("PRO B850-P WIFI (MS-7E56)", StringComparison.OrdinalIgnoreCase):
                 return Model.B850P_PRO_WIFI;
+            case var _ when name.Equals("PRO B850-S WIFI6E (MS-7E80)", StringComparison.OrdinalIgnoreCase):
+                return Model.B850S_PRO_WIFI6E;
             case var _ when name.Equals("B850 GAMING PLUS WIFI (MS-7E56)", StringComparison.OrdinalIgnoreCase):
                 return Model.B850_GAMING_PLUS_WIFI;
             case var _ when name.Equals("MAG B850M MORTAR WIFI (MS-7E61)", StringComparison.OrdinalIgnoreCase):

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
@@ -423,6 +423,7 @@ internal class LpcIO
                             case Model.Z890P_PRO_WIFI:
                             case Model.Z890A_PRO_WIFI:
                             case Model.Z890S_PRO_WIFI:
+                            case Model.B850S_PRO_WIFI6E:
                                 chip = Chip.NCT6687DR; // MSI AM5/LGA1851 Compatibility
                                 break;
                             default:

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Model.cs
@@ -170,6 +170,7 @@ public enum Model
     Z890S_PRO_WIFI,
     Z890_GAMING_PLUS_WIFI,
     Z890S_PRO_WIFI_PROJECT_ZERO,
+    B850S_PRO_WIFI6E,
 
     // EVGA
     X58_SLI_Classified,


### PR DESCRIPTION
added identifier string to Identification.cs
added new model enum entry B850S_PRO_WIFI6E
added B850S_PRO_WIFI6E to the list of models that get the NCT6687DR instead of NCT6687D