### PR TITLE
Fix Intel 700 series water flow EC register and factor

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Lpc/EC/EmbeddedController.cs
@@ -526,7 +526,12 @@ public abstract class EmbeddedController : Hardware
                 { ECSensor.TempTSensor2, new EmbeddedControllerSource("T Sensor 2", SensorType.Temperature, 0x105, blank: -40) },
                 { ECSensor.TempWaterIn, new EmbeddedControllerSource("Water In", SensorType.Temperature, 0x0100, blank: -40) },
                 { ECSensor.TempWaterOut, new EmbeddedControllerSource("Water Out", SensorType.Temperature, 0x0101, blank: -40) },
-                { ECSensor.FanWaterFlow, new EmbeddedControllerSource("Water Flow", SensorType.Flow, 0x00be, 2, factor: 1.0f / 42f * 60f) } // todo: need validation for this calculation
+                // Water flow: 0x00BC validated on a ROG MAXIMUS Z790 DARK HERO
+                // (i9-14900KF, Alphacool ES on W_FLOW): L/min = raw / 42,
+                // cross-checked against an OCCT pump-RPM calibration within
+                // ~2% across the pump range. Matches mainline Linux
+                // asus-ec-sensors (family_intel_700_series Water_Flow 0x00BC).
+                { ECSensor.FanWaterFlow, new EmbeddedControllerSource("Water Flow", SensorType.Flow, 0x00bc, 2, factor: 1.0f / 42f) }
             }
         }
     };


### PR DESCRIPTION
## Problem

The `BoardFamily.Intel700` EC map points `FanWaterFlow` ("Water Flow") at register `0x00BE` with factor `1.0f / 42f * 60f`, marked `// todo: need validation for this calculation`. On an **ASUS ROG MAXIMUS Z790 DARK HERO** (i9-14900KF, Alphacool ES pump on the `W_FLOW` header), that register reads **0** at all times — so the sensor is dead on this board family.

## Fix

Point the Intel700 water flow sensor at **`0x00BC`** (uint16, existing big-endian decode) and correct the factor to **`1.0f / 42f`** (L/min per raw count).

- The mainline Linux driver [`asus-ec-sensors`](https://git.kernel.org/pub/scm/linux/kernel/git/gregkh/hwmon.git/tree/drivers/hwmon/asus-ec-sensors.c) (zeule) has DMI entries for the Z790 HERO / EXTREME boards and places `Water_Flow` for `family_intel_700_series` at `0x00BC` — the same board family this map targets.
- Empirically validated on the DARK HERO: `L/min = raw / 42` matches an independent OCCT pump-RPM flow-gauge calibration (5 points, 1355–4753 rpm, R² = 0.999) within **~2%** at 3300–4687 rpm, and the raw count tracks pump speed monotonically. The previous `* 60` factor is also wrong for this board: the register is pre-scaled, not pulses/second.

## Scope

Only the `BoardFamily.Intel700` entry is changed. `Intel400` and `Intel600` still use `0x00BE` — they were not validated here, and the Linux driver likewise uses `0x00BE` for the intel_600 series, so no change is warranted for them.

## Sample data (DARK HERO, 14900KF)

| pump rpm | raw 0x00BC | raw/42 (L/min) | OCCT gauge (L/min) |
|---|---|---|---|
| 3300 | 742  | 17.67 | 17.18 |
| 3638 | 824  | 19.62 | 19.57 |
| 4005 | 918  | 21.86 | 22.16 |
| 4545 | 1071 | 25.5 | 25.97 |
| 4687 | ~1111 | 26.45 | 26.97 |
