### PR TITLE
Fix unhandled NetworkInformationException in UpdateNetworkInterfaces

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Network/NetworkGroup.cs
+++ b/LibreHardwareMonitorLib/Hardware/Network/NetworkGroup.cs
@@ -92,9 +92,16 @@ internal class NetworkGroup : IGroup, IHardwareChanged
             {
                 if (hardware.All(x => x.NetworkInterface.Id != networkInterface.Id))
                 {
-                    Network network = new(networkInterface, settings);
-                    hardware.Add(network);
-                    additions.Add(network);
+                    try
+                    {
+                        Network network = new(networkInterface, settings);
+                        hardware.Add(network);
+                        additions.Add(network);
+                    }
+                    catch (NetworkInformationException)
+                    {
+                        // Interface became unavailable between enumeration and construction; skip it.
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes #2307

Wrap 
new Network(networkInterface, settings) in UpdateNetworkInterfaces with a try/catch for NetworkInformationException, matching how GetNetworkInterfaces() already handles the same exception type.

If a network interface disappears between enumeration and the Network constructor calling GetIPStatistics(), the exception is now caught and the interface is silently skipped.