### PR TITLE
Probe-based CCD temperature detection for Ryzen CPUs

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Controller/MSI/MsiCoreLiquidController.cs
+++ b/LibreHardwareMonitorLib/Hardware/Controller/MSI/MsiCoreLiquidController.cs
@@ -88,6 +88,14 @@ internal class MsiCoreLiquidController : Hardware
         AddSensor("Temperature Sensor 1", 2, SensorType.Temperature, m => m.TemperatureSensor1 == 125 ? -100 : m.TemperatureSensor1);
         AddSensor("Temperature Sensor 2", 3, SensorType.Temperature, m => m.TemperatureSensor2 == 125 ? -100 : m.TemperatureSensor2);
 
+        //Fan Controls
+        TryAddFanControl(_fan1);
+        TryAddFanControl(_fan2);
+        TryAddFanControl(_fan3);
+        TryAddFanControl(_fan4);
+        TryAddFanControl(_fan5);
+        return;
+
         void TryAddFanControl(Sensor fan)
         {
             if (fan != null)
@@ -128,13 +136,6 @@ internal class MsiCoreLiquidController : Hardware
                 }
             }
         }
-
-        //Fan Controls
-        TryAddFanControl(_fan1);
-        TryAddFanControl(_fan2);
-        TryAddFanControl(_fan3);
-        TryAddFanControl(_fan4);
-        TryAddFanControl(_fan5);
     }
 
     private MsiSensor AddSensor(string name, int index, SensorType sensorType, GetMsiSensorValue getValue)

--- a/LibreHardwareMonitorLib/Hardware/Cpu/Amd10Cpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/Amd10Cpu.cs
@@ -285,10 +285,6 @@ internal sealed class Amd10Cpu : AmdCpu
                     _coreClocks[i].Value = (float)TimeStampCounterFrequency;
                 }
 
-                float SVI2Volt(uint vid) => vid < 0b1111_1000 ? 1.5500f - (0.00625f * vid) : 0;
-
-                float SVI1Volt(uint vid) => vid < 0x7C ? 1.550f - (0.0125f * vid) : 0;
-
                 float newCoreVoltage, newNbVoltage;
                 uint coreVid60 = (curEax >> 9) & 0x7F;
                 if (_isSvi2)
@@ -307,6 +303,11 @@ internal sealed class Amd10Cpu : AmdCpu
 
                 if (newNbVoltage > maxNbVoltage)
                     maxNbVoltage = newNbVoltage;
+                continue;
+
+                float SVI2Volt(uint vid) => vid < 0b1111_1000 ? 1.5500f - (0.00625f * vid) : 0;
+
+                float SVI1Volt(uint vid) => vid < 0x7C ? 1.550f - (0.0125f * vid) : 0;
             }
 
             _coreVoltage.Value = maxCoreVoltage;

--- a/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
@@ -120,10 +120,36 @@ internal sealed class Amd17Cpu : AmdCpu
         private readonly Dictionary<KeyValuePair<uint, RyzenSMU.SmuSensorType>, Sensor> _smuSensors = new();
         private readonly Sensor _socVoltage;
 
+        private uint _ccdTemperatureRegister;
         private Sensor _ccdsAverageTemperature;
         private Sensor _ccdsMaxTemperature;
         private DateTime _lastSampleTime = new(0);
         private uint _lastPwrValue;
+
+        private static readonly uint[] _ccdTemperatureRegisterCandidates =
+        [
+            ZEN_CCD_TEMP_REGISTER_308,
+            ZEN_CCD_TEMP_REGISTER_300,
+            ZEN_CCD_TEMP_REGISTER_154
+        ];
+
+        private static readonly uint[] _family1AhModel00HCcdTemperatureRegisterCandidates =
+        [
+            ZEN_CCD_TEMP_REGISTER_1F0,
+            ZEN_CCD_TEMP_REGISTER_308,
+            ZEN_CCD_TEMP_REGISTER_300,
+            ZEN_CCD_TEMP_REGISTER_154
+        ];
+
+        private static readonly Dictionary<uint, uint[]> _ccdKnownTemperatureRegisterMappingsByCpu = new()
+        {
+            { GetCpuModelKey(0x17, 0x31), [ZEN_CCD_TEMP_REGISTER_154] }, // Threadripper 3000.
+            { GetCpuModelKey(0x17, 0x71), [ZEN_CCD_TEMP_REGISTER_154] }, // Zen 2.
+            { GetCpuModelKey(0x19, 0x21), [ZEN_CCD_TEMP_REGISTER_154] }, // Zen 3.
+            { GetCpuModelKey(0x19, 0x61), [ZEN_CCD_TEMP_REGISTER_308] }, // Zen 4.
+            { GetCpuModelKey(0x1A, 0x08), [ZEN_CCD_TEMP_REGISTER_1F0] }, // Threadripper 9000.
+            { GetCpuModelKey(0x1A, 0x44), [ZEN_CCD_TEMP_REGISTER_308] } // Zen 5.
+        };
 
         public Processor(Hardware hardware)
         {
@@ -133,7 +159,7 @@ internal sealed class Amd17Cpu : AmdCpu
             _coreTemperatureTctl = new Sensor("Core (Tctl)", _cpu._sensorTypeIndex[SensorType.Temperature]++, SensorType.Temperature, _cpu, _cpu._settings);
             _coreTemperatureTdie = new Sensor("Core (Tdie)", _cpu._sensorTypeIndex[SensorType.Temperature]++, SensorType.Temperature, _cpu, _cpu._settings);
             _coreTemperatureTctlTdie = new Sensor("Core (Tctl/Tdie)", _cpu._sensorTypeIndex[SensorType.Temperature]++, SensorType.Temperature, _cpu, _cpu._settings);
-            _ccdTemperatures = new Sensor[8]; // Hardcoded until there's a way to get max CCDs.
+            _ccdTemperatures = new Sensor[MAX_CCD_TEMPERATURE_SENSORS]; // Hardcoded until there's a way to get max CCDs.
             _coreVoltage = new Sensor("Core (SVI2 TFN)", _cpu._sensorTypeIndex[SensorType.Voltage]++, SensorType.Voltage, _cpu, _cpu._settings);
             _socVoltage = new Sensor("SoC (SVI2 TFN)", _cpu._sensorTypeIndex[SensorType.Voltage]++, SensorType.Voltage, _cpu, _cpu._settings);
             _busClock = new Sensor("Bus Speed", _cpu._sensorTypeIndex[SensorType.Clock]++, SensorType.Clock, _cpu, _cpu._settings);
@@ -193,8 +219,6 @@ internal sealed class Amd17Cpu : AmdCpu
                 // SVI0_TFN_PLANE1 [1]
                 smuSvi0Tfn = _cpu._pawnModule.ReadSmn(F17H_M01H_SVI + 0x8);
 
-                bool supportsPerCcdTemperatures = false;
-
                 // TODO: find a better way because these will probably keep changing in the future.
 
                 uint sviPlane0Offset;
@@ -204,21 +228,18 @@ internal sealed class Amd17Cpu : AmdCpu
                     case 0x31: // Threadripper 3000.
                         sviPlane0Offset = F17H_M01H_SVI + 0x14;
                         sviPlane1Offset = F17H_M01H_SVI + 0x10;
-                        supportsPerCcdTemperatures = true;
                         break;
 
                     case 0x71: // Zen 2.
                     case 0x21: // Zen 3.
                         sviPlane0Offset = F17H_M01H_SVI + 0x10;
                         sviPlane1Offset = F17H_M01H_SVI + 0xC;
-                        supportsPerCcdTemperatures = true;
                         break;
 
                     case 0x61: //Zen 4
                     case 0x44: //Zen 5
                         sviPlane0Offset = F17H_M01H_SVI + 0x10;
                         sviPlane1Offset = F17H_M01H_SVI + 0xC;
-                        supportsPerCcdTemperatures = true;
                         break;
 
                     default: // Zen and Zen+.
@@ -307,62 +328,9 @@ internal sealed class Amd17Cpu : AmdCpu
                     _cpu.ActivateSensor(_coreTemperatureTctlTdie);
                 }
 
