### PR TITLE
Added query parameters to the /metrics endpoint

### DIFF
--- a/LibreHardwareMonitor/Utilities/HttpServer.cs
+++ b/LibreHardwareMonitor/Utilities/HttpServer.cs
@@ -571,7 +571,6 @@ public class HttpServer
 
     private string GeneratePrometheusResponse(Node node, Dictionary<string, int> prometheusSettings)
     {
-
         string responseStr = "";
         string lastTagName = "";
 
@@ -657,7 +656,6 @@ public class HttpServer
                     // Preparing the labels for all data and uniqueness
                     string valueSensorId = sensor.Sensor.Identifier.ToString().Substring(valueHardwareId.Length);
                     string valueSensorAlias = $"{valueSensorName} ({valueSensorId})";
-
                     string valueHost = _root.Text;
 
                     // Creates the tag with labels
@@ -712,6 +710,7 @@ public class HttpServer
         if (request != null && request.QueryString != null && request.QueryString.Count > 0)
         {
             int archive = 0, timestamps = 0, lastvalue = 1;
+            
             foreach (string key in request.QueryString.AllKeys)
             {
                 switch (key)
@@ -726,25 +725,23 @@ public class HttpServer
                             timestamps = 1;     // If archive is requested, timestamps must be enabled
 
                         break;
-
                     case "archivelength":
                         int.TryParse(request.QueryString[key], out archive);
-                        archive = Math.Min(10, archive);                                        // Enforce max 10
-                        archive = Math.Max(0, archive);                                         // Enforce min 0
+                        archive = Math.Min(10, archive); // Enforce max 10
+                        archive = Math.Max(0, archive); // Enforce min 0
 
                         if (archive == 0 && lastvalue == 0)
-                            archive = 1;        // If lastvalue was not requested then return at least 1 archived value
+                            archive = 1; // If lastvalue was not requested then return at least 1 archived value
 
                         if (archive > 0)
-                            timestamps = 1;     // If archive is requested, timestamps must be enabled
+                            timestamps = 1; // If archive is requested, timestamps must be enabled
 
                         break;
-
                     case "lastvalue":
                         int.TryParse(request.QueryString[key], out lastvalue);
 
                         if (lastvalue < 0 || lastvalue > 1)
-                            lastvalue = 1;      // Enforce boolean range 0 to 1
+                            lastvalue = 1; // Enforce boolean range 0 to 1
 
                         if (lastvalue == 0 && archive  == 0)
                         {
@@ -753,9 +750,7 @@ public class HttpServer
                         }
 
                         break;
-
                     default:
-
                         break;
                 }
             }


### PR DESCRIPTION
`lastvalue`
--
A value of zero will not send the most recent sensor value. This sensor value has a rolling timestamp if the same value is read repeatedly, if you are only interested in archiving the data this would provide an easy way to reduce the data sent even before the Prometheus agent picks it up.

`archivelength`
--
A value from 1 to 10 will make the endpoint return that amount of extra archived values if available for each sensor. Getting data from the archive will always enable timestamps otherwise you would have multiple values for the same metric without a timestamp and Prometheus will complain about it.

`timestamps`
--
A value of 1 will make the endpoint return timestamps with the data. This value is forced if archived data is requested.


Examples
--
| Endpoint | Last Value | Archived Values | Timestamps | Returned data |
|---|---|---|---|---|
| /metrics | Yes | No | No | Last value with no timestamp |
| /metrics?lastvalue=0 | No | 1** | Yes** | Last archive value with timestamp, archived values always have timestamps.  |
| /metrics?archivelength=1 | Yes* | 1 | Yes** | Last value and one archive value with timestamps |
| /metrics?archivelength=5&lastvalue=0 | No | 5 | Yes** | At most 5 archived values with timestamps |
| /metrics?archivelength=4&lastvalue=1&timestamps=1 | Yes | 4 | Yes | My favorite, Last value, 4 archived values, with timestamps. |

*: Value taken from default
**: Value was forced

The default behavior of the endpoint matches the behavior of other software. I still do not feel this is correct because polling Apache (the sensor) for its data is not the same as asking LHM what were the last values it saw from the sensors. In the Apache case we are directly querying our data source, in the case of LHM we are requesting the latest values that it has seen and we would not know at what time that was. The /metrics endpoint may be running inside the LHM software but it is effectively isolated from any and all data collecting logic from the sensors.

Agent configuration
--
```
scrape_configs:
  - job_name: "librehardwaremonitor"
    scrape_interval: 5s
    scrape_timeout: 3s
    static_configs:
      - targets: ["127.0.0.1:8085"]
        labels:
          app: "librehardwaremonitor"
          job: "librehardwaremonitor"
    metrics_path: "/metrics"
    params:
      archivelength: 5
      lastvalue: 0
      timestamps: 1
 ```    

The endpoint will also add custom headers `X-archivelength`, `X-lastvalue` and `X-timestamps` with the values as interpreted by the endpoint.