### PR TITLE
B850 GAMING PLUS WIFI6E (MS-7E80)

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -683,6 +683,8 @@ internal class Identification
                 return Model.B840P_PRO_WIFI;
             case var _ when name.Equals("B840M GAMING PLUS WIFI6E (MS-7E77)", StringComparison.OrdinalIgnoreCase):
                 return Model.B840M_GAMING_PLUS_WIFI6E;
+            case var _ when name.Equals("B850 GAMING PLUS WIFI6E (MS-7E80)", StringComparison.OrdinalIgnoreCase):
+                return Model.B850_GAMING_PLUS_WIFI6E;
             case var _ when name.Equals("PRO B850-P WIFI (MS-7E56)", StringComparison.OrdinalIgnoreCase):
                 return Model.B850P_PRO_WIFI;
             case var _ when name.Equals("PRO B850-S WIFI6E (MS-7E80)", StringComparison.OrdinalIgnoreCase):


### PR DESCRIPTION
This PR https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/commit/1ee7c16cba307185655b5fda440c011f3a444d0d

Removed an existing board from the identification list, which breaks compatibility for users with this board: https://github.com/Rem0o/FanControl.Releases/issues/3817#issuecomment-3745671108

Adding it back, as I see no reason for its removal as it was clearly working.