### PR TITLE
Distinguish between CPU and Chassis fans on the ASRock B450 Pro4

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -3527,11 +3527,29 @@ internal sealed class SuperIOHardware : Hardware
                         t.Add(new Temperature("Auxiliary Index #2", 5));
                         //t.Add(new Temperature("Temperature #6", 6));
 
-                        for (int i = 0; i < superIO.Fans.Length; i++)
-                            f.Add(new Fan("Fan #" + (i + 1), i));
+                        if (model == Model.B450_Pro4)
+                        {
+                            f.Add(new Fan("CPU Fan", 1));
+                            c.Add(new Control("CPU Fan", 1));
+                            f.Add(new Fan("CPU Pump", 2));
+                            c.Add(new Control("CPU Pump", 2));
 
-                        for (int i = 0; i < superIO.Controls.Length; i++)
-                            c.Add(new Control("Fan #" + (i + 1), i));
+                            f.Add(new Fan("Chassis #1", 0));
+                            c.Add(new Control("Chassis #1", 0));
+                            f.Add(new Fan("Chassis #2", 3));
+                            c.Add(new Control("Chassis #2", 3));
+                            f.Add(new Fan("Chassis #3", 4));
+                            c.Add(new Control("Chassis #3", 4));
+                        }
+                        else
+                        {
+                            for (int i = 0; i < superIO.Fans.Length; i++)
+                                f.Add(new Fan("Fan #" + (i + 1), i));
+
+                            for (int i = 0; i < superIO.Controls.Length; i++)
+                                c.Add(new Control("Fan #" + (i + 1), i));
+                        }
+
 
                         break;
 

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -3527,29 +3527,17 @@ internal sealed class SuperIOHardware : Hardware
                         t.Add(new Temperature("Auxiliary Index #2", 5));
                         //t.Add(new Temperature("Temperature #6", 6));
 
-                        if (model == Model.B450_Pro4)
-                        {
-                            f.Add(new Fan("CPU Fan", 1));
-                            c.Add(new Control("CPU Fan", 1));
-                            f.Add(new Fan("CPU Pump", 2));
-                            c.Add(new Control("CPU Pump", 2));
+                        f.Add(new Fan("CPU Fan", 1));
+                        c.Add(new Control("CPU Fan", 1));
+                        f.Add(new Fan("CPU Pump", 2));
+                        c.Add(new Control("CPU Pump", 2));
 
-                            f.Add(new Fan("Chassis #1", 0));
-                            c.Add(new Control("Chassis #1", 0));
-                            f.Add(new Fan("Chassis #2", 3));
-                            c.Add(new Control("Chassis #2", 3));
-                            f.Add(new Fan("Chassis #3", 4));
-                            c.Add(new Control("Chassis #3", 4));
-                        }
-                        else
-                        {
-                            for (int i = 0; i < superIO.Fans.Length; i++)
-                                f.Add(new Fan("Fan #" + (i + 1), i));
-
-                            for (int i = 0; i < superIO.Controls.Length; i++)
-                                c.Add(new Control("Fan #" + (i + 1), i));
-                        }
-
+                        f.Add(new Fan("Chassis #1", 0));
+                        c.Add(new Control("Chassis #1", 0));
+                        f.Add(new Fan("Chassis #2", 3));
+                        c.Add(new Control("Chassis #2", 3));
+                        f.Add(new Fan("Chassis #3", 4));
+                        c.Add(new Control("Chassis #3", 4));
 
                         break;
 


### PR DESCRIPTION
Changes the fan labels to be more descriptive. The main motivation behind this change was to allow other software using LibreHardwareMonitorLib to find the CPU fan by name.