### PR TITLE
Add CCD temperatures for Zen 5 Turin / Threadripper 9000

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
+++ b/LibreHardwareMonitorLib/Hardware/Cpu/Amd17Cpu.cs
@@ -133,7 +133,7 @@ internal sealed class Amd17Cpu : AmdCpu
             _coreTemperatureTctl = new Sensor("Core (Tctl)", _cpu._sensorTypeIndex[SensorType.Temperature]++, SensorType.Temperature, _cpu, _cpu._settings);
             _coreTemperatureTdie = new Sensor("Core (Tdie)", _cpu._sensorTypeIndex[SensorType.Temperature]++, SensorType.Temperature, _cpu, _cpu._settings);
             _coreTemperatureTctlTdie = new Sensor("Core (Tctl/Tdie)", _cpu._sensorTypeIndex[SensorType.Temperature]++, SensorType.Temperature, _cpu, _cpu._settings);
-            _ccdTemperatures = new Sensor[8]; // Hardcoded until there's a way to get max CCDs.
+            _ccdTemperatures = new Sensor[16]; // Turin / Shimada Peak expose up to 16 CCDs (k10temp).
             _coreVoltage = new Sensor("Core (SVI2 TFN)", _cpu._sensorTypeIndex[SensorType.Voltage]++, SensorType.Voltage, _cpu, _cpu._settings);
             _socVoltage = new Sensor("SoC (SVI2 TFN)", _cpu._sensorTypeIndex[SensorType.Voltage]++, SensorType.Voltage, _cpu, _cpu._settings);
             _busClock = new Sensor("Bus Speed", _cpu._sensorTypeIndex[SensorType.Clock]++, SensorType.Clock, _cpu, _cpu._settings);
@@ -227,6 +227,12 @@ internal sealed class Amd17Cpu : AmdCpu
                         break;
                 }
 
+                // Zen 5 HEDT/server: family 0x1A models 0x00-0x2F (Turin / Shimada Peak).
+                // Threadripper 9970X is model 0x08. Desktop Granite Ridge is 0x40-0x4F (0x44 above).
+                bool isZen5Turin = cpuId.Family == 0x1A && cpuId.Model <= 0x2F;
+                if (isZen5Turin)
+                    supportsPerCcdTemperatures = true;
+
                 // SVI0_PLANE0_VDDCOR [24:16]
                 // SVI0_PLANE0_IDDCOR [7:0]
                 smuSvi0TelPlane0 = _cpu._pawnModule.ReadSmn(sviPlane0Offset);
@@ -307,21 +313,37 @@ internal sealed class Amd17Cpu : AmdCpu
                     _cpu.ActivateSensor(_coreTemperatureTctlTdie);
                 }
 
