### PR TITLE
Make Ring0 DeviceIoControl Native AOT friendly

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/KernelDriver.cs
+++ b/LibreHardwareMonitorLib/Hardware/KernelDriver.cs
@@ -109,45 +109,264 @@ internal class KernelDriver
 
     public bool DeviceIOControl(Kernel32.IOControlCode ioControlCode, object inBuffer)
     {
-        return _device != null && Kernel32.DeviceIoControl(_device, ioControlCode, inBuffer, inBuffer == null ? 0 : (uint)Marshal.SizeOf(inBuffer), null, 0, out uint _, IntPtr.Zero);
+        if (_device == null)
+            return false;
+
+        if (inBuffer == null)
+            return DeviceIOControlCore(ioControlCode, IntPtr.Zero, 0, IntPtr.Zero, 0);
+
+        return inBuffer switch
+        {
+            byte value => DeviceIOControl(ioControlCode, value),
+            ushort value => DeviceIOControl(ioControlCode, value),
+            uint value => DeviceIOControl(ioControlCode, value),
+            ulong value => DeviceIOControl(ioControlCode, value),
+            _ => DeviceIOControlBoxed(ioControlCode, inBuffer),
+        };
+    }
+
+    public bool DeviceIOControl<TInput>(Kernel32.IOControlCode ioControlCode, TInput inBuffer)
+        where TInput : struct
+    {
+        if (_device == null)
+            return false;
+
+        IntPtr inPtr = StructureToPtr(inBuffer, out uint inSize);
+        try
+        {
+            return DeviceIOControlCore(ioControlCode, inPtr, inSize, IntPtr.Zero, 0);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(inPtr);
+        }
     }
 
     public bool DeviceIOControl<T>(Kernel32.IOControlCode ioControlCode, object inBuffer, ref T outBuffer)
+        where T : struct
     {
         if (_device == null)
             return false;
 
-        object boxedOutBuffer = outBuffer;
-        bool b = Kernel32.DeviceIoControl(_device,
-                                          ioControlCode,
-                                          inBuffer,
-                                          inBuffer == null ? 0 : (uint)Marshal.SizeOf(inBuffer),
-                                          boxedOutBuffer,
-                                          (uint)Marshal.SizeOf(boxedOutBuffer),
-                                          out uint _,
-                                          IntPtr.Zero);
+        if (inBuffer == null)
+            return DeviceIOControlNoInput(ioControlCode, ref outBuffer);
 
-        outBuffer = (T)boxedOutBuffer;
-        return b;
+        return inBuffer switch
+        {
+            byte value => DeviceIOControl(ioControlCode, value, ref outBuffer),
+            ushort value => DeviceIOControl(ioControlCode, value, ref outBuffer),
+            uint value => DeviceIOControl(ioControlCode, value, ref outBuffer),
+            ulong value => DeviceIOControl(ioControlCode, value, ref outBuffer),
+            _ => DeviceIOControlBoxed(ioControlCode, inBuffer, ref outBuffer),
+        };
+    }
+
+    public bool DeviceIOControl<TInput, TOutput>(
+        Kernel32.IOControlCode ioControlCode,
+        TInput inBuffer,
+        ref TOutput outBuffer)
+        where TInput : struct
+        where TOutput : struct
+    {
+        if (_device == null)
+            return false;
+
+        IntPtr inPtr = StructureToPtr(inBuffer, out uint inSize);
+        try
+        {
+            return DeviceIOControlWithInput(ioControlCode, inPtr, inSize, ref outBuffer);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(inPtr);
+        }
+    }
+
+    private bool DeviceIOControlNoInput<TOutput>(Kernel32.IOControlCode ioControlCode, ref TOutput outBuffer)
+        where TOutput : struct
+    {
+        return DeviceIOControlWithInput(ioControlCode, IntPtr.Zero, 0, ref outBuffer);
+    }
+
+    private bool DeviceIOControlWithInput<TOutput>(
+        Kernel32.IOControlCode ioControlCode,
+        IntPtr inPtr,
+        uint inSize,
+        ref TOutput outBuffer)
+        where TOutput : struct
+    {
+        int outSize = Marshal.SizeOf<TOutput>();
+        IntPtr outPtr = Marshal.AllocHGlobal(outSize);
+        try
+        {
+            Marshal.StructureToPtr(outBuffer, outPtr, false);
+            bool result = DeviceIOControlCore(ioControlCode, inPtr, inSize, outPtr, (uint)outSize);
+            if (result)
+                outBuffer = Marshal.PtrToStructure<TOutput>(outPtr);
+
+            return result;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(outPtr);
+        }
     }
 
     public bool DeviceIOControl<T>(Kernel32.IOControlCode ioControlCode, object inBuffer, ref T[] outBuffer)
