### PR TITLE
Fix Remote Web Server authentication

### DIFF
--- a/LibreHardwareMonitor.Windows.Forms/UI/AuthForm.cs
+++ b/LibreHardwareMonitor.Windows.Forms/UI/AuthForm.cs
@@ -33,7 +33,10 @@ public partial class AuthForm : Form
     private void HttpAuthOkButton_Click(object sender, EventArgs e)
     {
         _parent.Server.UserName = httpAuthUsernameTextBox.Text;
-        _parent.Server.Password = httpAuthPasswordTextBox.Text;
+        if (!string.IsNullOrWhiteSpace(httpAuthPasswordTextBox.Text))
+        {
+            _parent.Server.SetPassword(httpAuthPasswordTextBox.Text);
+        }
         _parent.Server.AuthEnabled = enableHTTPAuthCheckBox.Checked;
         _parent.AuthWebServerMenuItemChecked = _parent.Server.AuthEnabled;
         Close();

--- a/LibreHardwareMonitor.Windows.Forms/UI/MainForm.cs
+++ b/LibreHardwareMonitor.Windows.Forms/UI/MainForm.cs
@@ -964,7 +964,7 @@ public sealed partial class MainForm : Form
         _settings.SetValue("listenerPort", Server.ListenerPort);
         _settings.SetValue("authenticationEnabled", Server.AuthEnabled);
         _settings.SetValue("authenticationUserName", Server.UserName);
-        _settings.SetValue("authenticationPassword", Server.Password);
+        _settings.SetValue("authenticationPassword", Server.PasswordSHA256);
 
         string fileName = Path.ChangeExtension(Application.ExecutablePath, ".config");
 

--- a/LibreHardwareMonitor.Windows.Forms/Utilities/HttpServer.cs
+++ b/LibreHardwareMonitor.Windows.Forms/Utilities/HttpServer.cs
@@ -35,7 +35,7 @@ public class HttpServer
     private Task _listenerTask;
     private CancellationTokenSource _cts;
 
-    public HttpServer(Node node, IElement rootElement, string ip, int port, bool authEnabled = false, string userName = "", string password = "")
+    public HttpServer(Node node, IElement rootElement, string ip, int port, bool authEnabled = false, string userName = "", string passwordSHA256 = "")
     {
         _root = node;
         _rootElement = rootElement;
@@ -43,7 +43,7 @@ public class HttpServer
         ListenerPort = port;
         AuthEnabled = authEnabled;
         UserName = userName;
-        Password = password;
+        PasswordSHA256 = passwordSHA256;
 
         try
         {
@@ -74,10 +74,9 @@ public class HttpServer
 
     public int ListenerPort { get; set; }
 
-    public string Password
+    public void SetPassword(string plainPassword)
     {
-        get { return PasswordSHA256; }
-        set { PasswordSHA256 = ComputeSHA256(value); }
+        PasswordSHA256 = ComputeSHA256(plainPassword);
     }
 
     public bool PlatformNotSupported
@@ -87,7 +86,7 @@ public class HttpServer
 
     public string UserName { get; set; }
 
-    private string PasswordSHA256 { get; set; }
+    public string PasswordSHA256 { get; set; }
 
     public bool StartHttpListener()
     {


### PR DESCRIPTION
When using the Remote Web Server with authentication enabled, the stored SHA256 password gets double encoded after LHM or web-server restart.
This causes the authentication to always fail.
This PR also allows closing the AuthForm via OK without accidentally resetting an already existing password.