### PR TITLE
Refactor PawnIo to PawnIO to fix null return crash

### DIFF
--- a/LibreHardwareMonitor/UI/MainForm.cs
+++ b/LibreHardwareMonitor/UI/MainForm.cs
@@ -169,9 +169,9 @@ public sealed partial class MainForm : Form
         _computer.HardwareAdded += HardwareAdded;
         _computer.HardwareRemoved += HardwareRemoved;
 
-        if (PawnIo.PawnIo.IsInstalled)
+        if (PawnIo.PawnIO.IsInstalled)
         {
-            if (PawnIo.PawnIo.Version < new Version(2, 0, 0, 0))
+            if (PawnIo.PawnIO.Version < new Version(2, 0, 0, 0))
             {
                 DialogResult result = MessageBox.Show("PawnIO is outdated, do you want to update it?", nameof(LibreHardwareMonitor), MessageBoxButtons.OKCancel);
                 if (result == DialogResult.OK)

--- a/LibreHardwareMonitorLib/PawnIo/AmdFamily0F.cs
+++ b/LibreHardwareMonitorLib/PawnIo/AmdFamily0F.cs
@@ -1,10 +1,10 @@
-﻿using LibreHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Hardware;
 
 namespace LibreHardwareMonitor.PawnIo;
 
 public class AmdFamily0F
 {
-    private readonly PawnIo _pawnIO = PawnIo.LoadModuleFromResource(typeof(AmdFamily0F).Assembly, $"{nameof(LibreHardwareMonitor)}.Resources.PawnIo.AMDFamily0F.bin");
+    private readonly PawnIO _pawnIO = PawnIO.LoadModuleFromResource(typeof(AmdFamily0F).Assembly, $"{nameof(LibreHardwareMonitor)}.Resources.PawnIO.AMDFamily0F.bin");
 
     public bool ReadMsr(uint index, out uint eax, out uint edx)
     {

--- a/LibreHardwareMonitorLib/PawnIo/AmdFamily10.cs
+++ b/LibreHardwareMonitorLib/PawnIo/AmdFamily10.cs
@@ -1,10 +1,10 @@
-﻿using LibreHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Hardware;
 
 namespace LibreHardwareMonitor.PawnIo;
 
 public class AmdFamily10
 {
-    private readonly PawnIo _pawnIo = PawnIo.LoadModuleFromResource(typeof(AmdFamily0F).Assembly, $"{nameof(LibreHardwareMonitor)}.Resources.PawnIo.AMDFamily10.bin");
+    private readonly PawnIO _pawnIo = PawnIO.LoadModuleFromResource(typeof(AmdFamily0F).Assembly, $"{nameof(LibreHardwareMonitor)}.Resources.PawnIO.AMDFamily10.bin");
 
     public void MeasureTscMultiplier(out long ctrPerTick, out long cofVid)
     {

--- a/LibreHardwareMonitorLib/PawnIo/AmdFamily17.cs
+++ b/LibreHardwareMonitorLib/PawnIo/AmdFamily17.cs
@@ -1,8 +1,8 @@
-﻿namespace LibreHardwareMonitor.PawnIo;
+namespace LibreHardwareMonitor.PawnIo;
 
 public class AmdFamily17
 {
-    private readonly PawnIo _pawnIo = PawnIo.LoadModuleFromResource(typeof(AmdFamily0F).Assembly, $"{nameof(LibreHardwareMonitor)}.Resources.PawnIo.AMDFamily17.bin");
+    private readonly PawnIO _pawnIo = PawnIO.LoadModuleFromResource(typeof(AmdFamily0F).Assembly, $"{nameof(LibreHardwareMonitor)}.Resources.PawnIO.AMDFamily17.bin");
 
     public uint ReadSmn(uint offset)
     {

--- a/LibreHardwareMonitorLib/PawnIo/IntelMsr.cs
+++ b/LibreHardwareMonitorLib/PawnIo/IntelMsr.cs
@@ -1,11 +1,11 @@
-﻿using LibreHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Hardware;
 
 namespace LibreHardwareMonitor.PawnIo;
 
 public class IntelMsr
 {
     private readonly long[] _inArray = new long[1];
-    private readonly PawnIo _pawnIO = PawnIo.LoadModuleFromResource(typeof(IntelMsr).Assembly, $"{nameof(LibreHardwareMonitor)}.Resources.PawnIo.IntelMSR.bin");
+    private readonly PawnIO _pawnIO = PawnIO.LoadModuleFromResource(typeof(IntelMsr).Assembly, $"{nameof(LibreHardwareMonitor)}.Resources.PawnIO.IntelMSR.bin");
 
     public bool ReadMsr(uint index, out ulong value)
     {

--- a/LibreHardwareMonitorLib/PawnIo/LpcACPIEC.cs
+++ b/LibreHardwareMonitorLib/PawnIo/LpcACPIEC.cs
@@ -1,8 +1,8 @@
-﻿namespace LibreHardwareMonitor.PawnIo;
+namespace LibreHardwareMonitor.PawnIo;
 
 public class LpcAcpiEc
 {
-    private readonly PawnIo _pawnIO = PawnIo. LoadModuleFromResource(typeof(AmdFamily0F).Assembly, $"{nameof(LibreHardwareMonitor)}.Resources.PawnIo.LpcACPIEC.bin");
+    private readonly PawnIO _pawnIO = PawnIO. LoadModuleFromResource(typeof(AmdFamily0F).Assembly, $"{nameof(LibreHardwareMonitor)}.Resources.PawnIO.LpcACPIEC.bin");
 
     public byte ReadPort(byte port)
     {

--- a/LibreHardwareMonitorLib/PawnIo/LpcIO.cs
+++ b/LibreHardwareMonitorLib/PawnIo/LpcIO.cs
@@ -1,9 +1,9 @@
-﻿namespace LibreHardwareMonitor.PawnIo;
+namespace LibreHardwareMonitor.PawnIo;
 
 internal class LpcIo
 {
     private readonly long[] _doubleArgArray = new long[2];
-    private readonly PawnIo _pawnIO = PawnIo.LoadModuleFromResource(typeof(LpcIo).Assembly, $"{nameof(LibreHardwareMonitor)}.Resources.PawnIO.LpcIO.bin");
+    private readonly PawnIO _pawnIO = PawnIO.LoadModuleFromResource(typeof(LpcIo).Assembly, $"{nameof(LibreHardwareMonitor)}.Resources.PawnIO.LpcIO.bin");
     private readonly long[] _singleArgArray = new long[1];
 
     public void SelectSlot(int slot)

--- a/LibreHardwareMonitorLib/PawnIo/PawnIo.cs
+++ b/LibreHardwareMonitorLib/PawnIo/PawnIo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -12,7 +12,7 @@ using PInvoke = Windows.Win32.PInvoke;
 
 namespace LibreHardwareMonitor.PawnIo;
 
-public class PawnIo
+public class PawnIO
 {
     private const uint DEVICE_TYPE = 41394u << 16;
     private const int FN_NAME_LENGTH = 32;
@@ -21,7 +21,7 @@ public class PawnIo
 
     private readonly SafeFileHandle _handle;
 
-    static PawnIo()
+    static PawnIO()
     {
         using RegistryKey subKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PawnIO");
 
@@ -42,7 +42,7 @@ public class PawnIo
         }
     }
 
-    private PawnIo(SafeFileHandle handle) => _handle = handle;
+    private PawnIO(SafeFileHandle handle) => _handle = handle;
 
     /// <summary>
     /// Gets a value indicating whether PawnIO is installed on the system.
@@ -63,7 +63,7 @@ public class PawnIo
         IsClosed: false
     };
 
-    internal static unsafe PawnIo LoadModuleFromResource(Assembly assembly, string resourceName)
+    internal static unsafe PawnIO LoadModuleFromResource(Assembly assembly, string resourceName)
     {
         SafeFileHandle handle = PInvoke.CreateFile(@"\\.\PawnIO",
                                                    (uint)FileAccess.ReadWrite,
@@ -74,7 +74,7 @@ public class PawnIo
                                                    null);
 
         if (handle.IsInvalid)
-            return new PawnIo(null);
+            return new PawnIO(null);
 
         using Stream stream = assembly.GetManifestResourceStream(resourceName);
         using MemoryStream memory = new();
@@ -84,10 +84,10 @@ public class PawnIo
         fixed (byte* pIn = bin)
         {
             if (PInvoke.DeviceIoControl((HANDLE)handle.DangerousGetHandle(), (uint)ControlCode.LoadBinary, pIn, (uint)bin.Length, null, 0u, null, null))
-                return new PawnIo(handle);
+                return new PawnIO(handle);
         }
 
-        return new PawnIo(null);
+        return new PawnIO(null);
     }
 
     public void Close()

--- a/LibreHardwareMonitorLib/PawnIo/RyzenSmu.cs
+++ b/LibreHardwareMonitorLib/PawnIo/RyzenSmu.cs
@@ -1,11 +1,11 @@
-﻿using System;
+using System;
 using LibreHardwareMonitor.Hardware;
 
 namespace LibreHardwareMonitor.PawnIo;
 
 public class RyzenSmu
 {
-    private readonly PawnIo _pawnIO = PawnIo.LoadModuleFromResource(typeof(IntelMsr).Assembly, $"{nameof(LibreHardwareMonitor)}.Resources.PawnIo.RyzenSMU.bin");
+    private readonly PawnIO _pawnIO = PawnIO.LoadModuleFromResource(typeof(IntelMsr).Assembly, $"{nameof(LibreHardwareMonitor)}.Resources.PawnIO.RyzenSMU.bin");
 
     public uint GetSmuVersion()
     {

--- a/LibreHardwareMonitorLib/RAMSPDToolkitDriver.cs
+++ b/LibreHardwareMonitorLib/RAMSPDToolkitDriver.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using RAMSPDToolkit.I2CSMBus.Interop.PawnIO;
 using RAMSPDToolkit.Windows.Driver.Interfaces;
@@ -40,7 +40,7 @@ internal sealed class RAMSPDToolkitDriver : IPawnIODriver
 
         try
         {
-            var pawnIO = PawnIo.PawnIo.LoadModuleFromResource(typeof(RAMSPDToolkitDriver).Assembly, $"{nameof(LibreHardwareMonitor)}.Resources.PawnIO.{moduleResourceFilename}");
+            var pawnIO = PawnIo.PawnIO.LoadModuleFromResource(typeof(RAMSPDToolkitDriver).Assembly, $"{nameof(LibreHardwareMonitor)}.Resources.PawnIO.{moduleResourceFilename}");
 
             if (pawnIO.IsLoaded)
             {
@@ -69,9 +69,9 @@ internal sealed class RAMSPDToolkitDriver : IPawnIODriver
 
     internal class PawnIOModule : IPawnIOModule, IDisposable
     {
-        private PawnIo.PawnIo _pawnIO;
+        private PawnIo.PawnIO _pawnIO;
 
-        public PawnIOModule(PawnIo.PawnIo pawnIO)
+        public PawnIOModule(PawnIo.PawnIO pawnIO)
         {
             _pawnIO = pawnIO;
         }


### PR DESCRIPTION
assembly.GetManifestResourceStream(resourceName) was returning null in The PawnIo.cs > LoadModuleFromResource() function.
```
    internal static unsafe PawnIo LoadModuleFromResource(Assembly assembly, string resourceName)
    {
        SafeFileHandle handle = PInvoke.CreateFile(@"\\.\PawnIO",
                                                   (uint)FileAccess.ReadWrite,
                                                   FILE_SHARE_MODE.FILE_SHARE_READ | FILE_SHARE_MODE.FILE_SHARE_WRITE,
                                                   null,
                                                   FILE_CREATION_DISPOSITION.OPEN_EXISTING,
                                                   FILE_FLAGS_AND_ATTRIBUTES.FILE_ATTRIBUTE_NORMAL,
                                                   null);

        if (handle.IsInvalid)
            return new PawnIo(null);

        using Stream stream = assembly.GetManifestResourceStream(resourceName);
```
When I step through it in the Debugger the value for resourceName is LibreHardwareMonitor.Resources.PawnIo.AMDFamily17.bin. The problem with this is that the resource is actually found at LibreHardwareMonitor.Resources.PawnIO.AMDFamily17.bin. The only way I was able to get this to build and run is by refactoring the PawnIo class to PawnIO. Then it runs just fine.