+        where T : struct
     {
         if (_device == null)
             return false;
 
-        object boxedOutBuffer = outBuffer;
-        bool b = Kernel32.DeviceIoControl(_device,
-                                          ioControlCode,
-                                          inBuffer,
-                                          inBuffer == null ? 0 : (uint)Marshal.SizeOf(inBuffer),
-                                          boxedOutBuffer,
-                                          (uint)(Marshal.SizeOf(typeof(T)) * outBuffer.Length),
-                                          out uint _,
-                                          IntPtr.Zero);
+        if (inBuffer == null)
+            return DeviceIOControlNoInput(ioControlCode, ref outBuffer);
 
-        outBuffer = (T[])boxedOutBuffer;
-        return b;
+        return inBuffer switch
+        {
+            byte value => DeviceIOControl(ioControlCode, value, ref outBuffer),
+            ushort value => DeviceIOControl(ioControlCode, value, ref outBuffer),
+            uint value => DeviceIOControl(ioControlCode, value, ref outBuffer),
+            ulong value => DeviceIOControl(ioControlCode, value, ref outBuffer),
+            _ => DeviceIOControlBoxed(ioControlCode, inBuffer, ref outBuffer),
+        };
+    }
+
+    public bool DeviceIOControl<TInput, TOutput>(
+        Kernel32.IOControlCode ioControlCode,
+        TInput inBuffer,
+        ref TOutput[] outBuffer)
+        where TInput : struct
+        where TOutput : struct
+    {
+        if (_device == null)
+            return false;
+
+        IntPtr inPtr = StructureToPtr(inBuffer, out uint inSize);
+        try
+        {
+            return DeviceIOControlWithInput(ioControlCode, inPtr, inSize, ref outBuffer);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(inPtr);
+        }
+    }
+
+    private bool DeviceIOControlNoInput<TOutput>(Kernel32.IOControlCode ioControlCode, ref TOutput[] outBuffer)
+        where TOutput : struct
+    {
+        return DeviceIOControlWithInput(ioControlCode, IntPtr.Zero, 0, ref outBuffer);
+    }
+
+    private bool DeviceIOControlWithInput<TOutput>(
+        Kernel32.IOControlCode ioControlCode,
+        IntPtr inPtr,
+        uint inSize,
+        ref TOutput[] outBuffer)
+        where TOutput : struct
+    {
+        int elementSize = Marshal.SizeOf<TOutput>();
+        int outSize = elementSize * outBuffer.Length;
+        IntPtr outPtr = Marshal.AllocHGlobal(outSize);
+        try
+        {
+            bool result = DeviceIOControlCore(ioControlCode, inPtr, inSize, outPtr, (uint)outSize);
+            if (result)
+            {
+                for (int i = 0; i < outBuffer.Length; i++)
+                    outBuffer[i] = Marshal.PtrToStructure<TOutput>(IntPtr.Add(outPtr, i * elementSize));
+            }
+
+            return result;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(outPtr);
+        }
+    }
+
+    private bool DeviceIOControlBoxed(Kernel32.IOControlCode ioControlCode, object inBuffer)
+    {
+        IntPtr inPtr = BoxedStructureToPtr(inBuffer, out uint inSize);
+        try
+        {
+            return DeviceIOControlCore(ioControlCode, inPtr, inSize, IntPtr.Zero, 0);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(inPtr);
+        }
+    }
+
+    private bool DeviceIOControlBoxed<TOutput>(
+        Kernel32.IOControlCode ioControlCode,
+        object inBuffer,
+        ref TOutput outBuffer)
+        where TOutput : struct
+    {
+        IntPtr inPtr = BoxedStructureToPtr(inBuffer, out uint inSize);
+        try
+        {
+            return DeviceIOControlWithInput(ioControlCode, inPtr, inSize, ref outBuffer);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(inPtr);
+        }
+    }
+
+    private bool DeviceIOControlBoxed<TOutput>(
+        Kernel32.IOControlCode ioControlCode,
+        object inBuffer,
+        ref TOutput[] outBuffer)
+        where TOutput : struct
+    {
+        IntPtr inPtr = BoxedStructureToPtr(inBuffer, out uint inSize);
+        try
+        {
+            return DeviceIOControlWithInput(ioControlCode, inPtr, inSize, ref outBuffer);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(inPtr);
+        }
+    }
+
+    private bool DeviceIOControlCore(
+        Kernel32.IOControlCode ioControlCode,
+        IntPtr inBuffer,
+        uint inBufferSize,
+        IntPtr outBuffer,
+        uint outBufferSize)
+    {
+        return Kernel32.DeviceIoControl(
+            _device,
+            ioControlCode.Code,
+            inBuffer,
+            inBufferSize,
+            outBuffer,
+            outBufferSize,
+            out uint _,
+            IntPtr.Zero);
+    }
+
+    private static IntPtr StructureToPtr<T>(T value, out uint size)
+        where T : struct
+    {
+        int byteCount = Marshal.SizeOf<T>();
+        IntPtr ptr = Marshal.AllocHGlobal(byteCount);
+        Marshal.StructureToPtr(value, ptr, false);
+        size = (uint)byteCount;
+        return ptr;
+    }
+
+    private static IntPtr BoxedStructureToPtr(object value, out uint size)
+    {
+        int byteCount = Marshal.SizeOf(value);
+        IntPtr ptr = Marshal.AllocHGlobal(byteCount);
+        Marshal.StructureToPtr(value, ptr, false);
+        size = (uint)byteCount;
+        return ptr;
     }
 
     public void Close()

