### PR TITLE
The appropriate solution to address abnormal noises caused by disk statistics.

### DIFF
--- a/LibreHardwareMonitor.Windows.Forms/UI/MainForm.Designer.cs
+++ b/LibreHardwareMonitor.Windows.Forms/UI/MainForm.Designer.cs
@@ -128,6 +128,12 @@ namespace LibreHardwareMonitor.Windows.Forms.UI
             this.updateInterval5sMenuItem = new LibreHardwareMonitor.Windows.Forms.UI.ToolStripRadioButtonMenuItem();
             this.updateInterval10sMenuItem = new LibreHardwareMonitor.Windows.Forms.UI.ToolStripRadioButtonMenuItem();
             this.throttleAtaUpdateMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.ataStorageUpdateIntervalMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.ataStorageUpdateFollowMenuItem = new LibreHardwareMonitor.Windows.Forms.UI.ToolStripRadioButtonMenuItem();
+            this.ataStorageUpdate10minMenuItem = new LibreHardwareMonitor.Windows.Forms.UI.ToolStripRadioButtonMenuItem();
+            this.ataStorageUpdate30minMenuItem = new LibreHardwareMonitor.Windows.Forms.UI.ToolStripRadioButtonMenuItem();
+            this.ataStorageUpdate1hMenuItem = new LibreHardwareMonitor.Windows.Forms.UI.ToolStripRadioButtonMenuItem();
+            this.ataStorageUpdate6hMenuItem = new LibreHardwareMonitor.Windows.Forms.UI.ToolStripRadioButtonMenuItem();
             this.sensorValuesTimeWindowMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.timeWindow30sMenuItem = new LibreHardwareMonitor.Windows.Forms.UI.ToolStripRadioButtonMenuItem();
             this.timeWindow1minMenuItem = new LibreHardwareMonitor.Windows.Forms.UI.ToolStripRadioButtonMenuItem();
@@ -823,7 +829,8 @@ namespace LibreHardwareMonitor.Windows.Forms.UI
             this.updateInterval2sMenuItem,
             this.updateInterval5sMenuItem,
             this.updateInterval10sMenuItem,
-            this.throttleAtaUpdateMenuItem});
+            this.throttleAtaUpdateMenuItem,
+            this.ataStorageUpdateIntervalMenuItem});
             this.updateIntervalMenuItem.Name = "updateIntervalMenuItem";
             this.updateIntervalMenuItem.Size = new System.Drawing.Size(221, 22);
             this.updateIntervalMenuItem.Text = "Update Interval";
@@ -876,6 +883,53 @@ namespace LibreHardwareMonitor.Windows.Forms.UI
             this.throttleAtaUpdateMenuItem.Name = "throttleATAUpdateMenuItem";
             this.throttleAtaUpdateMenuItem.Size = new System.Drawing.Size(107, 22);
             this.throttleAtaUpdateMenuItem.Text = "Throttle ATA Storage";
+            //
+            // ataStorageUpdateIntervalMenuItem
+            //
+            this.ataStorageUpdateIntervalMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ataStorageUpdateFollowMenuItem,
+            this.ataStorageUpdate10minMenuItem,
+            this.ataStorageUpdate30minMenuItem,
+            this.ataStorageUpdate1hMenuItem,
+            this.ataStorageUpdate6hMenuItem});
+            this.ataStorageUpdateIntervalMenuItem.Name = "ataStorageUpdateIntervalMenuItem";
+            this.ataStorageUpdateIntervalMenuItem.Size = new System.Drawing.Size(221, 22);
+            this.ataStorageUpdateIntervalMenuItem.Text = "ATA Storage Update Interval";
+            //
+            // ataStorageUpdateFollowMenuItem
+            //
+            this.ataStorageUpdateFollowMenuItem.CheckOnClick = true;
+            this.ataStorageUpdateFollowMenuItem.Name = "ataStorageUpdateFollowMenuItem";
+            this.ataStorageUpdateFollowMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.ataStorageUpdateFollowMenuItem.Text = "Follow Update Interval";
+            //
+            // ataStorageUpdate10minMenuItem
+            //
+            this.ataStorageUpdate10minMenuItem.CheckOnClick = true;
+            this.ataStorageUpdate10minMenuItem.Name = "ataStorageUpdate10minMenuItem";
+            this.ataStorageUpdate10minMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.ataStorageUpdate10minMenuItem.Text = "10min";
+            //
+            // ataStorageUpdate30minMenuItem
+            //
+            this.ataStorageUpdate30minMenuItem.CheckOnClick = true;
+            this.ataStorageUpdate30minMenuItem.Name = "ataStorageUpdate30minMenuItem";
+            this.ataStorageUpdate30minMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.ataStorageUpdate30minMenuItem.Text = "30min";
+            //
+            // ataStorageUpdate1hMenuItem
+            //
+            this.ataStorageUpdate1hMenuItem.CheckOnClick = true;
+            this.ataStorageUpdate1hMenuItem.Name = "ataStorageUpdate1hMenuItem";
+            this.ataStorageUpdate1hMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.ataStorageUpdate1hMenuItem.Text = "1h";
+            //
+            // ataStorageUpdate6hMenuItem
+            //
+            this.ataStorageUpdate6hMenuItem.CheckOnClick = true;
+            this.ataStorageUpdate6hMenuItem.Name = "ataStorageUpdate6hMenuItem";
+            this.ataStorageUpdate6hMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.ataStorageUpdate6hMenuItem.Text = "6h";
             //
             // sensorValuesTimeWindowMenuItem
             //
