### PR TITLE
Update DiskInfoToolkit.

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Storage/StorageDevice.cs
+++ b/LibreHardwareMonitorLib/Hardware/Storage/StorageDevice.cs
@@ -140,7 +140,10 @@ public sealed class StorageDevice : Hardware, ISmart
 
             r.AppendLine();
 
-            r.AppendLine($"Total Free Size: {_storage.TotalFreeSize}");
+            if (_storage.TotalFreeSize != null)
+            {
+                r.AppendLine($"Total Free Size: {_storage.TotalFreeSize}");
+            }
         }
 
         r.AppendLine($"Total Size: {_storage.TotalSize}");
@@ -311,7 +314,8 @@ public sealed class StorageDevice : Hardware, ISmart
 
     private void ToggleUsageSensor()
     {
-        if (!_storage.IsDynamicDisk)
+        if (!_storage.IsDynamicDisk
+         && !_storage.Partitions.Any(p => p.IsOtherOperatingSystemPartition))
         {
             ActivateSensor(_usageSensor);
         }

--- a/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
+++ b/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
@@ -55,7 +55,7 @@
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DiskInfoToolkit" Version="1.0.3" />
+    <PackageReference Include="DiskInfoToolkit" Version="1.0.4" />
     <PackageReference Include="HidSharp" Version="2.6.4" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.242">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Update DiskInfoToolkit.
Remove usage sensor if any partition on disk is another operating system partition as this leads to incorrectly reported free space.

See: https://github.com/Blacktempel/DiskInfoToolkit/releases/tag/1.0.4