### PR TITLE
Fix freeze on SerialPort.Close (TG WVP2)

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/PowerMonitor/SharedSerialPort.cs
+++ b/LibreHardwareMonitorLib/Hardware/PowerMonitor/SharedSerialPort.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Ports;
+﻿using BlackSharp.IO.Ports;
 
 namespace LibreHardwareMonitor.Hardware.PowerMonitor;
 
@@ -13,13 +13,6 @@ internal sealed class SharedSerialPort : SerialPort
     { }
 
     public SharedSerialPort(string portName, int baudRate) : base(portName, baudRate)
-    { }
-
-    public SharedSerialPort(string portName, int baudRate, Parity parity) : base(portName, baudRate, parity)
-    { }
-
-    public SharedSerialPort(string portName, int baudRate, Parity parity, int dataBits)
-        : base(portName, baudRate, parity, dataBits)
     { }
 
     public SharedSerialPort(string portName, int baudRate, Parity parity, int dataBits, StopBits stopBits)
@@ -37,18 +30,18 @@ internal sealed class SharedSerialPort : SerialPort
         }
     }
 
-    public new void Close()
+    public bool TryClose()
     {
         if (!_hasMutex)
         {
-            return;
+            return true;
         }
 
         try
         {
             if (IsOpen)
             {
-                base.Close();
+                return base.TryClose(CloseTimeout);
             }
         }
         finally
@@ -56,6 +49,8 @@ internal sealed class SharedSerialPort : SerialPort
             _hasMutex = false;
             Mutexes.ReleaseUsbSensors();
         }
+
+        return true;
     }
 
     public new void Write(byte[] buffer, int offset, int count)

--- a/LibreHardwareMonitorLib/Hardware/PowerMonitor/WireViewPro2.cs
+++ b/LibreHardwareMonitorLib/Hardware/PowerMonitor/WireViewPro2.cs
@@ -8,10 +8,10 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.IO.Ports;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
+using BlackSharp.IO.Ports;
 using LibreHardwareMonitor.Interop.PowerMonitor;
 
 namespace LibreHardwareMonitor.Hardware.PowerMonitor;
@@ -271,7 +271,10 @@ public sealed class WireViewPro2 : Hardware, IPowerMonitor
             }
             finally
             {
-                _serialPort.Close();
+                if (!_serialPort.TryClose())
+                {
+                    Reconnect();
+                }
             }
         }
     }
@@ -622,7 +625,7 @@ public sealed class WireViewPro2 : Hardware, IPowerMonitor
                 {
                     if (_serialPort.IsOpen)
                     {
-                        _serialPort.Close();
+                        _serialPort.TryClose();
                     }
                 }
                 catch
@@ -651,7 +654,7 @@ public sealed class WireViewPro2 : Hardware, IPowerMonitor
 
             if (_serialPort != null)
             {
-                _serialPort.Close();
+                _serialPort.TryClose();
                 _serialPort.Dispose();
                 _serialPort = null;
             }
@@ -661,6 +664,12 @@ public sealed class WireViewPro2 : Hardware, IPowerMonitor
             VendorData = null;
             UniqueID = null;
         }
+    }
+
+    private void Reconnect()
+    {
+        Disconnect();
+        Connect();
     }
 
     private bool ReadWelcomeMessage(bool sendCmd = false)
@@ -789,7 +798,10 @@ public sealed class WireViewPro2 : Hardware, IPowerMonitor
             }
             finally
             {
-                _serialPort.Close();
+                if (!_serialPort.TryClose())
+                {
+                    Reconnect();
+                }
             }
 
             return buf;

--- a/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
+++ b/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
@@ -81,6 +81,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="BlackSharp.IO.Ports" Version="1.1.0" />
     <PackageReference Include="DiskInfoToolkit" Version="2.1.0" />
     <PackageReference Include="HidSharp" Version="2.6.4" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.275">


### PR DESCRIPTION
Fix freeze when calling SerialPort.Close by replacing standard SerialPort implementation.