@@ -1220,6 +1274,12 @@ namespace LibreHardwareMonitor.Windows.Forms.UI
         private ToolStripRadioButtonMenuItem updateInterval5sMenuItem;
         private ToolStripRadioButtonMenuItem updateInterval10sMenuItem;
         private System.Windows.Forms.ToolStripMenuItem throttleAtaUpdateMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem ataStorageUpdateIntervalMenuItem;
+        private ToolStripRadioButtonMenuItem ataStorageUpdateFollowMenuItem;
+        private ToolStripRadioButtonMenuItem ataStorageUpdate10minMenuItem;
+        private ToolStripRadioButtonMenuItem ataStorageUpdate30minMenuItem;
+        private ToolStripRadioButtonMenuItem ataStorageUpdate1hMenuItem;
+        private ToolStripRadioButtonMenuItem ataStorageUpdate6hMenuItem;
         private System.Windows.Forms.ToolStripMenuItem nicMenuItem;
         private System.Windows.Forms.ToolStripMenuItem sensorValuesTimeWindowMenuItem;
         private ToolStripRadioButtonMenuItem timeWindow30sMenuItem;

--- a/LibreHardwareMonitor.Windows.Forms/UI/MainForm.cs
+++ b/LibreHardwareMonitor.Windows.Forms/UI/MainForm.cs
@@ -32,6 +32,7 @@ public sealed partial class MainForm : Form
     private readonly UserRadioGroup _loggingInterval;
     private readonly UserRadioGroup _updateInterval;
     private readonly UserOption _throttleAtaUpdate;
+    private readonly UserRadioGroup _ataStorageUpdateInterval;
     private readonly UserOption _logSensors;
     private readonly UserOption _forceDriveWakeup;
     private readonly UserOption _minimizeOnClose;
@@ -419,27 +420,42 @@ public sealed partial class MainForm : Form
 
         _updateInterval.Changed += (sender, e) =>
         {
+            TimeSpan newInterval;
             switch (_updateInterval.Value)
             {
                 case 0:
                     timer.Interval = 250;
+                    newInterval = TimeSpan.FromMilliseconds(250);
                     break;
                 case 1:
                     timer.Interval = 500;
+                    newInterval = TimeSpan.FromMilliseconds(500);
                     break;
                 case 2:
                     timer.Interval = 1000;
+                    newInterval = TimeSpan.FromSeconds(1);
                     break;
                 case 3:
                     timer.Interval = 2000;
+                    newInterval = TimeSpan.FromSeconds(2);
                     break;
                 case 4:
                     timer.Interval = 5000;
+                    newInterval = TimeSpan.FromSeconds(5);
                     break;
                 case 5:
                     timer.Interval = 10000;
+                    newInterval = TimeSpan.FromSeconds(10);
                     break;
+                default:
+                    return;
             }
+
+            // If ATA Storage is in "Follow Update Interval" mode, sync DitRefreshInterval.
+            // Null check is required because _updateInterval is initialized before _ataStorageUpdateInterval,
+            // and the Changed event fires once during construction via UserRadioGroup.
+            if (_ataStorageUpdateInterval != null && _ataStorageUpdateInterval.Value == 0)
+                StorageDevice.DitRefreshInterval = newInterval;
         };
 
         _throttleAtaUpdate = new UserOption("throttleAtaUpdateMenuItem", false, throttleAtaUpdateMenuItem, _settings);
@@ -453,6 +469,41 @@ public sealed partial class MainForm : Form
 
                 case false:
                     StorageDevice.ThrottleInterval = TimeSpan.Zero;
