### PR TITLE
Add application version to root node of data.json

### DIFF
--- a/LibreHardwareMonitor/Utilities/HttpServer.cs
+++ b/LibreHardwareMonitor/Utilities/HttpServer.cs
@@ -30,10 +30,10 @@ public class HttpServer
     private readonly HttpListener _listener;
     private readonly Node _root;
     private readonly IElement _rootElement;
+    private readonly Version _version = typeof(HttpServer).Assembly.GetName().Version;
+
     private Task _listenerTask;
     private CancellationTokenSource _cts;
-
-    private readonly Version _version = typeof(HttpServer).Assembly.GetName().Version;
 
     public HttpServer(Node node, IElement rootElement, string ip, int port, bool authEnabled = false, string userName = "", string password = "")
     {

--- a/LibreHardwareMonitor/Utilities/HttpServer.cs
+++ b/LibreHardwareMonitor/Utilities/HttpServer.cs
@@ -33,6 +33,8 @@ public class HttpServer
     private Task _listenerTask;
     private CancellationTokenSource _cts;
 
+    private readonly Version _version = typeof(HttpServer).Assembly.GetName().Version;
+
     public HttpServer(Node node, IElement rootElement, string ip, int port, bool authEnabled = false, string userName = "", string password = "")
     {
         _root = node;
@@ -523,6 +525,7 @@ public class HttpServer
         int nodeIndex = 0;
 
         json["id"] = nodeIndex++;
+        json["Version"] = $"{_version.Major}.{_version.Minor}.{_version.Build}";
         json["Text"] = "Sensor";
         json["Min"] = "Min";
         json["Value"] = "Value";


### PR DESCRIPTION
It can be very useful for API clients to know which version of LHM is running i.e. different fields may be available.
This PR introduces a `Version` key at the root node of the generated json file. The Version has the format:
```
Major.Minor.Patch
e.g.
0.9.6
```