-                // Tested only on R5 3600 & Threadripper 3960X, 5900X, 7900X
-                if (supportsPerCcdTemperatures)
-                {
-                    for (uint i = 0; i < _ccdTemperatures.Length; i++)
-                    {
-                        uint ccd1Offset = 0;
-                        if (cpuId.Model is 0x61 or 0x44) // Raphael or GraniteRidge
-                            ccd1Offset = F17H_M61H_CCD1_TEMP + i * 0x4;
-                        else
-                            ccd1Offset = F17H_M70H_CCD1_TEMP + i * 0x4;
-                        uint ccdRawTemp = _cpu._pawnModule.ReadSmn(ccd1Offset);
-
-                        ccdRawTemp &= 0xFFF;
-                        float ccdTemp = ((ccdRawTemp * 125) - 305000) * 0.001f;
-                        if (ccdRawTemp > 0 && ccdTemp < 125) // Zen 2 reports 95 degrees C max, but it might exceed that.
-                        {
-                            if (_ccdTemperatures[i] == null)
-                            {
-                                _cpu.ActivateSensor(_ccdTemperatures[i] = new Sensor($"CCD{i + 1} (Tdie)",
-                                                                                     _cpu._sensorTypeIndex[SensorType.Temperature]++,
-                                                                                     SensorType.Temperature,
-                                                                                     _cpu,
-                                                                                     _cpu._settings));
-                            }
-
-                            _ccdTemperatures[i].Value = ccdTemp;
-                        }
-                    }
-
-                    Sensor[] activeCcds = _ccdTemperatures.Where(x => x != null).ToArray();
-                    if (activeCcds.Length > 1)
-                    {
-                        // No need to get the max / average ccds temp if there is only one CCD.
-
-                        if (_ccdsMaxTemperature == null)
-                        {
-                            _cpu.ActivateSensor(_ccdsMaxTemperature = new Sensor("CCDs Max (Tdie)",
-                                                                                 _cpu._sensorTypeIndex[SensorType.Temperature]++,
-                                                                                 SensorType.Temperature,
-                                                                                 _cpu,
-                                                                                 _cpu._settings));
-                        }
-
-                        if (_ccdsAverageTemperature == null)
-                        {
-                            _cpu.ActivateSensor(_ccdsAverageTemperature = new Sensor("CCDs Average (Tdie)",
-                                                                                     _cpu._sensorTypeIndex[SensorType.Temperature]++,
-                                                                                     SensorType.Temperature,
-                                                                                     _cpu,
-                                                                                     _cpu._settings));
-                        }
-
-                        _ccdsMaxTemperature.Value = activeCcds.Max(x => x.Value);
-                        _ccdsAverageTemperature.Value = activeCcds.Average(x => x.Value);
-                    }
-                }
+                uint ccdTemperatureRegister = GetCcdTemperatureRegister(cpuId);
+                if (ccdTemperatureRegister != 0)
+                    UpdateCcdTemperatureSensors(ccdTemperatureRegister);
 
                 Mutexes.ReleasePciBus();
             }
@@ -428,6 +396,187 @@ internal sealed class Amd17Cpu : AmdCpu
 
             clock = Nodes.Average(x => x.EffectiveClock);
             _avgClockEffcetive.Value = (float)Math.Round(clock, 0);
