### PR TITLE
Save Sensor.Identifier in constructor

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Sensor.cs
+++ b/LibreHardwareMonitorLib/Hardware/Sensor.cs
@@ -79,10 +79,7 @@ internal class Sensor : ISensor
         get { return _hardware; }
     }
 
-    public Identifier Identifier
-    {
-        get { return new Identifier(_hardware.Identifier, SensorType.ToString().ToLowerInvariant(), Index.ToString(CultureInfo.InvariantCulture)); }
-    }
+    public Identifier Identifier => field ??= new Identifier(_hardware.Identifier, SensorType.ToString().ToLowerInvariant(), Index.ToString(CultureInfo.InvariantCulture));
 
     public int Index { get; }
 


### PR DESCRIPTION
My usecase involves calling Sensor.Identifier many times, which causes lots of garbage memory with the string manipulations.

Identifier is already called in the constructor, this will only add a small memory pressure for each Sensor object, but other classes seem to have this behavior anyways.