### PR TITLE
Use AMD GFX temperature when edge temperature is unavailable

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Gpu/AmdGpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Gpu/AmdGpu.cs
@@ -409,7 +409,8 @@ internal sealed class AmdGpu : GenericGpu
             GetAdlSensor(adlPMLogData, logDataOutput, AtiAdlxx.ADLPMLogSensors.ADL_PMLOG_CLK_SOCCLK, _socClock);
             GetAdlSensor(adlPMLogData, logDataOutput, AtiAdlxx.ADLPMLogSensors.ADL_PMLOG_CLK_MEMCLK, _memoryClock, reset: false);
 
-            GetAdlSensor(adlPMLogData, logDataOutput, AtiAdlxx.ADLPMLogSensors.ADL_PMLOG_TEMPERATURE_EDGE, _temperatureCore, reset: false);
+            if (!GetAdlSensor(adlPMLogData, logDataOutput, AtiAdlxx.ADLPMLogSensors.ADL_PMLOG_TEMPERATURE_EDGE, _temperatureCore, reset: false))
+                GetAdlSensor(adlPMLogData, logDataOutput, AtiAdlxx.ADLPMLogSensors.ADL_PMLOG_TEMPERATURE_GFX, _temperatureCore, reset: false);
             GetAdlSensor(adlPMLogData, logDataOutput, AtiAdlxx.ADLPMLogSensors.ADL_PMLOG_TEMPERATURE_MEM, _temperatureMemory, reset: false);
             GetAdlSensor(adlPMLogData, logDataOutput, AtiAdlxx.ADLPMLogSensors.ADL_PMLOG_TEMPERATURE_VRVDDC, _temperatureVddc, reset: false);
             GetAdlSensor(adlPMLogData, logDataOutput, AtiAdlxx.ADLPMLogSensors.ADL_PMLOG_TEMPERATURE_VRMVDD, _temperatureMvdd, reset: false);


### PR DESCRIPTION
## Summary

Use `ADL_PMLOG_TEMPERATURE_GFX` as a fallback for the `GPU Core` temperature sensor when `ADL_PMLOG_TEMPERATURE_EDGE` is unsupported.

Some AMD APUs expose the GFX temperature through PMLog without exposing the edge temperature. The existing edge reading remains preferred, so behavior is unchanged on GPUs that already support it.

## Validation

- Built `LibreHardwareMonitorLib` for x64 across `net472`, `netstandard2.0`, `net8.0`, `net9.0`, and `net10.0`
- Tested on an AMD Ryzen AI 9 HX 370 with Radeon 890M:
  - Edge temperature: unsupported
  - GFX temperature: supported, 33 C
  - `GPU Core` after this change: 33 C
