### PR TITLE
NVIDIA GPU: reserve load index 3 for GPU Memory, remap other loads

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Gpu/NvidiaGpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Gpu/NvidiaGpu.cs
@@ -42,6 +42,7 @@ internal sealed class NvidiaGpu : GenericGpu
     private readonly Sensor _pcieThroughputRx;
     private readonly Sensor _pcieThroughputTx;
     private readonly Sensor[] _powers;
+    private int _nextLoadIndex; // next Load sensor index during construction
     private readonly Sensor _powerUsage;
     private readonly Sensor _coreVoltage;
     private readonly Sensor[] _temperatures;
@@ -260,7 +261,7 @@ internal sealed class NvidiaGpu : GenericGpu
                     string name = GetUtilizationDomainName(utilizationDomain);
 
                     if (name != null)
-                        loads.Add(new Sensor(name, MapNvUtilizationToLoadSensorIndex(index), SensorType.Load, this, settings));
+                        loads.Add(new Sensor(name, _nextLoadIndex++, SensorType.Load, this, settings));
                 }
             }
 
@@ -287,7 +288,7 @@ internal sealed class NvidiaGpu : GenericGpu
                         string name = GetUtilizationDomainName(utilizationDomain);
 
                         if (name != null)
-                            loads.Add(new Sensor(name, MapNvUtilizationToLoadSensorIndex(index), SensorType.Load, this, settings));
+                            loads.Add(new Sensor(name, _nextLoadIndex++, SensorType.Load, this, settings));
                     }
                 }
 
@@ -306,7 +307,6 @@ internal sealed class NvidiaGpu : GenericGpu
         if (powerStatus == NvApi.NvStatus.OK && powerTopology.Count > 0)
         {
             _powers = new Sensor[powerTopology.Count];
-            int powerLoadIndex = NextLoadIndexAfter(MaxLoadSensorIndex(_loads));
             for (int i = 0; i < powerTopology.Count; i++)
             {
                 NvApi.NvPowerTopologyEntry entry = powerTopology.Entries[i];
@@ -319,9 +319,8 @@ internal sealed class NvidiaGpu : GenericGpu
 
                 if (name != null)
                 {
-                    _powers[i] = new Sensor(name, powerLoadIndex, SensorType.Load, this, settings);
+                    _powers[i] = new Sensor(name, _nextLoadIndex++, SensorType.Load, this, settings);
                     ActivateSensor(_powers[i]);
-                    powerLoadIndex = NextLoadIndexAfter(powerLoadIndex);
                 }
             }
         }