--- a/LibreHardwareMonitorLib/Hardware/Ring0.cs
+++ b/LibreHardwareMonitorLib/Hardware/Ring0.cs
@@ -393,21 +393,23 @@ internal static class Ring0
     }
 
     public static bool ReadMemory<T>(ulong address, ref T buffer)
+        where T : struct
     {
         if (_driver == null)
             return false;
 
         ReadMemoryInput input = new() { Address = address, UnitSize = 1, Count = (uint)Marshal.SizeOf(buffer) };
-        return _driver.DeviceIOControl(Interop.Ring0.IOCTL_OLS_READ_MEMORY, input, ref buffer);
+        return _driver.DeviceIOControl<ReadMemoryInput, T>(Interop.Ring0.IOCTL_OLS_READ_MEMORY, input, ref buffer);
     }
 
     public static bool ReadMemory<T>(ulong address, ref T[] buffer)
+        where T : struct
     {
         if (_driver == null)
             return false;
 
         ReadMemoryInput input = new() { Address = address, UnitSize = (uint)Marshal.SizeOf(typeof(T)), Count = (uint)buffer.Length };
-        return _driver.DeviceIOControl(Interop.Ring0.IOCTL_OLS_READ_MEMORY, input, ref buffer);
+        return _driver.DeviceIOControl<ReadMemoryInput, T>(Interop.Ring0.IOCTL_OLS_READ_MEMORY, input, ref buffer);
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]

--- a/LibreHardwareMonitorLib/Interop/Kernel32.cs
+++ b/LibreHardwareMonitorLib/Interop/Kernel32.cs
@@ -370,6 +370,20 @@ public class Kernel32
 
     [DllImport(DllName, CallingConvention = CallingConvention.Winapi, SetLastError = true)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool DeviceIoControl
+    (
+        SafeFileHandle device,
+        uint ioControlCode,
+        IntPtr inBuffer,
+        uint inBufferSize,
+        IntPtr outBuffer,
+        uint nOutBufferSize,
+        out uint bytesReturned,
+        IntPtr overlapped);
+
+    [DllImport(DllName, CallingConvention = CallingConvention.Winapi, SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     internal static extern IntPtr CreateFile
     (
         string lpFileName,


### PR DESCRIPTION
My motivation for these changes is to fix fan sensor data when compiling with .NET Native AOT. This currently fails because fan sensor detection can use Ring0 driver IOCTL calls, and `KernelDriver.DeviceIOControl` passes buffers through `object` parameters with `[MarshalAs(UnmanagedType.AsAny)]`. That works in normal JIT builds, but Native AOT cannot support that dynamic marshalling path for private structs such as `Ring0.WriteIoPortInput`.

The fix is to update the Ring0 path to avoid `AsAny` marshalling entirely:

- Added a `DeviceIoControl` P/Invoke overload that accepts raw `IntPtr` input/output buffers.
- Added typed `DeviceIOControl<TInput>` and `DeviceIOControl<TInput, TOutput>` handling in `KernelDriver`.
- Marshalled structs explicitly with `Marshal.StructureToPtr<T>` and `Marshal.PtrToStructure<T>`.
- Kept primitive/object fallback behavior for existing callers.
- Constrained `Ring0.ReadMemory<T>` to `where T : struct` so Native AOT has a concrete, typed marshalling path.

Before these changes, `KernelDriver` called `Kernel32.DeviceIoControl(...)` with `object inBuffer` and boxed output objects, which depended on the P/Invoke layer figuring out the input/output struct shape at runtime. The IOCTL behavior itself is unchanged; this only changes how the buffers are marshalled across the managed/native boundary.