+        }
+
+        /// <summary>
+        /// Gets the first CCD temperature SMN register for the current processor.
+        /// </summary>
+        private uint GetCcdTemperatureRegister(CpuId cpuId)
+        {
+            if (_ccdTemperatureRegister != 0)
+                return _ccdTemperatureRegister;
+
+            _ccdTemperatureRegister = ProbeCcdTemperatureRegister(cpuId);
+            return _ccdTemperatureRegister;
+        }
+
+        /// <summary>
+        /// Finds the CCD temperature register layout exposed by this Zen processor.
+        /// </summary>
+        private uint ProbeCcdTemperatureRegister(CpuId cpuId)
+        {
+            uint bestRegister = 0;
+            int bestLeadingValidCount = 0;
+            int bestValidCount = 0;
+            int bestFirstValidIndex = MAX_CCD_TEMPERATURE_SENSORS;
+            uint[] candidateRegisters = GetCcdTemperatureRegisterCandidates(cpuId);
+
+            foreach (uint candidateRegister in candidateRegisters)
+            {
+                int leadingValidCount = 0;
+                int validCount = 0;
+                int firstValidIndex = MAX_CCD_TEMPERATURE_SENSORS;
+
+                for (int i = 0; i < MAX_CCD_TEMPERATURE_SENSORS; i++)
+                {
+                    uint register = candidateRegister + ((uint)i * CCD_TEMPERATURE_REGISTER_STRIDE);
+                    if (!TryReadSmn(register, out uint rawTemperature))
+                        continue;
+
+                    if (!TryDecodeCcdTemperature(rawTemperature, out _))
+                        continue;
+
+                    validCount++;
+                    if (firstValidIndex == MAX_CCD_TEMPERATURE_SENSORS)
+                        firstValidIndex = i;
+
+                    if (i == leadingValidCount)
+                        leadingValidCount++;
+                }
+
+                bool isBetterRegister = leadingValidCount > bestLeadingValidCount
+                                        || (leadingValidCount == bestLeadingValidCount && validCount > bestValidCount)
+                                        || (leadingValidCount == bestLeadingValidCount && validCount == bestValidCount && firstValidIndex < bestFirstValidIndex);
+
+                if (!isBetterRegister)
+                    continue;
+
+                bestRegister = candidateRegister;
+                bestLeadingValidCount = leadingValidCount;
+                bestValidCount = validCount;
+                bestFirstValidIndex = firstValidIndex;
+            }
+
+            return bestValidCount > 0 ? bestRegister : 0;
+        }
+
+        /// <summary>
+        /// Gets CCD temperature register candidates for the processor family and model.
+        /// </summary>
+        private static uint[] GetCcdTemperatureRegisterCandidates(CpuId cpuId)
+        {
+            uint cpuModelKey = GetCpuModelKey(cpuId.Family, cpuId.Model);
+            if (_ccdKnownTemperatureRegisterMappingsByCpu.TryGetValue(cpuModelKey, out uint[] candidates))
+                return candidates;
+
+            if (cpuId.Family == 0x1A && cpuId.Model <= 0x0F)
+                return _family1AhModel00HCcdTemperatureRegisterCandidates;
+
+            return _ccdTemperatureRegisterCandidates;
+        }
+
+        /// <summary>
+        /// Gets a lookup key for CPU family and model specific CCD temperature candidates.
+        /// </summary>
+        private static uint GetCpuModelKey(uint family, uint model)
+        {
+            return (family << 16) | model;
+        }
+
+        /// <summary>
+        /// Updates CCD temperature sensors from the resolved SMN register layout.
+        /// </summary>
+        private void UpdateCcdTemperatureSensors(uint ccdTemperatureRegister)
+        {
+            int activeCcdCount = 0;
+            float ccdTemperatureTotal = 0;
+            float ccdTemperatureMax = 0;
+
+            for (int i = 0; i < _ccdTemperatures.Length; i++)
+            {
+                uint register = ccdTemperatureRegister + ((uint)i * CCD_TEMPERATURE_REGISTER_STRIDE);
+                if (!TryReadSmn(register, out uint rawTemperature))
+                    continue;
+
+                if (!TryDecodeCcdTemperature(rawTemperature, out float ccdTemperature))
+                    continue;
+
+                if (_ccdTemperatures[i] == null)
+                {
+                    _cpu.ActivateSensor(_ccdTemperatures[i] = new Sensor($"CCD{i} (Tdie)",
+                                                                         _cpu._sensorTypeIndex[SensorType.Temperature]++,
+                                                                         SensorType.Temperature,
+                                                                         _cpu,
+                                                                         _cpu._settings));
+                }
+
+                _ccdTemperatures[i].Value = ccdTemperature;
+
+                activeCcdCount++;
+                ccdTemperatureTotal += ccdTemperature;
+                if (activeCcdCount == 1 || ccdTemperature > ccdTemperatureMax)
+                    ccdTemperatureMax = ccdTemperature;
+            }
+
+            if (activeCcdCount <= 1)
+                return;
+
+            // No need to get the max / average CCD temp if there is only one CCD.
+            if (_ccdsMaxTemperature == null)
+            {
+                _cpu.ActivateSensor(_ccdsMaxTemperature = new Sensor("CCDs Max (Tdie)",
+                                                                     _cpu._sensorTypeIndex[SensorType.Temperature]++,
+                                                                     SensorType.Temperature,
+                                                                     _cpu,
+                                                                     _cpu._settings));
+            }
+
+            if (_ccdsAverageTemperature == null)
+            {
+                _cpu.ActivateSensor(_ccdsAverageTemperature = new Sensor("CCDs Average (Tdie)",
+                                                                         _cpu._sensorTypeIndex[SensorType.Temperature]++,
+                                                                         SensorType.Temperature,
+                                                                         _cpu,
+                                                                         _cpu._settings));
+            }
+
+            _ccdsMaxTemperature.Value = ccdTemperatureMax;
+            _ccdsAverageTemperature.Value = ccdTemperatureTotal / activeCcdCount;
+        }
+
+        /// <summary>
+        /// Converts a raw CCD temperature register value to Celsius.
+        /// </summary>
+        private static bool TryDecodeCcdTemperature(uint rawTemperature, out float ccdTemperature)
+        {
+            ccdTemperature = 0;
+
+            if ((rawTemperature & CCD_TEMPERATURE_VALID_MASK) == 0)
+                return false;
+
+            int rawTemperatureValue = (int)(rawTemperature & CCD_TEMPERATURE_VALUE_MASK);
+            int temperatureMilliCelsius = (rawTemperatureValue * CCD_TEMPERATURE_SCALE_MILLI_CELSIUS) - CCD_TEMPERATURE_OFFSET_MILLI_CELSIUS;
+            ccdTemperature = temperatureMilliCelsius * 0.001f;
+
+            return ccdTemperature is > CCD_TEMPERATURE_MIN and < CCD_TEMPERATURE_MAX;
+        }
+
+        /// <summary>
+        /// Reads an SMN register without failing the entire CPU update path.
+        /// </summary>
+        private bool TryReadSmn(uint register, out uint value)
+        {
+            try
+            {
+                value = _cpu._pawnModule.ReadSmn(register);
+                return true;
+            }
+            catch
+            {
+                // Some Zen SMN CCD temperature windows are sparse across products.
+                value = 0;
+                return false;
+            }
         }
 
         private double GetTimeStampCounterMultiplier()
@@ -812,6 +961,13 @@ internal sealed class Amd17Cpu : AmdCpu
 
     // ReSharper disable InconsistentNaming
     private const uint COFVID_STATUS = 0xC0010071;
+    private const uint CCD_TEMPERATURE_REGISTER_STRIDE = 0x4;
+    private const uint CCD_TEMPERATURE_VALID_MASK = 0x800;
+    private const uint CCD_TEMPERATURE_VALUE_MASK = 0x7FF;
+    private const int CCD_TEMPERATURE_SCALE_MILLI_CELSIUS = 125;
+    private const int CCD_TEMPERATURE_OFFSET_MILLI_CELSIUS = 49000;
+    private const float CCD_TEMPERATURE_MIN = -50.0f;
+    private const float CCD_TEMPERATURE_MAX = 125.0f;
     private const uint F17H_M01H_SVI = 0x0005A000;
     private const uint F17H_M01H_THM_TCON_CUR_TMP = 0x00059800;
     private const uint F17H_M70H_CCD1_TEMP = 0x00059954;
@@ -819,6 +975,7 @@ internal sealed class Amd17Cpu : AmdCpu
     private const uint F17H_TEMP_RANGE_SEL_MASK = 0x80000;
     private const uint F17H_TEMP_TJ_SEL_MASK = 0x30000;
     private const uint FAMILY_17H_PCI_CONTROL_REGISTER = 0x60;
+    private const int MAX_CCD_TEMPERATURE_SENSORS = 16;
     private const uint HWCR = 0xC0010015;
     private const uint MSR_CORE_ENERGY_STAT = 0xC001029A;
     private const uint MSR_HARDWARE_PSTATE_STATUS = 0xC0010293;
@@ -830,5 +987,9 @@ internal sealed class Amd17Cpu : AmdCpu
     private const uint MSR_APERF_RO = 0xC000_00E8;
     private const uint PERF_CTL_0 = 0xC0010000;
     private const uint PERF_CTR_0 = 0xC0010004;
+    private const uint ZEN_CCD_TEMP_REGISTER_154 = 0x00059954;
+    private const uint ZEN_CCD_TEMP_REGISTER_1F0 = 0x000599F0;
+    private const uint ZEN_CCD_TEMP_REGISTER_300 = 0x00059B00;
+    private const uint ZEN_CCD_TEMP_REGISTER_308 = 0x00059B08;
     // ReSharper restore InconsistentNaming
 }