@@ -358,6 +357,7 @@ internal sealed class NvidiaGpu : GenericGpu
                         string[] deviceIds = D3DDisplayDevice.GetDeviceIdentifiers();
                         if (deviceIds != null)
                         {
+                            int d3dLoadStartIndex = _nextLoadIndex;
                             foreach (string deviceId in deviceIds)
                             {
                                 if (deviceId.IndexOf("VEN_" + pci.pciVendorId.ToString("X"), StringComparison.OrdinalIgnoreCase) != -1 &&
@@ -419,9 +419,8 @@ internal sealed class NvidiaGpu : GenericGpu
 
                                     if (isMatch && D3DDisplayDevice.GetDeviceInfoByIdentifier(deviceId, out D3DDisplayDevice.D3DDeviceInfo deviceInfo))
                                     {
-                                        int maxLoadSoFar = Math.Max(MaxLoadSensorIndex(_loads), MaxLoadSensorIndex(_powers));
-                                        int loadSensorIndex = NextLoadIndexAfter(maxLoadSoFar);
                                         int smallDataSensorIndex = 3; // There are three normal GPU memory sensors.
+                                        int nextD3dLoadIndex = d3dLoadStartIndex;
 
                                         _d3dDeviceId = deviceId;
 
@@ -434,11 +433,12 @@ internal sealed class NvidiaGpu : GenericGpu
 
                                         foreach (D3DDisplayDevice.D3DDeviceNodeInfo node in deviceInfo.Nodes.OrderBy(x => x.Name))
                                         {
-                                            _gpuNodeUsage[node.Id] = new Sensor(node.Name, loadSensorIndex, SensorType.Load, this, settings);
+                                            _gpuNodeUsage[node.Id] = new Sensor(node.Name, nextD3dLoadIndex++, SensorType.Load, this, settings);
                                             _gpuNodeUsagePrevValue[node.Id] = node.RunningTime;
                                             _gpuNodeUsagePrevTick[node.Id] = node.QueryTime;
-                                            loadSensorIndex = NextLoadIndexAfter(loadSensorIndex);
                                         }
+
+                                        _nextLoadIndex = nextD3dLoadIndex;
                                     }
                                 }
                             }
@@ -451,7 +451,7 @@ internal sealed class NvidiaGpu : GenericGpu
         _memoryFree = new Sensor("GPU Memory Free", 0, SensorType.SmallData, this, settings);
         _memoryUsed = new Sensor("GPU Memory Used", 1, SensorType.SmallData, this, settings);
         _memoryTotal = new Sensor("GPU Memory Total", 2, SensorType.SmallData, this, settings);
-        _memoryLoad = new Sensor("GPU Memory", GpuMemoryLoadSensorIndex, SensorType.Load, this, settings);
+        _memoryLoad = new Sensor("GPU Memory", _nextLoadIndex++, SensorType.Load, this, settings);
 
         // Pin power sensors for NVIDIA RTX Astral series from ASUS
         if (NvApi.NvAPI_I2CReadEx != null && NvApi.NvAPI_GPU_GetPCIIdentifiers != null)
@@ -506,32 +506,6 @@ internal sealed class NvidiaGpu : GenericGpu
         }
 
         Update();
-    }
-
-    private const int GpuMemoryLoadSensorIndex = 3;
-
-    private static int MapNvUtilizationToLoadSensorIndex(int utilizationDomainIndex) =>
-        utilizationDomainIndex < GpuMemoryLoadSensorIndex ? utilizationDomainIndex : utilizationDomainIndex + 1;
-
-    private static int MaxLoadSensorIndex(Sensor[] sensors)
-    {
-        if (sensors == null)
-            return -1;
-
-        int max = -1;
-        foreach (Sensor s in sensors)
-        {
-            if (s != null)
-                max = Math.Max(max, s.Index);
-        }
-
-        return max;
-    }
-
-    private static int NextLoadIndexAfter(int previousIndex)
-    {
-        int next = previousIndex + 1;
-        return next == GpuMemoryLoadSensorIndex ? next + 1 : next;
     }
 
     /// <inheritdoc />

--- a/LibreHardwareMonitorLib/Hardware/Gpu/NvidiaGpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Gpu/NvidiaGpu.cs
@@ -260,7 +260,7 @@ internal sealed class NvidiaGpu : GenericGpu
                     string name = GetUtilizationDomainName(utilizationDomain);
 
                     if (name != null)
-                        loads.Add(new Sensor(name, index, SensorType.Load, this, settings));
+                        loads.Add(new Sensor(name, MapNvUtilizationToLoadSensorIndex(index), SensorType.Load, this, settings));
                 }
             }
 
@@ -287,7 +287,7 @@ internal sealed class NvidiaGpu : GenericGpu
                         string name = GetUtilizationDomainName(utilizationDomain);
 
                         if (name != null)
-                            loads.Add(new Sensor(name, index, SensorType.Load, this, settings));
+                            loads.Add(new Sensor(name, MapNvUtilizationToLoadSensorIndex(index), SensorType.Load, this, settings));
                     }
                 }
 
