### PR TITLE
GA-A320M Add missing controls

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2038,6 +2038,8 @@ internal sealed class SuperIOHardware : Hardware
                         t.Add(new Temperature("VSoC MOS", 5));
                         f.Add(new Fan("CPU Fan", 0));
                         f.Add(new Fan("System Fan", 1));
+                        c.Add(new Control("CPU Fan", 0));
+                        c.Add(new Control("System Fan", 1));
 
                         break;
 


### PR DESCRIPTION
This PR only added the fan sensors, not the controls, which were working before the board specific config was added:
https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/pull/2094

FanControl issue: https://github.com/Rem0o/FanControl.Releases/issues/3815#issuecomment-3742130184

Adding back the control sensors for the 2 fan headers of this board, CPU and SYS.