### PR TITLE
Add method to be able to access Storage object.

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Storage/StorageDevice.cs
+++ b/LibreHardwareMonitorLib/Hardware/Storage/StorageDevice.cs
@@ -57,7 +57,7 @@ public sealed class StorageDevice : Hardware, ISmart
 
     public override HardwareType HardwareType => HardwareType.Storage;
 
-    internal DiskInfoToolkit.Storage Storage => _storage;
+    public DiskInfoToolkit.Storage Storage => _storage;
 
     public IReadOnlyList<SmartAttribute> Attributes => _attributes;
 
@@ -156,8 +156,6 @@ public sealed class StorageDevice : Hardware, ISmart
         foreach (ISensor sensor in Sensors)
             sensor.Accept(visitor);
     }
-
-    public DiskInfoToolkit.Storage GetUnderlyingStorageObject() => _storage;
 
     private void CreateAttributes()
     {


### PR DESCRIPTION
Use information of `Storage` object outside of LHM.

Example of current usage:
https://github.com/Blacktempel/LibreDiagnostics/blob/bad58ee5bcf5b54c97ad9c71af349a85aae13e46/LibreDiagnostics.Models/Helper/LHMReflection.cs#L20

It should be possible somehow to map it as the `Storage` object stays the same when retrieving it again from DiskInfoToolkit, but thats more complicated than this simple change.