@@ -306,6 +306,7 @@ internal sealed class NvidiaGpu : GenericGpu
         if (powerStatus == NvApi.NvStatus.OK && powerTopology.Count > 0)
         {
             _powers = new Sensor[powerTopology.Count];
+            int powerLoadIndex = NextLoadIndexAfter(MaxLoadSensorIndex(_loads));
             for (int i = 0; i < powerTopology.Count; i++)
             {
                 NvApi.NvPowerTopologyEntry entry = powerTopology.Entries[i];
@@ -318,8 +319,9 @@ internal sealed class NvidiaGpu : GenericGpu
 
                 if (name != null)
                 {
-                    _powers[i] = new Sensor(name, i + (_loads?.Length ?? 0), SensorType.Load, this, settings);
+                    _powers[i] = new Sensor(name, powerLoadIndex, SensorType.Load, this, settings);
                     ActivateSensor(_powers[i]);
+                    powerLoadIndex = NextLoadIndexAfter(powerLoadIndex);
                 }
             }
         }
@@ -417,8 +419,8 @@ internal sealed class NvidiaGpu : GenericGpu
 
                                     if (isMatch && D3DDisplayDevice.GetDeviceInfoByIdentifier(deviceId, out D3DDisplayDevice.D3DDeviceInfo deviceInfo))
                                     {
-                                        int sensorCount = (_loads?.Length ?? 0) + (_powers?.Length ?? 0);
-                                        int loadSensorIndex = sensorCount > 0 ? sensorCount + 1 : 0;
+                                        int maxLoadSoFar = Math.Max(MaxLoadSensorIndex(_loads), MaxLoadSensorIndex(_powers));
+                                        int loadSensorIndex = NextLoadIndexAfter(maxLoadSoFar);
                                         int smallDataSensorIndex = 3; // There are three normal GPU memory sensors.
 
                                         _d3dDeviceId = deviceId;
@@ -432,9 +434,10 @@ internal sealed class NvidiaGpu : GenericGpu
 
                                         foreach (D3DDisplayDevice.D3DDeviceNodeInfo node in deviceInfo.Nodes.OrderBy(x => x.Name))
                                         {
-                                            _gpuNodeUsage[node.Id] = new Sensor(node.Name, loadSensorIndex++, SensorType.Load, this, settings);
+                                            _gpuNodeUsage[node.Id] = new Sensor(node.Name, loadSensorIndex, SensorType.Load, this, settings);
                                             _gpuNodeUsagePrevValue[node.Id] = node.RunningTime;
                                             _gpuNodeUsagePrevTick[node.Id] = node.QueryTime;
+                                            loadSensorIndex = NextLoadIndexAfter(loadSensorIndex);
                                         }
                                     }
                                 }
@@ -448,7 +451,7 @@ internal sealed class NvidiaGpu : GenericGpu
         _memoryFree = new Sensor("GPU Memory Free", 0, SensorType.SmallData, this, settings);
         _memoryUsed = new Sensor("GPU Memory Used", 1, SensorType.SmallData, this, settings);
         _memoryTotal = new Sensor("GPU Memory Total", 2, SensorType.SmallData, this, settings);
-        _memoryLoad = new Sensor("GPU Memory", 3, SensorType.Load, this, settings);
+        _memoryLoad = new Sensor("GPU Memory", GpuMemoryLoadSensorIndex, SensorType.Load, this, settings);
 
         // Pin power sensors for NVIDIA RTX Astral series from ASUS
         if (NvApi.NvAPI_I2CReadEx != null && NvApi.NvAPI_GPU_GetPCIIdentifiers != null)
@@ -503,6 +506,32 @@ internal sealed class NvidiaGpu : GenericGpu
         }
 
         Update();
+    }
+
+    private const int GpuMemoryLoadSensorIndex = 3;
+
+    private static int MapNvUtilizationToLoadSensorIndex(int utilizationDomainIndex) =>
+        utilizationDomainIndex < GpuMemoryLoadSensorIndex ? utilizationDomainIndex : utilizationDomainIndex + 1;
+
+    private static int MaxLoadSensorIndex(Sensor[] sensors)
+    {
+        if (sensors == null)
+            return -1;
+
+        int max = -1;
+        foreach (Sensor s in sensors)
+        {
+            if (s != null)
+                max = Math.Max(max, s.Index);
+        }
+
+        return max;
+    }
+
+    private static int NextLoadIndexAfter(int previousIndex)
+    {
+        int next = previousIndex + 1;
+        return next == GpuMemoryLoadSensorIndex ? next + 1 : next;
     }
 
     /// <inheritdoc />

