### PR TITLE
Fix build status badge links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Libre Hardware Monitor, a fork of Open Hardware Monitor, is free software that c
 ## What's included?
 | Name| .NET | Build Status |
 | --- | --- | --- | 
-| **LibreHardwareMonitor** <br /> Windows Forms based application that presents all data in a graphical interface | .NET Framework 4.7.2 | [![Build status](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/workflows/CI/badge.svg)](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/actions) | 
-| **LibreHardwareMonitorLib** <br /> Library that allows you to use all features in your own application | .NET Framework 4.7.2, .NET 8.0, and .NET 9.0 | [![Build status](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/workflows/CI/badge.svg)](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/actions) | 
+| **LibreHardwareMonitor** <br /> Windows Forms based application that presents all data in a graphical interface | .NET Framework 4.7.2 | [![Build status](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/actions/workflows/master.yml/badge.svg)](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/actions) | 
+| **LibreHardwareMonitorLib** <br /> Library that allows you to use all features in your own application | .NET Framework 4.7.2, .NET 8.0, and .NET 9.0 | [![Build status](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/actions/workflows/master.yml/badge.svg)](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/actions) | 
 
 ## What can it do?
 You can read information from devices such as:


### PR DESCRIPTION
Updated build status badge links in README.md to point to the master workflow.

Before:
<img width="852" height="255" alt="image" src="https://github.com/user-attachments/assets/d4876540-f36d-4c3d-b90e-336402e463dd" />

After:
<img width="858" height="242" alt="image" src="https://github.com/user-attachments/assets/c0016803-3fe7-4f97-9fb5-f3f7eac9e4f5" />