-                // Tested only on R5 3600 & Threadripper 3960X, 5900X, 7900X
+                // Tested only on R5 3600 & Threadripper 3960X, 5900X, 7900X.
+                // Zen 5 Turin CCD map: linux/drivers/hwmon/k10temp.c (offset 0x1F0 from 0x59800).
                 if (supportsPerCcdTemperatures)
                 {
-                    for (uint i = 0; i < _ccdTemperatures.Length; i++)
+                    uint ccdBase;
+                    uint ccdCount;
+                    if (isZen5Turin)
                     {
-                        uint ccd1Offset = 0;
-                        if (cpuId.Model is 0x61 or 0x44) // Raphael or GraniteRidge
-                            ccd1Offset = F17H_M61H_CCD1_TEMP + i * 0x4;
-                        else
-                            ccd1Offset = F17H_M70H_CCD1_TEMP + i * 0x4;
-                        uint ccdRawTemp = _cpu._pawnModule.ReadSmn(ccd1Offset);
+                        ccdBase = F1AH_M00H_CCD1_TEMP;
+                        ccdCount = 16;
+                    }
+                    else if (cpuId.Model is 0x61 or 0x44) // Raphael or GraniteRidge
+                    {
+                        ccdBase = F17H_M61H_CCD1_TEMP;
+                        ccdCount = 8;
+                    }
+                    else
+                    {
+                        ccdBase = F17H_M70H_CCD1_TEMP;
+                        ccdCount = 8;
+                    }
 
+                    for (uint i = 0; i < ccdCount; i++)
+                    {
+                        uint ccdRawTemp = _cpu._pawnModule.ReadSmn(ccdBase + i * 0x4);
+                        bool ccdPresent = isZen5Turin
+                            ? (ccdRawTemp & F17H_CCD_TEMP_VALID) != 0
+                            : (ccdRawTemp & 0xFFF) > 0;
                         ccdRawTemp &= 0xFFF;
                         float ccdTemp = ((ccdRawTemp * 125) - 305000) * 0.001f;
-                        if (ccdRawTemp > 0 && ccdTemp < 125) // Zen 2 reports 95 degrees C max, but it might exceed that.
+                        if (ccdPresent && ccdTemp < 125) // Zen 2 reports 95 degrees C max, but it might exceed that.
                         {
                             if (_ccdTemperatures[i] == null)
                             {
@@ -816,6 +838,8 @@ internal sealed class Amd17Cpu : AmdCpu
     private const uint F17H_M01H_THM_TCON_CUR_TMP = 0x00059800;
     private const uint F17H_M70H_CCD1_TEMP = 0x00059954;
     private const uint F17H_M61H_CCD1_TEMP = 0x00059b08;
+    private const uint F1AH_M00H_CCD1_TEMP = 0x000599F0; // 0x59800 + 0x1F0 (k10temp Turin / Shimada Peak)
+    private const uint F17H_CCD_TEMP_VALID = 0x800;
     private const uint F17H_TEMP_RANGE_SEL_MASK = 0x80000;
     private const uint F17H_TEMP_TJ_SEL_MASK = 0x30000;
     private const uint FAMILY_17H_PCI_CONTROL_REGISTER = 0x60;


### PR DESCRIPTION
## Summary

Zen 5 HEDT/server parts (family `0x1A`, models `0x00`–`0x2F`, including Ryzen Threadripper 9970X / Shimada Peak) only exposed **Core (Tctl/Tdie)**. Per-CCD Tdie was never enabled because `Amd17Cpu` only treated desktop Granite Ridge (`model 0x44`) as Zen 5.

This adds the Linux `k10temp` Turin CCD map so those CPUs report CCD Tdie, plus CCDs Max/Average when more than one CCD is present.

## Root cause

`supportsPerCcdTemperatures` is an allow-list of CPUID models. Threadripper 9970X is **family 26 (`0x1A`), model 8 (`0x08`)**, which fell through to the Zen/Zen+ default (Tctl only).

Even if `0x08` were added next to `0x44`, the SMN address would still be wrong: Raphael/Granite Ridge use `0x59B08` (`0x59800 + 0x308`). Turin/Shimada Peak use `0x599F0` (`0x59800 + 0x1F0`).

Source: [linux/drivers/hwmon/k10temp.c](https://github.com/torvalds/linux/blob/master/drivers/hwmon/k10temp.c) — family `0x1A` models `0x00`–`0x2F` → `ccd_offset = 0x1F0`, up to 16 CCDs.

## Change

- Enable per-CCD reads for family `0x1A` models `<= 0x2F`
- SMN base `F1AH_M00H_CCD1_TEMP = 0x000599F0`, probe 16 slots
- Require CCD valid bit (`BIT(11)`) on the Turin path so empty CCDs stay hidden
- Grow the CCD sensor array to 16; Zen 2/3/4 still probe 8 and keep the previous presence check
- Existing Tctl/Tdie path is unchanged

## Hardware verification

Tested on **AMD Ryzen Threadripper 9970X** (family `0x1A`, model `0x08`), TRX50:

| Sensor | Example idle reading |
|--------|----------------------|
| Core (Tctl/Tdie) | 51.5 °C |
| CCD1 (Tdie) | 48.5 °C |
| CCD2 (Tdie) | 36.4 °C |
| CCD3 (Tdie) | 36.8 °C |
| CCD4 (Tdie) | 37.8 °C |
| CCDs Max (Tdie) | 48.5 °C |
| CCDs Average (Tdie) | 39.8 °C |

Matches HWiNFO CCD Tdie / die-average style sensors. Per-core, IOD, and L3 temps are **not** in this PR (those need an SMU PM-table layout this tree does not have for Shimada Peak).

## Test plan

- [x] Manual verification on Threadripper 9970X (elevated SMN dump + GUI)
- [ ] Existing tests still pass (CI)
- [ ] No regression on Zen 2/3/4 / Granite Ridge CCD path (logic unchanged except loop bound is explicit 8)

## Risk

Low. New SMN addresses are only used on family `0x1A` models `0x00`–`0x2F`. Other Zen generations keep their previous CCD base and count. Invalid CCD slots are rejected via the valid bit + `< 125 °C` filter.