--- a/LibreHardwareMonitorLib/Hardware/Gpu/NvidiaGpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Gpu/NvidiaGpu.cs
@@ -42,7 +42,6 @@ internal sealed class NvidiaGpu : GenericGpu
     private readonly Sensor _pcieThroughputRx;
     private readonly Sensor _pcieThroughputTx;
     private readonly Sensor[] _powers;
-    private int _nextLoadIndex; // next Load sensor index during construction
     private readonly Sensor _powerUsage;
     private readonly Sensor _coreVoltage;
     private readonly Sensor[] _temperatures;
@@ -247,6 +246,8 @@ internal sealed class NvidiaGpu : GenericGpu
             }
         }
 
+        int nextLoadIndex = 0;
+
         // Load usages.
         NvApi.NvDynamicPStatesInfo pStatesInfo = GetDynamicPstatesInfoEx(out status);
         if (status == NvApi.NvStatus.OK)
@@ -261,7 +262,7 @@ internal sealed class NvidiaGpu : GenericGpu
                     string name = GetUtilizationDomainName(utilizationDomain);
 
                     if (name != null)
-                        loads.Add(new Sensor(name, _nextLoadIndex++, SensorType.Load, this, settings));
+                        loads.Add(new Sensor(name, nextLoadIndex++, SensorType.Load, this, settings));
                 }
             }
 
@@ -288,7 +289,7 @@ internal sealed class NvidiaGpu : GenericGpu
                         string name = GetUtilizationDomainName(utilizationDomain);
 
                         if (name != null)
-                            loads.Add(new Sensor(name, _nextLoadIndex++, SensorType.Load, this, settings));
+                            loads.Add(new Sensor(name, nextLoadIndex++, SensorType.Load, this, settings));
                     }
                 }
 
@@ -303,7 +304,7 @@ internal sealed class NvidiaGpu : GenericGpu
         }
 
         // GPU Memory load: created after NVAPI utilization loads so it appears with other GPU metrics (before power/D3D loads).
-        _memoryLoad = new Sensor("GPU Memory", _nextLoadIndex++, SensorType.Load, this, settings);
+        _memoryLoad = new Sensor("GPU Memory", nextLoadIndex++, SensorType.Load, this, settings);
 
         // Power.
         NvApi.NvPowerTopology powerTopology = GetPowerTopology(out NvApi.NvStatus powerStatus);
@@ -322,7 +323,7 @@ internal sealed class NvidiaGpu : GenericGpu
 
                 if (name != null)
                 {
-                    _powers[i] = new Sensor(name, _nextLoadIndex++, SensorType.Load, this, settings);
+                    _powers[i] = new Sensor(name, nextLoadIndex++, SensorType.Load, this, settings);
                     ActivateSensor(_powers[i]);
                 }
             }
@@ -360,7 +361,7 @@ internal sealed class NvidiaGpu : GenericGpu
                         string[] deviceIds = D3DDisplayDevice.GetDeviceIdentifiers();
                         if (deviceIds != null)
                         {
-                            int d3dLoadStartIndex = _nextLoadIndex;
+                            int d3dLoadStartIndex = nextLoadIndex;
                             foreach (string deviceId in deviceIds)
                             {
                                 if (deviceId.IndexOf("VEN_" + pci.pciVendorId.ToString("X"), StringComparison.OrdinalIgnoreCase) != -1 &&
@@ -441,7 +442,7 @@ internal sealed class NvidiaGpu : GenericGpu
                                             _gpuNodeUsagePrevTick[node.Id] = node.QueryTime;
                                         }
 
-                                        _nextLoadIndex = nextD3dLoadIndex;
+                                        nextLoadIndex = nextD3dLoadIndex;
                                     }
                                 }
                             }

