### PR TITLE
Gigabyte x870 Aorus Elite Wifi - Remove the 0-initialized control registers array

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/IT87XX.cs
@@ -78,7 +78,6 @@ internal class IT87XX : ISuperIO
         {
             Chip.IT8665E or Chip.IT8625E => new byte[] { 0x15, 0x16, 0x17, 0x1e, 0x1f, 0x92 },
             Chip.IT8792E => new byte[] { 0x15, 0x16, 0x17 },
-            Chip.IT8696E when motherboard.Model is Model.X870_AORUS_ELITE_WIFI7 or Model.X870_AORUS_ELITE_WIFI7_ICE => new byte[] { 0, 0, 0, 0, 0, 0 },
             _ => new byte[] { 0x15, 0x16, 0x17, 0x7f, 0xa7, 0xaf }
         };
 


### PR DESCRIPTION
From 5 different users in https://github.com/Rem0o/FanControl.Releases/issues/3797#issuecomment-3713131023

This fixes the controllability of the fans. 

I don't know what was the intent behind the [0,0,0... ] array in [this PR](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/pull/1510). I don't really understand how that could work, as writing to the same "0" register for 5-6 different fans can't possibly control them individually. 

[A comment in that same PR](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/pull/1510#issuecomment-2466521354) also mentioned it broke the controls. 

So I would prefer to revert this back until someone can make a case for a bug with this board or the ITE8696E in general. 