### PR TITLE
Fix remote web-server crash when sensors contain a "NaN" value.

### DIFF
--- a/LibreHardwareMonitor.Windows.Forms/Utilities/HttpServer.cs
+++ b/LibreHardwareMonitor.Windows.Forms/Utilities/HttpServer.cs
@@ -534,7 +534,13 @@ public class HttpServer
 
         json["Children"] = new List<object> { GenerateJsonForNode(_root, ref nodeIndex) };
 
-        byte[] buffer = Encoding.UTF8.GetBytes(System.Text.Json.JsonSerializer.Serialize(json));
+        byte[] buffer = Encoding.UTF8.GetBytes(System.Text.Json.JsonSerializer.Serialize(
+            json,
+            new System.Text.Json.JsonSerializerOptions
+            {
+                NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowNamedFloatingPointLiterals, // Allow "NaN"
+            }
+        ));
 
         bool acceptGzip;
         try


### PR DESCRIPTION
This fixes a crash in the remote web-server that happens while serializing the sensor data.
If a sensor contains a float value of "NaN", the JSON serialization fails.

Here is an example sensor that causes this issue:

<img width="408" height="106" alt="image" src="https://github.com/user-attachments/assets/b4a37447-0ff6-46b5-b6e2-5808a494d2c5" />

After the fix the remote web-server app will show the same Text: "NaN %" and does no longer crash.