### PR TITLE
Add EmbeddedResource for LpcCrOSEC.bin

### DIFF
--- a/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
+++ b/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
@@ -39,6 +39,7 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\PawnIo\LpcIO.bin" />
     <EmbeddedResource Include="Resources\PawnIo\LpcACPIEC.bin" />
+    <EmbeddedResource Include="Resources\PawnIo\LpcCrOSEC.bin" />
     <EmbeddedResource Include="Resources\PawnIo\IntelMSR.bin" />
     <EmbeddedResource Include="Resources\PawnIo\RyzenSMU.bin" />
     <EmbeddedResource Include="Resources\PawnIo\AMDFamily0F.bin" />


### PR DESCRIPTION
Hi. I'm so sorry, I must have skipped this file in #1681.

Without it, LibreHardwareMonitor crashes on Framework Laptops.

Thanks,
Steve