### PR TITLE
Fix web-server resource names when using a different assembly name

### DIFF
--- a/LibreHardwareMonitor.Windows.Forms/Utilities/HttpServer.cs
+++ b/LibreHardwareMonitor.Windows.Forms/Utilities/HttpServer.cs
@@ -445,7 +445,7 @@ public class HttpServer
     private async Task ServeResourceFileAsync(HttpListenerResponse response, string name, string ext)
     {
         // resource names do not support the hyphen
-        name = "LibreHardwareMonitor.Resources." +
+        name = Assembly.GetExecutingAssembly().GetName().Name + ".Resources." +
                name.Replace("custom-theme", "custom_theme");
 
         string[] names = Assembly.GetExecutingAssembly().GetManifestResourceNames();
@@ -486,7 +486,7 @@ public class HttpServer
 
     private async Task ServeResourceImageAsync(HttpListenerResponse response, string name)
     {
-        name = "LibreHardwareMonitor.Resources." + name;
+        name = Assembly.GetExecutingAssembly().GetName().Name + ".Resources." + name;
 
         string[] names = Assembly.GetExecutingAssembly().GetManifestResourceNames();
 


### PR DESCRIPTION
When running LHM under a different executable name, the integrated web-server does not serve the files correctly.
This happens because the resource-path logic has the default assembly name hard coded.

One example:
When debugging LHM via Visual Studio, the assembly name will change to "LibreHardwareMonitor.Windows.Forms".
This results in a 404 error when opening http://localhost:8085 in a browser.