### PR TITLE
Support X870E Apex's New CPU Sensor Index for BIOS 1804+

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -5068,12 +5068,18 @@ internal sealed class SuperIOHardware : Hardware
                             t.Add(new Temperature("CPU Package", 0));
                             t.Add(new Temperature("VRM", 1));
                             t.Add(new Temperature("Motherboard", 2));
+
+                            // BIOS 1804 or above moved CPU Temp Sensor to 21
+                            t.Add(new Temperature("CPU", 21));
+
+                            // For BIOS 1803 or older
                             t.Add(new Temperature("CPU", 22));
 
                             // Add all unmapped temperature sensors
                             for (int i = 3; i < superIO.Temperatures.Length; i++)
                             {
-                                if (i != 22)
+                                // 21 and 22 are not used at the same time
+                                if (i != 21 && i != 22)
                                 {
                                     t.Add(new Temperature($"Temperature #{i}", i));
                                 }


### PR DESCRIPTION
# Support X870E Apex's New CPU Sensor Index for BIOS 1804+
ASUS X870E Apex's CPU Sensor Index changed from 22 to 21 after the latest BIOS 1804 update.

### Before
<img width="482" height="684" alt="image" src="https://github.com/user-attachments/assets/1b61749b-c244-480b-8073-59e60bd2324f" />

### After & Validation with HWInfo64
<img width="967" height="884" alt="Screenshot 2025-11-12 222539" src="https://github.com/user-attachments/assets/c414b328-d18d-431e-a258-3acab189eeb0" />
