### PR TITLE
Add support for Intel ArrowLake-U

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Cpu/IntelCpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/IntelCpu.cs
@@ -232,6 +232,7 @@ internal sealed class IntelCpu : GenericCpu
                             tjMax = GetTjMaxFromMsr();
                             break;
 
+                        case 0xB5: // Intel Core Ultra 5/7 200 Series ArrowLake-U
                         case 0xC5: // Intel Core Ultra 9 200 Series ArrowLake
                         case 0xC6: // Intel Core Ultra 7 200 Series ArrowLake
                             _microArchitecture = MicroArchitecture.ArrowLake;


### PR DESCRIPTION
The model of `Intel Core Ultra 7 265U` and `Intel Core Ultra 5 235U` is `0xB5`.
Fixes #2221.