### PR TITLE
Prometheus: use correct timestamp resolution

### DIFF
--- a/LibreHardwareMonitor/Utilities/HttpServer.cs
+++ b/LibreHardwareMonitor/Utilities/HttpServer.cs
@@ -683,7 +683,7 @@ public class HttpServer
                         else
                         {
                             // Outputs prometheus tag with labels, value, and timestamp
-                            responseStr += $"{tagLine} {(val.Value * factor).ToString(CultureInfo.InvariantCulture)} {((DateTimeOffset)val.Time).ToUnixTimeSeconds()}\n";
+                            responseStr += $"{tagLine} {(val.Value * factor).ToString(CultureInfo.InvariantCulture)} {((DateTimeOffset)val.Time).ToUnixTimeMilliseconds()}\n";
                         }
                     }
                 }


### PR DESCRIPTION
The spec says it must be milliseconds.