+                    break;
+            }
+        };
+
+        _ataStorageUpdateInterval = new UserRadioGroup("ataStorageUpdateInterval",
+                                                       0,
+                                                       new[]
+                                                       {
+                                                           ataStorageUpdateFollowMenuItem,
+                                                           ataStorageUpdate10minMenuItem,
+                                                           ataStorageUpdate30minMenuItem,
+                                                           ataStorageUpdate1hMenuItem,
+                                                           ataStorageUpdate6hMenuItem
+                                                       },
+                                                       _settings);
+
+        _ataStorageUpdateInterval.Changed += (sender, e) =>
+        {
+            switch (_ataStorageUpdateInterval.Value)
+            {
+                case 0:
+                    // Follow global update interval
+                    StorageDevice.DitRefreshInterval = TimeSpan.FromMilliseconds(timer.Interval);
+                    break;
+                case 1:
+                    StorageDevice.DitRefreshInterval = TimeSpan.FromMinutes(10);
+                    break;
+                case 2:
+                    StorageDevice.DitRefreshInterval = TimeSpan.FromMinutes(30);
+                    break;
+                case 3:
+                    StorageDevice.DitRefreshInterval = TimeSpan.FromHours(1);
+                    break;
+                case 4:
+                    StorageDevice.DitRefreshInterval = TimeSpan.FromHours(6);
                     break;
             }
         };

--- a/LibreHardwareMonitorLib/Hardware/Storage/StorageDevice.cs
+++ b/LibreHardwareMonitorLib/Hardware/Storage/StorageDevice.cs
@@ -37,6 +37,15 @@ public sealed class StorageDevice : Hardware, ISmart
     private long _lastWriteCount;
 
     private DateTime _lastUpdate = DateTime.MinValue;
+    private DateTime _lastDitRefreshTime = DateTime.MinValue;
+
+    /// <summary>
+    /// Gets or sets the interval between DiskInfoToolkit refresh calls.
+    /// DiskInfoToolkit refresh physically accesses the disk (waking it up), so this
+    /// should be set to a reasonable value (e.g. 1 hour) to avoid excessive disk head activation.
+    /// Default is 1 hour. Set to <see cref="TimeSpan.Zero"/> to disable throttling (refresh every update cycle).
+    /// </summary>
+    public static TimeSpan DitRefreshInterval { get; set; } = TimeSpan.FromHours(1);
 
     private readonly List<StorageDeviceSensor> _sensors = new();
     private readonly List<SmartAttribute> _attributes = new();
@@ -91,10 +100,14 @@ public sealed class StorageDevice : Hardware, ISmart
 
         bool hasChanges = false;
 
-        //No updates for sleeping devices if we should not wake it up
-        if (isDevicePoweredOn)
+        // Only call StorageDIT.Refresh every hour to avoid excessive disk head activation.
+        // DiskInfoToolkit refresh physically accesses the disk (waking it up), so we cache
+        // the data and reuse it between refreshes.
+        bool ditRefreshDue = DateTime.UtcNow - _lastDitRefreshTime >= DitRefreshInterval;
+        if (isDevicePoweredOn && ditRefreshDue)
         {
             hasChanges = StorageDIT.Refresh(_storage);
+            _lastDitRefreshTime = DateTime.UtcNow;
         }
 
         if (!hasChanges)


### PR DESCRIPTION
I noticed that after the program starts, the mechanical hard drive begins to emit a regular sound of head movement, approximately once per second.

After reviewing the update logs of DiskInfoToolkit, it appears that this issue has been fixed. However, it remains ineffective for my Seagate ST2000DM008-2UB102 drive, which still consistently triggers regular abnormal noises.

After checking the issues, I found #2302. This approach would cause a complete delay in updating disk monitoring data. In fact, after carefully studying the code, I realized that the disk performance data requiring high real-time accuracy is the real-time disk read/write speed. This data is not obtained using DiskInfoToolkit and does not require access to SMART data. Accessing SMART data appears to be the culprit behind abnormal disk noises. It can interfere with the disk's normal sleep mode, potentially accelerating the wear and tear of the disk's lifespan.

Therefore, I believe a new setting can be designed to individually configure the update frequency of disk statistics data that does not require high real-time performance.

<img width="885" height="627" alt="image" src="https://github.com/user-attachments/assets/7f9f265b-af3c-4f8f-8a4b-8a023558ec08" />

This can prevent abnormal disk noises and potential lifespan reduction. At the same time, metrics such as real-time disk read/write speeds can be updated in real time. I believe this solution can address the issue while maximizing the protection of user experience.