### PR TITLE
Fix PawnIO installer extraction (silent fail) due to resource namespace mismatch in MainForm

### DIFF
--- a/LibreHardwareMonitor.Windows.Forms/UI/MainForm.cs
+++ b/LibreHardwareMonitor.Windows.Forms/UI/MainForm.cs
@@ -204,7 +204,7 @@ public sealed partial class MainForm : Form
             try
             {
 
-                using Stream resourceStream = typeof(MainForm).Assembly.GetManifestResourceStream("LibreHardwareMonitor.Resources.PawnIO_setup.exe");
+                using Stream resourceStream = typeof(MainForm).Assembly.GetManifestResourceStream("LibreHardwareMonitor.Windows.Forms.Resources.PawnIO_setup.exe");
                 using FileStream fileStream = new(destination, FileMode.Create, FileAccess.Write);
                 resourceStream.CopyTo(fileStream);
 


### PR DESCRIPTION

I am a new user without PawnIO already installed, so I wanted to install the bundled PawnIO driver but the install silently failed.   
I discovered and fixed a namespace mismatch in `MainForm.cs`.

**TL;DR:** 
PawnIO installer extraction fails silently on startup because the code looks for the embedded resource using the wrong namespace path.

**What was happening:**
When LHM prompts to install PawnIO, it attempts to extract the embedded `PawnIO_setup.exe` to the current directory and run it. However, the installation helper was silently failing to extract the file, even when running the app as Administrator.

**Reason**
In `MainForm.cs`, the code was calling:

```csharp
typeof(MainForm).Assembly.GetManifestResourceStream("LibreHardwareMonitor.Resources.PawnIO_setup.exe");
```

Since the Windows Forms project has the root namespace/assembly name LibreHardwareMonitor.Windows.Forms, the resource is actually compiled into the assembly under: `LibreHardwareMonitor.Windows.Forms.Resources.PawnIO_setup.exe`

Because of the incorrect namespace path, GetManifestResourceStream returned null, which caused the extraction to fail silently in the try-catch block and abort the install process entirely.

PR Fix: Updated the resource name string in MainForm.cs to match the actual manifest resource path (LibreHardwareMonitor.Windows.Forms.Resources.PawnIO_setup.exe). I verified that the setup now successfully extracts, launches, and installs PawnIO when prompted (on my machine anyway).