--- a/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
@@ -117,7 +117,7 @@ internal sealed class Amd17Cpu : AmdCpu
         private readonly Sensor _coreVoltage;
         private readonly Amd17Cpu _cpu;
         private readonly Sensor _packagePower;
-        private readonly Dictionary<KeyValuePair<uint, RyzenSMU.SmuSensorType>, Sensor> _smuSensors = new();
+        private readonly Dictionary<KeyValuePair<uint, RyzenSMU.SmuSensorType>, Sensor> _smuSensors = [];
         private readonly Sensor _socVoltage;
 
         private uint _ccdTemperatureRegister;
@@ -156,9 +156,9 @@ internal sealed class Amd17Cpu : AmdCpu
             _cpu = (Amd17Cpu)hardware;
 
             _packagePower = new Sensor("Package", _cpu._sensorTypeIndex[SensorType.Power]++, SensorType.Power, _cpu, _cpu._settings);
-            _coreTemperatureTctl = new Sensor("Core (Tctl)", _cpu._sensorTypeIndex[SensorType.Temperature]++, SensorType.Temperature, _cpu, _cpu._settings);
-            _coreTemperatureTdie = new Sensor("Core (Tdie)", _cpu._sensorTypeIndex[SensorType.Temperature]++, SensorType.Temperature, _cpu, _cpu._settings);
-            _coreTemperatureTctlTdie = new Sensor("Core (Tctl/Tdie)", _cpu._sensorTypeIndex[SensorType.Temperature]++, SensorType.Temperature, _cpu, _cpu._settings);
+            _coreTemperatureTctl = new Sensor("Package (Tctl)", _cpu._sensorTypeIndex[SensorType.Temperature]++, SensorType.Temperature, _cpu, _cpu._settings);
+            _coreTemperatureTdie = new Sensor("Package (Tdie)", _cpu._sensorTypeIndex[SensorType.Temperature]++, SensorType.Temperature, _cpu, _cpu._settings);
+            _coreTemperatureTctlTdie = new Sensor("Package (Tctl/Tdie)", _cpu._sensorTypeIndex[SensorType.Temperature]++, SensorType.Temperature, _cpu, _cpu._settings);
             _ccdTemperatures = new Sensor[MAX_CCD_TEMPERATURE_SENSORS]; // Hardcoded until there's a way to get max CCDs.
             _coreVoltage = new Sensor("Core (SVI2 TFN)", _cpu._sensorTypeIndex[SensorType.Voltage]++, SensorType.Voltage, _cpu, _cpu._settings);
             _socVoltage = new Sensor("SoC (SVI2 TFN)", _cpu._sensorTypeIndex[SensorType.Voltage]++, SensorType.Voltage, _cpu, _cpu._settings);
@@ -176,7 +176,7 @@ internal sealed class Amd17Cpu : AmdCpu
             }
         }
 
-        public List<NumaNode> Nodes { get; } = new();
+        public List<NumaNode> Nodes { get; } = [];
 
         public void UpdateSensors()
         {
@@ -261,7 +261,7 @@ internal sealed class Amd17Cpu : AmdCpu
                 TimeSpan deltaTime = sampleTime - _lastSampleTime;
                 if (_lastSampleTime.Ticks == 0)
                 {
-                    deltaTime = new(0);
+                    deltaTime = new TimeSpan(0);
                     _lastSampleTime = sampleTime;
                     _lastPwrValue = totalEnergy;
                 }
@@ -620,20 +620,11 @@ internal sealed class Amd17Cpu : AmdCpu
         }
     }
 
-    private class NumaNode
+    private class NumaNode(Amd17Cpu cpu, int id)
     {
-        private readonly Amd17Cpu _cpu;
+        public List<Core> Cores { get; } = [];
 
-        public NumaNode(Amd17Cpu cpu, int id)
-        {
-            Cores = new List<Core>();
-            NodeId = id;
-            _cpu = cpu;
-        }
-
-        public List<Core> Cores { get; }
-
-        public int NodeId { get; }
+        public int NodeId { get; } = id;
 
         public double CoreClock
         {
@@ -669,7 +660,7 @@ internal sealed class Amd17Cpu : AmdCpu
 
             if (core == null)
             {
-                core = new Core(_cpu, coreId);
+                core = new Core(cpu, coreId);
                 Cores.Add(core);
             }
 
@@ -681,32 +672,22 @@ internal sealed class Amd17Cpu : AmdCpu
         { }
     }
 
-    private class CpuThread
+    private class CpuThread(Amd17Cpu cpu, CpuId cpuId)
     {
         private DateTime _sampleTime = new(0);
         private DateTime _lastSampleTime = new(0);
-        private ulong _mperf = 0;
-        private ulong _aperf = 0;
-        private ulong _mperfLast = 0;
-        private ulong _aperfLast = 0;
-        private ulong _mperfDelta = 0;
-        private ulong _aperfDelta = 0;
+        private ulong _mperf;
+        private ulong _aperf;
+        private ulong _mperfLast;
+        private ulong _aperfLast;
 
-        private CpuId _cpuId;
-        private Amd17Cpu _cpu;
-        public CpuId Cpu { get { return _cpuId; } }
+        public CpuId Cpu { get { return cpuId; } }
 
-        public TimeSpan SampleDuration { get; private set; }= TimeSpan.Zero;
-        public double EffectiveClock { get; private set; } = 0;
+        private TimeSpan SampleDuration { get; set; }= TimeSpan.Zero;
+        public double EffectiveClock { get; private set; }
 
-        public ulong MperfDelta { get {  return _mperfDelta; } }
-        public ulong AperfDelta { get { return _aperfDelta; } }
-
-        public CpuThread(Amd17Cpu cpu, CpuId cpuId)
-        {
-            _cpu = cpu;
-            _cpuId = cpuId;
-        }
+        public ulong MperfDelta { get; private set; }
+        public ulong AperfDelta { get; private set; }
 
         public void ReadPerformanceCounter()
         {
@@ -716,10 +697,10 @@ internal sealed class Amd17Cpu : AmdCpu
 
             // performance counter
             // MSRC000_00E7, P0 state counter
-            _cpu._pawnModule.ReadMsr(MSR_MPERF_RO, out ulong edxeax);
+            cpu._pawnModule.ReadMsr(MSR_MPERF_RO, out ulong edxeax);
             _mperf = edxeax;
             // MSRC000_00E8, C0 state counter
-            _cpu._pawnModule.ReadMsr(MSR_APERF_RO, out edxeax);
+            cpu._pawnModule.ReadMsr(MSR_APERF_RO, out edxeax);
             _aperf = edxeax;
         }
 
@@ -728,7 +709,7 @@ internal sealed class Amd17Cpu : AmdCpu
             if (_mperf < _mperfLast || _aperf < _aperfLast)
             {
                 // current measurment is invalid when _mperf or _aperf overflow
-                _lastSampleTime = new(0);
+                _lastSampleTime = new DateTime(0);
             }
 
             if (_lastSampleTime.Ticks == 0)
@@ -737,39 +718,39 @@ internal sealed class Amd17Cpu : AmdCpu
                 _mperfLast = _mperf;
                 _aperfLast = _aperf;
 
-                _mperfDelta = 0;
-                _aperfDelta = 0;
+                MperfDelta = 0;
+                AperfDelta = 0;
                 return;
             }
 
             SampleDuration = _sampleTime - _lastSampleTime;
             _lastSampleTime = _sampleTime;
 
-            _mperfDelta = _mperf - _mperfLast;
-            _aperfDelta = _aperf - _aperfLast;
+            MperfDelta = _mperf - _mperfLast;
+            AperfDelta = _aperf - _aperfLast;
             _mperfLast = _mperf;
             _aperfLast = _aperf;
 
-            if (_mperfDelta > 20000e6)
-                _mperfDelta = 0;
-            if (_aperfDelta > 20000e6)
-                _aperfDelta = 0;
+            if (MperfDelta > 20000e6)
+                MperfDelta = 0;
+            if (AperfDelta > 20000e6)
+                AperfDelta = 0;
 
-            if(_aperfDelta == 0 || _mperfDelta == 0)
+            if(AperfDelta == 0 || MperfDelta == 0)
             {
                 //overflow possible, numbers are > 20 GHz
-                _lastSampleTime = new(0);
+                _lastSampleTime = new DateTime(0);
                 return;
             }
 
             //effective clock
-            double freq = (double)_aperfDelta / (SampleDuration.TotalMilliseconds * 1000.0);
+            double freq = AperfDelta / (SampleDuration.TotalMilliseconds * 1000.0);
             EffectiveClock = Math.Round(freq);
         }
 
         public bool HasValidCounters()
         {
-            return _mperfDelta > 0 && _aperfDelta > 0 && SampleDuration.Ticks > 0;
+            return MperfDelta > 0 && AperfDelta > 0 && SampleDuration.Ticks > 0;
         }
     }
 
