### PR TITLE
Update DiskInfoToolkit - fixes bluescreen.

### DIFF
--- a/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
+++ b/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
@@ -81,7 +81,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DiskInfoToolkit" Version="2.0.1" />
+    <PackageReference Include="DiskInfoToolkit" Version="2.0.2" />
     <PackageReference Include="HidSharp" Version="2.6.4" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Update DiskInfoToolkit.
Fixes bluescreen for Intel Rst drives where it has occurred.

https://github.com/Blacktempel/DiskInfoToolkit/releases/tag/2.0.2