--- a/LibreHardwareMonitorLib/Hardware/Gpu/NvidiaGpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Gpu/NvidiaGpu.cs
@@ -302,6 +302,9 @@ internal sealed class NvidiaGpu : GenericGpu
             }
         }
 
+        // GPU Memory load: created after NVAPI utilization loads so it appears with other GPU metrics (before power/D3D loads).
+        _memoryLoad = new Sensor("GPU Memory", _nextLoadIndex++, SensorType.Load, this, settings);
+
         // Power.
         NvApi.NvPowerTopology powerTopology = GetPowerTopology(out NvApi.NvStatus powerStatus);
         if (powerStatus == NvApi.NvStatus.OK && powerTopology.Count > 0)
@@ -451,7 +454,6 @@ internal sealed class NvidiaGpu : GenericGpu
         _memoryFree = new Sensor("GPU Memory Free", 0, SensorType.SmallData, this, settings);
         _memoryUsed = new Sensor("GPU Memory Used", 1, SensorType.SmallData, this, settings);
         _memoryTotal = new Sensor("GPU Memory Total", 2, SensorType.SmallData, this, settings);
-        _memoryLoad = new Sensor("GPU Memory", _nextLoadIndex++, SensorType.Load, this, settings);
 
         // Pin power sensors for NVIDIA RTX Astral series from ASUS
         if (NvApi.NvAPI_I2CReadEx != null && NvApi.NvAPI_GPU_GetPCIIdentifiers != null)


### PR DESCRIPTION
Encountered this problem of `GPU Memory` display in Gadget not being saved when the software closed.
Saw several issues here but none being addressed yet:
https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/issues/1545
https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/issues/2178

I tried to edit the config to forcefully add this
```xml
    <add key="/gpu-nvidia/0/load/3/gadget" value="true" />
```

but it then loads the `GPU Bus` alongside the `GPU Memory`, which confirms there is a index collision

The fix detail:

## Summary

`Sensor` identifiers use hardware + type + **numeric index**. On NVIDIA GPUs, **GPU Memory** load was always index **3**, while other **Load** sensors (NVAPI utilization domains, power topology rows reported as load, D3D engine nodes) could also use index **3**. That produced **colliding** paths (e.g. `/gpu-nvidia/…/load/3/…`), so one config key could affect **multiple** sensors—wrong gadget rows, confusing manual edits to `LibreHardwareMonitor.config`, and settings that seemed not to “stick” for the intended sensor.

This change **keeps index 3 for GPU Memory load** (stable paths for existing VRAM-related settings) and **ensures no other load sensor uses index 3**.

## What changed

- **NVAPI utilization:** domains `0–2` unchanged; domain `n ≥ 3` maps to sensor index `n + 1` so slot **3** stays free for GPU Memory.
- **Power topology (load rows):** indices are allocated after the current max NV load index, advancing with a helper that **skips 3** (replacing `i + _loads.Length`, which could land on 3).
- **D3D node load sensors:** start after `max(NV loads, power loads)` and advance with the same **skip-3** rule (replacing count-based indexing that could overlap or hit 3).

## User-visible impact

- **GPU Memory** load should remain at **`…/load/3/…`** in config (gadget, plot, hidden, rename, etc.).
- Settings tied to **other** load sensors whose **old** index was **3** (e.g. a utilization domain that used to be index 3) may move to a **new** index; users may need to re-toggle those sensors once.

## Testing

- [x] Built locally (`LibreHardwareMonitorLib` / app as you usually do).
- [x] Confirmed gadget / config behavior for **GPU Memory** load on an NVIDIA GPU.
- [x] Spot-check other load rows (utilization, D3D nodes if present) still appear and keep distinct settings.

