### PR TITLE
Fix Intel iGPU appearing as duplicate hardware entry

### DIFF
--- a/LibreHardwareMonitorLib/Interop/IntelGcl.cs
+++ b/LibreHardwareMonitorLib/Interop/IntelGcl.cs
@@ -48,6 +48,17 @@ internal static class IntelGcl
         CTL_DEVICE_TYPE_MAX
     }
 
+    /// <summary>
+    /// Adapter properties flags from ctl_adapter_properties_flags_t.
+    /// The graphics_adapter_properties field is a bitmask of these values.
+    /// </summary>
+    public enum ctl_adapter_properties_flag_t : uint
+    {
+        CTL_ADAPTER_PROPERTIES_FLAG_INTEGRATED = 1 << 0,
+        CTL_ADAPTER_PROPERTIES_FLAG_LDA_PRIMARY = 1 << 1,
+        CTL_ADAPTER_PROPERTIES_FLAG_LDA_SECONDARY = 1 << 2,
+    }
+
     public enum ctl_fan_speed_mode_t
     {
         CTL_FAN_SPEED_MODE_DEFAULT = 0,


### PR DESCRIPTION
IGCL's `ctlEnumerateDevices` returns all Intel graphics devices including the iGPU. Since the IGCL enumeration loop in `IntelGpuGroup` wasn't filtering these out, the iGPU would show up twice — once as `IntelDiscreteGpu` (from IGCL) and once as `IntelIntegratedGpu` (from D3D), with overlapping sensors.

Fix is to check `graphics_adapter_properties` for the `CTL_ADAPTER_PROPERTIES_FLAG_INTEGRATED` flag and skip those in the IGCL loop, since they're already handled by the D3D path.

Tested on i9-14900HX (UHD Graphics) — iGPU now only appears once as `IntelIntegratedGpu` with the correct sensor set. Build passes across all target frameworks.