@@ -783,10 +764,10 @@ internal sealed class Amd17Cpu : AmdCpu
         private readonly Sensor _vcore;
         private ISensor _busSpeed;
         private DateTime _lastSampleTime = new(0);
-        private uint _lastPwrValue = 0;
+        private uint _lastPwrValue;
 
-        public double CoreClock { get; set; } = 0;
-        public double EffectiveClock { get; set; } = 0;
+        public double CoreClock { get; private set; }
+        public double EffectiveClock { get; private set; }
 
         public Core(Amd17Cpu cpu, int id)
         {
@@ -807,11 +788,11 @@ internal sealed class Amd17Cpu : AmdCpu
 
         public int CoreId { get; }
 
-        public List<CpuThread> Threads { get; } = new List<CpuThread>();
+        public List<CpuThread> Threads { get; } = [];
 
         public void AppedThread(CpuId cpuId)
         {
-            CpuThread t = new CpuThread(_cpu, cpuId);
+            CpuThread t = new(_cpu, cpuId);
             Threads.Add(t);
         }
 
@@ -847,7 +828,7 @@ internal sealed class Amd17Cpu : AmdCpu
             uint msrPstate = eax;
             int curCpuVid = (int)((eax >> 14) & 0xff);
 
-            foreach(var t in Threads)
+            foreach(CpuThread t in Threads)
             {
                 t.ReadPerformanceCounter();
             }
@@ -877,7 +858,7 @@ internal sealed class Amd17Cpu : AmdCpu
 
             if (thread.HasValidCounters())
             {
-                double coreClock = 0;
+                double coreClock;
                 double busClock = 100.0; //bus speed in MHz
                 _busSpeed ??= _cpu.Sensors.FirstOrDefault(x => x.Name == "Bus Speed");
                 if (_busSpeed?.Value.HasValue == true && _busSpeed.Value > 0)
@@ -914,7 +895,7 @@ internal sealed class Amd17Cpu : AmdCpu
 
                 //clock values valid when AperfDelta < MperfDelta (ratio is < 1.0)
                 if (thread.AperfDelta < thread.MperfDelta)
-                    coreClock = ((double)thread.AperfDelta / (double)thread.MperfDelta) * coreClock;
+                    coreClock = thread.AperfDelta / (double)thread.MperfDelta * coreClock;
 
                 CoreClock = Math.Round(coreClock);
                 _clock.Value = (float)CoreClock;
@@ -930,7 +911,7 @@ internal sealed class Amd17Cpu : AmdCpu
             TimeSpan deltaTime = sampleTime - _lastSampleTime;
             if (_lastSampleTime.Ticks == 0)
             {
-                deltaTime = new(0);
+                deltaTime = new TimeSpan(0);
                 _lastSampleTime = sampleTime;
                 _lastPwrValue = totalEnergy;
             }
@@ -960,7 +941,6 @@ internal sealed class Amd17Cpu : AmdCpu
     }
 
     // ReSharper disable InconsistentNaming
-    private const uint COFVID_STATUS = 0xC0010071;
     private const uint CCD_TEMPERATURE_REGISTER_STRIDE = 0x4;
     private const uint CCD_TEMPERATURE_VALID_MASK = 0x800;
     private const uint CCD_TEMPERATURE_VALUE_MASK = 0x7FF;
@@ -970,23 +950,16 @@ internal sealed class Amd17Cpu : AmdCpu
     private const float CCD_TEMPERATURE_MAX = 125.0f;
     private const uint F17H_M01H_SVI = 0x0005A000;
     private const uint F17H_M01H_THM_TCON_CUR_TMP = 0x00059800;
-    private const uint F17H_M70H_CCD1_TEMP = 0x00059954;
-    private const uint F17H_M61H_CCD1_TEMP = 0x00059b08;
     private const uint F17H_TEMP_RANGE_SEL_MASK = 0x80000;
     private const uint F17H_TEMP_TJ_SEL_MASK = 0x30000;
-    private const uint FAMILY_17H_PCI_CONTROL_REGISTER = 0x60;
     private const int MAX_CCD_TEMPERATURE_SENSORS = 16;
-    private const uint HWCR = 0xC0010015;
     private const uint MSR_CORE_ENERGY_STAT = 0xC001029A;
     private const uint MSR_HARDWARE_PSTATE_STATUS = 0xC0010293;
     private const uint MSR_PKG_ENERGY_STAT = 0xC001029B;
-    private const uint MSR_PSTATE_STATUS = 0xC0010063;
     private const uint MSR_PSTATE_0 = 0xC0010064;
     private const uint MSR_PWR_UNIT = 0xC0010299;
     private const uint MSR_MPERF_RO = 0xC000_00E7;
     private const uint MSR_APERF_RO = 0xC000_00E8;
-    private const uint PERF_CTL_0 = 0xC0010000;
-    private const uint PERF_CTR_0 = 0xC0010004;
     private const uint ZEN_CCD_TEMP_REGISTER_154 = 0x00059954;
     private const uint ZEN_CCD_TEMP_REGISTER_1F0 = 0x000599F0;
     private const uint ZEN_CCD_TEMP_REGISTER_300 = 0x00059B00;

--- a/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
@@ -23,7 +23,7 @@ internal sealed class Amd17Cpu : AmdCpu
         _pawnModule = new AmdFamily17();
 
         _sensorTypeIndex = new Dictionary<SensorType, int>();
-        foreach (SensorType type in Enum.GetValues(typeof(SensorType)))
+        foreach (SensorType type in Enum.GetValues<SensorType>())
         {
             _sensorTypeIndex.Add(type, 0);
         }

--- a/LibreHardwareMonitorLib/Hardware/Gpu/IntelDiscreteGpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Gpu/IntelDiscreteGpu.cs
@@ -149,7 +149,7 @@ internal sealed class IntelDiscreteGpu : GenericGpu
     {
         properties = new IntelGcl.ctl_device_adapter_properties_t
         {
-            Size = (uint)Marshal.SizeOf(typeof(IntelGcl.ctl_device_adapter_properties_t)),
+            Size = (uint)Marshal.SizeOf<IntelGcl.ctl_device_adapter_properties_t>(),
             Version = 2
         };
 
@@ -298,9 +298,9 @@ internal sealed class IntelDiscreteGpu : GenericGpu
         if (!IsValid)
             return false;
 
-        var telemetry = new IntelGcl.ctl_power_telemetry_t
+        IntelGcl.ctl_power_telemetry_t telemetry = new IntelGcl.ctl_power_telemetry_t
         {
-            Size = (uint)Marshal.SizeOf(typeof(IntelGcl.ctl_power_telemetry_t)),
+            Size = (uint)Marshal.SizeOf<IntelGcl.ctl_power_telemetry_t>(),
             Version = 1,
             psu = new IntelGcl.ctl_psu_info_t[IntelGcl.CTL_PSU_COUNT],
             fanSpeed = new IntelGcl.ctl_oc_telemetry_item_t[IntelGcl.CTL_FAN_COUNT]
@@ -326,16 +326,16 @@ internal sealed class IntelDiscreteGpu : GenericGpu
 
         if (result == (int)IntelGcl.ctl_result_t.CTL_RESULT_SUCCESS && freqCount > 0)
         {
-            var freqHandles = new IntelGcl.ctl_freq_handle_t[freqCount];
+            IntelGcl.ctl_freq_handle_t[] freqHandles = new IntelGcl.ctl_freq_handle_t[freqCount];
             result = IntelGcl.ctlEnumFrequencyDomains(_handle, ref freqCount, freqHandles);
 
             if (result == (int)IntelGcl.ctl_result_t.CTL_RESULT_SUCCESS)
             {
                 for (int i = 0; i < freqCount; i++)
                 {
-                    var properties = new IntelGcl.ctl_freq_properties_t
+                    IntelGcl.ctl_freq_properties_t properties = new IntelGcl.ctl_freq_properties_t
                     {
-                        Size = (uint)Marshal.SizeOf(typeof(IntelGcl.ctl_freq_properties_t)),
+                        Size = (uint)Marshal.SizeOf<IntelGcl.ctl_freq_properties_t>(),
                         Version = 0
                     };
 
@@ -344,9 +344,9 @@ internal sealed class IntelDiscreteGpu : GenericGpu
                     if (result == (int)IntelGcl.ctl_result_t.CTL_RESULT_SUCCESS &&
                         properties.type == IntelGcl.ctl_freq_domain_t.CTL_FREQ_DOMAIN_MEMORY)
                     {
-                        var state = new IntelGcl.ctl_freq_state_t
+                        IntelGcl.ctl_freq_state_t state = new IntelGcl.ctl_freq_state_t
                         {
-                            Size = (uint)Marshal.SizeOf(typeof(IntelGcl.ctl_freq_state_t)),
+                            Size = (uint)Marshal.SizeOf<IntelGcl.ctl_freq_state_t>(),
                             Version = 0
                         };
 

--- a/LibreHardwareMonitorLib/Hardware/Memory/MemoryGroup.cs
+++ b/LibreHardwareMonitorLib/Hardware/Memory/MemoryGroup.cs
@@ -6,8 +6,11 @@
 
 using System;
 using System.Collections.Generic;
+#if !DISABLE_RAM_SPD
 using System.Diagnostics;
+#endif
 using System.Text;
+#if !DISABLE_RAM_SPD
 using System.Threading;
 using System.Threading.Tasks;
 using RAMSPDToolkit.I2CSMBus;
@@ -15,6 +18,7 @@ using RAMSPDToolkit.SPD;
 using RAMSPDToolkit.SPD.Enums;
 using RAMSPDToolkit.SPD.Interop.Shared;
 using RAMSPDToolkit.Windows.Driver;
+#endif
 
 namespace LibreHardwareMonitor.Hardware.Memory;
 
@@ -23,21 +27,24 @@ internal class MemoryGroup : IGroup, IHardwareChanged
     private static readonly object _lock = new();
     private List<Hardware> _hardware = [];
 
+#if !DISABLE_RAM_SPD
     private CancellationTokenSource _cancellationTokenSource;
     private Exception _lastException;
     private bool _disposed = false;
+#endif
 
     public MemoryGroup(ISettings settings)
     {
+        _hardware.Add(new VirtualMemory(settings));
+        _hardware.Add(new TotalMemory(settings));
+
+#if !DISABLE_RAM_SPD
         if (DriverManager.Driver is null || !DriverManager.Driver.IsOpen)
         {
             // Assign implementation of IDriver.
             DriverManager.Driver = new RAMSPDToolkitDriver();
             SMBusManager.UseWMI = false;
         }
-
-        _hardware.Add(new VirtualMemory(settings));
-        _hardware.Add(new TotalMemory(settings));
 
         if (DriverManager.Driver == null || !DriverManager.LoadDriver())
         {
@@ -48,6 +55,7 @@ internal class MemoryGroup : IGroup, IHardwareChanged
         {
             StartRetryTask(settings);
         }
+#endif
     }
 
 #pragma warning disable 67
@@ -61,10 +69,12 @@ internal class MemoryGroup : IGroup, IHardwareChanged
     {
         StringBuilder report = new();
         report.AppendLine("Memory Report:");
+#if !DISABLE_RAM_SPD
         if (_lastException != null)
         {
             report.AppendLine($"Error while detecting memory: {_lastException.Message}");
         }
+#endif
 
         foreach (Hardware hardware in _hardware)
         {
@@ -81,9 +91,11 @@ internal class MemoryGroup : IGroup, IHardwareChanged
 
     public void Close()
     {
+#if !DISABLE_RAM_SPD
         _cancellationTokenSource?.Cancel();
         _cancellationTokenSource?.Dispose();
         _cancellationTokenSource = null;
+#endif
 
         lock (_lock)
         {
@@ -91,10 +103,13 @@ internal class MemoryGroup : IGroup, IHardwareChanged
                 ram.Close();
 
             _hardware = [];
+#if !DISABLE_RAM_SPD
             _disposed = true;
+#endif
         }
     }
 
+#if !DISABLE_RAM_SPD
     private bool TryAddDimms(ISettings settings)
     {
         try
@@ -194,4 +209,5 @@ internal class MemoryGroup : IGroup, IHardwareChanged
         foreach (Hardware hardware in additions)
             HardwareAdded?.Invoke(hardware);
     }
+#endif
 }

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
@@ -508,9 +508,9 @@ public abstract class EmbeddedController : Hardware
         sourcesList.Sort((left, right) => left.Register.CompareTo(right.Register));
         _sources = sourcesList;
         var indices = new Dictionary<SensorType, int>();
-        foreach (SensorType t in Enum.GetValues(typeof(SensorType)))
+        foreach (SensorType type in Enum.GetValues<SensorType>())
         {
-            indices.Add(t, 0);
+            indices.Add(type, 0);
         }
 
         _sensors = new List<Sensor>();

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/LpcIO.cs
@@ -27,8 +27,10 @@ internal class LpcIO
 
         Mutexes.ReleaseIsaBus();
 
+#if !DISABLE_IPMI_WMI
         if (Ipmi.IsBmcPresent())
             _superIOs.Add(new Ipmi(motherboard.Manufacturer));
+#endif
     }
 
     public ISuperIO[] SuperIO => _superIOs.ToArray();

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -797,6 +797,7 @@ internal sealed class SuperIOHardware : Hardware
 
                 break;
 
+#if !DISABLE_IPMI_WMI
             case Chip.IPMI:
                 Ipmi ipmi = (Ipmi)superIO;
 
@@ -813,6 +814,7 @@ internal sealed class SuperIOHardware : Hardware
                     c.Add(control);
 
                 break;
+#endif
 
             default:
                 GetDefaultConfiguration(superIO, v, t, f, c);

--- a/LibreHardwareMonitorLib/Hardware/OpCode.cs
+++ b/LibreHardwareMonitorLib/Hardware/OpCode.cs
@@ -5,7 +5,6 @@
 // All Rights Reserved.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 #if !NETFRAMEWORK
 using Mono.Unix.Native;
@@ -212,9 +211,6 @@ internal static class OpCode
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     public delegate ulong RdtscDelegate();
 
-#if NET
-    [RequiresUnreferencedCode("Dynamic code generation for OpCode delegates")]
-#endif
     public static unsafe void Open()
     {
         byte[] rdTscCode;

--- a/LibreHardwareMonitorLib/Hardware/Psu/Corsair/UsbApi.cs
+++ b/LibreHardwareMonitorLib/Hardware/Psu/Corsair/UsbApi.cs
@@ -115,12 +115,12 @@ internal static class UsbApi
         if (!SendCommand(stream, 3, Command.PROD_STR, 0, out byte[] productArr))
             throw new ProtocolError(stream.Device, "Can't read product");
 
+        return new FirmwareInfo { Vendor = ArrayToString(vendorArr), Product = ArrayToString(productArr) };
+
         static string ArrayToString(byte[] ar)
         {
             return Encoding.ASCII.GetString(ar.TakeWhile(x => x != 0).ToArray());
         }
-
-        return new FirmwareInfo { Vendor = ArrayToString(vendorArr), Product = ArrayToString(productArr) };
     }
 
     private static bool SendCommand(HidStream stream, byte length, Command cmd, byte arg, out byte[] replyData)

--- a/LibreHardwareMonitorLib/Hardware/Psu/Msi/UsbApi.cs
+++ b/LibreHardwareMonitorLib/Hardware/Psu/Msi/UsbApi.cs
@@ -44,12 +44,12 @@ internal static class UsbApi
         if (!Request(stream, new byte[2] { 0xFA, 0x51 }, out byte[] productArr, 1))
             throw new ProtocolError(stream.Device, "Can't read product name");
 
+        return new FirmwareInfo { Vendor = "MSI", Product = ArrayToString(productArr) };
+
         static string ArrayToString(byte[] ar)
         {
             return Encoding.ASCII.GetString(ar.TakeWhile(x => x != 0).ToArray());
         }
-
-        return new FirmwareInfo { Vendor = "MSI", Product = ArrayToString(productArr) };
     }
 
     private static float Linear11ToFloat32(ushort val)

--- a/LibreHardwareMonitorLib/Interop/IntelGcl.cs
+++ b/LibreHardwareMonitorLib/Interop/IntelGcl.cs
@@ -232,13 +232,13 @@ internal static class IntelGcl
         if (IsInitialized)
             return true;
 
-        var initArgs = new ctl_init_args_t();
-        initArgs.Size = (uint)Marshal.SizeOf(typeof(ctl_init_args_t));
+        ctl_init_args_t initArgs = new ctl_init_args_t();
+        initArgs.Size = (uint)Marshal.SizeOf<ctl_init_args_t>();
         initArgs.Version = 0;
         initArgs.AppVersion = CTL_IMPL_VERSION;
         initArgs.flags = (uint)ctl_init_flag_t.CTL_INIT_FLAG_USE_LEVEL_ZERO;
 
-        var apiHandle = new ctl_api_handle_t();
+        ctl_api_handle_t apiHandle = new ctl_api_handle_t();
         int result = ctlInit(ref initArgs, ref apiHandle);
 
         if (result != (int)ctl_result_t.CTL_RESULT_SUCCESS)

--- a/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
+++ b/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
@@ -22,6 +22,10 @@
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
+    <DisableIpmiWmi Condition="'$(DisableIpmiWmi)' == '' and '$(TargetFramework)' == 'net10.0' and ('$(Configuration)' == 'Release' or '$(Configuration)' == 'ReleaseWithDebugging')">true</DisableIpmiWmi>
+    <DisableIpmiWmi Condition="'$(DisableIpmiWmi)' == ''">false</DisableIpmiWmi>
+    <DisableRamSpd Condition="'$(DisableRamSpd)' == '' and '$(TargetFramework)' == 'net10.0' and ('$(Configuration)' == 'Release' or '$(Configuration)' == 'ReleaseWithDebugging')">true</DisableRamSpd>
+    <DisableRamSpd Condition="'$(DisableRamSpd)' == ''">false</DisableRamSpd>
   </PropertyGroup>
 
   <!-- AOT/Trimming compatibility for modern .NET -->
@@ -31,8 +35,6 @@
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
-    <!-- Suppress known AOT warnings from System.Management WMI usage and OpCode dynamic code -->
-    <NoWarn>$(NoWarn);IL2026;IL3050;IL2075;IL2070</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BuildOnlyRefs)'=='true'">
@@ -57,6 +59,14 @@
     <DefineConstants>$(DefineConstants);LINUX</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(DisableIpmiWmi)' == 'true'">
+    <DefineConstants>$(DefineConstants);DISABLE_IPMI_WMI</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(DisableRamSpd)' == 'true'">
+    <DefineConstants>$(DefineConstants);DISABLE_RAM_SPD</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="Resources\PawnIo\AMDFamily0F.bin" />
     <EmbeddedResource Include="Resources\PawnIo\AMDFamily10.bin" />
@@ -73,6 +83,16 @@
     <EmbeddedResource Include="Resources\PawnIo\SmbusIntelSkylakeIMC.bin" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(DisableIpmiWmi)' == 'true'">
+    <Compile Remove="Hardware\Motherboard\Lpc\Ipmi.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DisableRamSpd)' == 'true'">
+    <Compile Remove="Hardware\Memory\DimmMemory.cs" />
+    <Compile Remove="Hardware\Memory\Sensors\SpdThermalSensor.cs" />
+    <Compile Remove="RAMSPDToolkitDriver.cs" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
@@ -81,16 +101,39 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DiskInfoToolkit" Version="2.1.1" />
-    <PackageReference Include="HidSharp" Version="2.6.4" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.298">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="RAMSPDToolkit-NDD" Version="1.5.0" />
-    <PackageReference Include="System.Management" Version="10.0.9" />
+    <PackageReference Include="RAMSPDToolkit-NDD" Version="1.5.0" Condition="'$(DisableRamSpd)' != 'true'" />
+    <PackageReference Include="System.Management" Version="10.0.9" Condition="'$(DisableIpmiWmi)' != 'true'" />
     <PackageReference Include="System.Memory" Version="4.6.3" Condition="'$(TargetFramework)' == 'net472'" />
     <PackageReference Include="System.Threading.AccessControl" Version="10.0.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\DiskInfoToolkit\DiskInfoToolkit\DiskInfoToolkit.csproj">
+      <SetConfiguration>Configuration=$(Configuration)</SetConfiguration>
+      <SetPlatform>Platform=AnyCPU</SetPlatform>
+      <SetTargetFramework>TargetFramework=net10.0</SetTargetFramework>
+      <SetPlatformTarget>PlatformTarget=AnyCPU</SetPlatformTarget>
+      <SetGeneratePackageOnBuild>GeneratePackageOnBuild=false</SetGeneratePackageOnBuild>
+      <AdditionalProperties>EnableNETAnalyzers=false;TreatWarningsAsErrors=false;GeneratePackageOnBuild=false</AdditionalProperties>
+      <GlobalPropertiesToRemove>BaseIntermediateOutputPath;BuildOnlyRefs;IntermediateOutputPath;PublishAot;PublishSingleFile;SelfContained;PublishTrimmed;RuntimeIdentifier;RuntimeIdentifiers;OutputPath;OutDir;PublishDir</GlobalPropertiesToRemove>
+      <Private>true</Private>
+      <PrivateAssets>all</PrivateAssets>
+      <Visible>false</Visible>
+    </ProjectReference>
+    <ProjectReference Include="..\..\build\HIDSharp\HidSharp.Source.csproj">
+      <SetConfiguration>Configuration=$(Configuration)</SetConfiguration>
+      <SetPlatform>Platform=AnyCPU</SetPlatform>
+      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+      <SetPlatformTarget>PlatformTarget=AnyCPU</SetPlatformTarget>
+      <GlobalPropertiesToRemove>BaseIntermediateOutputPath;BuildOnlyRefs;IntermediateOutputPath;PublishAot;PublishSingleFile;SelfContained;PublishTrimmed;RuntimeIdentifier;RuntimeIdentifiers;OutputPath;OutDir;PublishDir</GlobalPropertiesToRemove>
+      <Private>true</Private>
+      <PrivateAssets>all</PrivateAssets>
+      <Visible>false</Visible>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
+++ b/LibreHardwareMonitorLib/LibreHardwareMonitorLib.csproj
@@ -22,9 +22,11 @@
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
-    <DisableIpmiWmi Condition="'$(DisableIpmiWmi)' == '' and '$(TargetFramework)' == 'net10.0' and ('$(Configuration)' == 'Release' or '$(Configuration)' == 'ReleaseWithDebugging')">true</DisableIpmiWmi>
+    <!-- FanControlTrayAppDotNET consumes the net10 sidecar for fan control only. Keep
+         WMI-backed BMC/IPMI and RAM SPD out of net10 builds so Debug has no System.Management path. -->
+    <DisableIpmiWmi Condition="'$(DisableIpmiWmi)' == '' and '$(TargetFramework)' == 'net10.0'">true</DisableIpmiWmi>
     <DisableIpmiWmi Condition="'$(DisableIpmiWmi)' == ''">false</DisableIpmiWmi>
-    <DisableRamSpd Condition="'$(DisableRamSpd)' == '' and '$(TargetFramework)' == 'net10.0' and ('$(Configuration)' == 'Release' or '$(Configuration)' == 'ReleaseWithDebugging')">true</DisableRamSpd>
+    <DisableRamSpd Condition="'$(DisableRamSpd)' == '' and '$(TargetFramework)' == 'net10.0'">true</DisableRamSpd>
     <DisableRamSpd Condition="'$(DisableRamSpd)' == ''">false</DisableRamSpd>
   </PropertyGroup>
 
@@ -105,8 +107,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="RAMSPDToolkit-NDD" Version="1.5.0" Condition="'$(DisableRamSpd)' != 'true'" />
-    <PackageReference Include="System.Management" Version="10.0.9" Condition="'$(DisableIpmiWmi)' != 'true'" />
+    <PackageReference Include="RAMSPDToolkit-NDD" Version="1.5.0" Condition="'$(TargetFramework)' != '' and '$(DisableRamSpd)' != 'true'" />
+    <PackageReference Include="System.Management" Version="10.0.9" Condition="'$(TargetFramework)' != '' and '$(DisableIpmiWmi)' != 'true'" />
     <PackageReference Include="System.Memory" Version="4.6.3" Condition="'$(TargetFramework)' == 'net472'" />
     <PackageReference Include="System.Threading.AccessControl" Version="10.0.9" />
   </ItemGroup>


### PR DESCRIPTION
I added this to get working CCD temperatures on my Threadripper 9960x (Family 1Ah model 00h-0Fh), though this change should affect all Ryzen CPUs. I've reworked the model matching and added Threadripper 9000 explicitly, and have added a probing fallback. Now, for unknown CPU's it probes known CCD temperature register layouts, validates raw readings, selects the best matching register window, and exposes stable 0-indexed CCD sensors. Known CPU family/model pairs still get to use explicit CCD register mappings.

Summarized changes in Amd17Cpu.cs:
- Added CCD register candidate probing:
  - Generic candidates: `0x59B08`, `0x59B00`, `0x59954`
  - Family 1Ah model 00h-0Fh prioritized `0x599F0`
- Added CPU family/model mappings for known Zen CCD layouts.
- Cached resolved CCD register base after successful probing.
- Decoded raw CCD temperatures using:
  - valid bit mask `0x800`
  - value mask `0x7FF`
  - formula: `(raw * 125 - 49000) / 1000`
  - sanity range: `-50C` to `125C`
- Replaced model-gated CCD reads with mapped/probed CCD register detection.
- Renamed aggregate `Core` temperature sensors to `Package` since Ryzen CPUs do not have core temperature sensors.
- Kept CCD Tdie sensors named separately and changed CCD labels to 0-indexed names.
- Increased CCD sensor slots from 8 to 16.
- Added safe SMN reads so sparse or unsupported register windows do not break CPU updates.
- Removed stale unused constants

I also did a round of small cleanups. I left everything non-essential in a separate commit in case anyone wants to cherry-pick.