### PR TITLE
[UI] Fixes for Node expansion

### DIFF
--- a/LibreHardwareMonitor/UI/MainForm.Designer.cs
+++ b/LibreHardwareMonitor/UI/MainForm.Designer.cs
@@ -1077,6 +1077,7 @@ namespace LibreHardwareMonitor.UI
             this.treeView.MouseMove += new System.Windows.Forms.MouseEventHandler(this.TreeView_MouseMove);
             this.treeView.MouseUp += new System.Windows.Forms.MouseEventHandler(this.TreeView_MouseUp);
             this.treeView.SizeChanged += new System.EventHandler(this.TreeView_SizeChanged);
+            this.treeView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.TreeView_KeyDown);
             //
             // batteryMenuItem
             //

--- a/LibreHardwareMonitor/UI/MainForm.cs
+++ b/LibreHardwareMonitor/UI/MainForm.cs
@@ -937,8 +937,6 @@ public sealed partial class MainForm : Form
 
         if (!backgroundUpdater.IsBusy)
             backgroundUpdater.RunWorkerAsync();
-
-        RestoreCollapsedNodeState(treeView);
     }
 
     private void SaveConfiguration()
@@ -1358,6 +1356,28 @@ public sealed partial class MainForm : Form
                 newWidth -= treeView.Columns[i].Width;
         }
         treeView.Columns[0].Width = newWidth;
+    }
+
+    private void TreeView_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (treeView.SelectedNode != null)
+        {
+            switch (e.KeyCode)
+            {
+                case Keys.Right:
+                    if (treeView.SelectedNode.Tag is IExpandPersistNode expandPersistNodeR)
+                    {
+                        expandPersistNodeR.Expanded = true;
+                    }
+                    return;
+                case Keys.Left:
+                    if (treeView.SelectedNode.Tag is IExpandPersistNode expandPersistNodeL)
+                    {
+                        expandPersistNodeL.Expanded = false;
+                    }
+                    return;
+            }
+        }
     }
 
     private void TreeView_ColumnWidthChanged(TreeColumn column)


### PR DESCRIPTION
Fix Nodes auto-closing right after expanding via `Right` key.
Fix Nodes not saving Expanded when opening or closing via `Left` and `Right` key.