### PR TITLE
Add display-layer UI localization framework with zh-CN translations

### DIFF
--- a/LibreHardwareMonitor.Windows.Forms/Localization/Localization.cs
+++ b/LibreHardwareMonitor.Windows.Forms/Localization/Localization.cs
@@ -1,0 +1,133 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (C) LibreHardwareMonitor and Contributors.
+// All Rights Reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Resources;
+using System.Windows.Forms;
+using LibreHardwareMonitor.Hardware;
+
+namespace LibreHardwareMonitor.Windows.Forms.Localization;
+
+/// <summary>
+/// Minimal localization helper.
+///
+/// The neutral resource <see cref="Strings"/> (English) is embedded in the main assembly, culture
+/// specific resources (currently zh-CN) are deployed as satellite resource assemblies. The
+/// canonical English strings in the code (designer texts, hard coded sensor group names) stay
+/// untouched, so the default experience and all API behavior remain English. Localization is only
+/// applied as a display layer on top of these defaults.
+/// </summary>
+public static class LocalizationManager
+{
+    private const string ResourceBaseName = "LibreHardwareMonitor.Windows.Forms.Localization.Strings";
+    private static readonly ResourceManager Resources = new(ResourceBaseName, typeof(LocalizationManager).Assembly);
+
+    private const string DefaultLanguage = "en";
+
+    // A few ToolStripMenuItems in MainForm.Designer.cs have a legacy "Name" that does not match
+    // their field name. The resource keys always use the field name, so translate the names here.
+    private static readonly Dictionary<string, string> MenuItemNameAliases = new()
+    {
+        { "menuItem5", "menuItemFileHardware" },
+        { "attachedPlotPanelScalingMenuItem", "splitPlotPanelScalingMenuItem" },
+        { "attachedPlotPanelPercentageScalingMenuItem", "splitPanelPercentageScalingMenuItem" },
+        { "attachedBottomMenuItem", "splitPanelFixedPlotScalingMenuItem" },
+        { "attachedRightMenuItem", "splitPanelFixedSensorScalingMenuItem" }
+    };
+
+    public static string Language { get; private set; } = DefaultLanguage;
+
+    /// <summary>
+    /// Selects the UI language and applies it to the current thread so that
+    /// <see cref="ResourceManager"/> resolves the right satellite resource set.
+    /// </summary>
+    public static void SetLanguage(string language)
+    {
+        if (string.IsNullOrEmpty(language))
+            language = DefaultLanguage;
+
+        try
+        {
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(language);
+        }
+        catch (CultureNotFoundException)
+        {
+            language = DefaultLanguage;
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(language);
+        }
+
+        Language = language;
+    }
+
+    /// <summary>
+    /// Returns the localized string for the current UI language, or null when no translation
+    /// exists (in which case callers keep their English default).
+    /// </summary>
+    public static string Get(string key)
+    {
+        return Resources.GetString(key);
+    }
+
+    /// <summary>
+    /// Like <see cref="Get(string)"/> but resolves the resource for a specific language,
+    /// independent of the current UI culture.
+    /// </summary>
+    public static string GetFor(string key, string language)
+    {
+        try
+        {
+            return Resources.GetString(key, CultureInfo.GetCultureInfo(language));
+        }
+        catch (CultureNotFoundException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Localizes the header of a sensor type group (for example "Temperatures").
+    /// </summary>
+    public static string GetGroupText(SensorType sensorType, string fallback)
+    {
+        return Get("SensorGroup." + sensorType) ?? fallback;
+    }
+
+    /// <summary>
+    /// Walks a <see cref="MenuStrip"/> and replaces the text of every item for which a
+    /// translation exists. Items without a translation keep their original (English) text.
+    /// </summary>
+    public static void ApplyToMenu(ToolStripItemCollection items)
+    {
+        foreach (ToolStripItem item in items)
+        {
+            if (item is ToolStripMenuItem menuItem)
+            {
+                if (!string.IsNullOrEmpty(menuItem.Text))
+                {
+                    string key = MenuItemKey(menuItem.Name);
+                    if (key != null)
+                    {
+                        string localized = Resources.GetString(key);
+                        if (localized != null)
+                            menuItem.Text = localized;
+                    }
+                }
+
+                if (menuItem.HasDropDownItems)
+                    ApplyToMenu(menuItem.DropDownItems);
+            }
+        }
+    }
+
+    private static string MenuItemKey(string itemName)
+    {
+        if (string.IsNullOrEmpty(itemName))
+            return null;
+
+        return "Menu." + (MenuItemNameAliases.TryGetValue(itemName, out string canonical) ? canonical : itemName);
+    }
+}

--- a/LibreHardwareMonitor.Windows.Forms/Localization/LocalizedNames.cs
+++ b/LibreHardwareMonitor.Windows.Forms/Localization/LocalizedNames.cs
@@ -1,0 +1,402 @@
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (C) LibreHardwareMonitor and Contributors.
+// All Rights Reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace LibreHardwareMonitor.Windows.Forms.Localization;
+
+/// <summary>
+/// Display-layer translations for hardware and sensor names.
+/// The library names ("CPU Package", "Fan #1", ...) are part of the public API
+/// and are consumed verbatim by the web server, logging and report generation, so they
+/// are never modified here. This helper only translates the copy that is *drawn* in the
+/// WinForms UI; when the current UI culture is not a language we support, the canonical
+/// English name is returned unchanged.
+/// </summary>
+internal static class LocalizedNames
+{
+    // Generic hardware category names that are safe to translate. Vendor/model names
+    // (e.g. "Intel Core i9-14900K", "NVIDIA GeForce RTX 4090") are intentionally NOT
+    // listed and therefore always stay as reported by the hardware.
+    private static readonly Dictionary<string, string> HardwareNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Memory"] = "内存",
+        ["Total Memory"] = "内存",
+        ["Virtual Memory"] = "虚拟内存"
+    };
+
+    // Exact sensor names whose canonical English name maps 1:1 to a translated one.
+    private static readonly Dictionary<string, string> ExactNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // ---- CPU ---------------------------------------------------------
+        ["CPU Package"] = "CPU 封装",
+        ["CPU Total"] = "CPU 总计",
+        ["CPU Core"] = "CPU 核心",
+        ["CPU Core Max"] = "CPU 核心最高",
+        ["CPU Core Average"] = "CPU 核心平均",
+        ["Core Average"] = "核心平均",
+        ["Core Max"] = "核心最高",
+        ["CPU Cores"] = "CPU 核心",
+        ["Bus Speed"] = "总线速度",
+        ["Northbridge"] = "北桥",
+        ["Package"] = "封装",
+        ["CPU Graphics"] = "CPU 核显",
+        ["CPU Platform"] = "CPU 平台",
+        ["Cores (Average)"] = "核心 (平均)",
+        ["Cores (Average Effective)"] = "核心 (平均有效)",
+        ["CCDs Max (Tdie)"] = "CCD 组最高 (Tdie)",
+        ["CCDs Average (Tdie)"] = "CCD 组平均 (Tdie)",
+        ["Core (Tctl)"] = "核心 (Tctl)",
+        ["Core (Tdie)"] = "核心 (Tdie)",
+        ["Core (Tctl/Tdie)"] = "核心 (Tctl/Tdie)",
+        ["Core (SVI2 TFN)"] = "核心 (SVI2 TFN)",
+
+        // ---- GPU ---------------------------------------------------------
+        ["GPU Core"] = "GPU 核心",
+        ["GPU Core Voltage"] = "GPU 核心电压",
+        ["GPU Power"] = "GPU 功耗",
+        ["GPU Package"] = "GPU 封装",
+        ["GPU Total"] = "GPU 总计",
+        ["GPU Fan"] = "GPU 风扇",
+        ["GPU Hot Spot"] = "GPU 热点",
+        ["GPU Liquid"] = "GPU 液冷",
+        ["GPU Memory Junction"] = "GPU 显存结温",
+        ["GPU Memory"] = "GPU 显存",
+        ["GPU Memory Used"] = "GPU 显存已用",
+        ["GPU Memory Free"] = "GPU 显存可用",
+        ["GPU Memory Total"] = "GPU 显存总计",
+        ["GPU Memory Controller"] = "GPU 内存控制器",
+        ["GPU Video Engine"] = "GPU 视频引擎",
+        ["GPU Video"] = "GPU 视频",
+        ["GPU Shader"] = "GPU 着色器",
+        ["GPU Bus"] = "GPU 总线",
+        ["GPU Render/Compute"] = "GPU 渲染/计算",
+        ["GPU Media"] = "GPU 媒体",
+        ["GPU Board"] = "GPU 板卡",
+        ["GPU Board Power"] = "GPU 板卡功耗",
+        ["GPU Power Supply"] = "GPU 供电",
+        ["GPU PCIe Rx"] = "GPU PCIe 接收",
+        ["GPU PCIe Tx"] = "GPU PCIe 发送",
+        ["GPU Visual Computing Board"] = "GPU 视觉计算板卡",
+        ["GPU Visual Computing Inlet"] = "GPU 视觉计算入口",
+        ["GPU Visual Computing Outlet"] = "GPU 视觉计算出口",
+        ["Fullscreen FPS"] = "全屏 FPS",
+        ["Memory Controller"] = "内存控制器",
+
+        // D3D video-memory usage sensors (AMD/Intel/NVIDIA). These are fixed names and are
+        // not engine-type phrases, so they are matched here before the generic "D3D ..." path.
+        ["D3D Dedicated Memory Used"] = "D3D 独立显存已用",
+        ["D3D Dedicated Memory Free"] = "D3D 独立显存可用",
+        ["D3D Dedicated Memory Total"] = "D3D 独立显存总计",
+        ["D3D Shared Memory Used"] = "D3D 共享显存已用",
+        ["D3D Shared Memory Free"] = "D3D 共享显存可用",
+        ["D3D Shared Memory Total"] = "D3D 共享显存总计",
+
+        // ---- Memory (RAM) ------------------------------------------------
+        ["Memory"] = "内存使用率",
+        ["Memory Used"] = "已用内存",
+        ["Memory Available"] = "可用内存",
+        ["Temperature Sensor Resolution"] = "温度传感器分辨率",
+        ["Thermal Sensor Low Limit"] = "热传感器下限",
+        ["Thermal Sensor High Limit"] = "热传感器上限",
+        ["Thermal Sensor Critical Limit"] = "热传感器临界阈值",
+        ["Thermal Sensor Critical Low Limit"] = "热传感器临界下限",
+        ["Thermal Sensor Critical High Limit"] = "热传感器临界上限",
+        ["Capacity"] = "容量",
+
+        // ---- Memory (DDR SPD timings; the tXXX acronyms are kept as-is) ---
+        ["tCKAVGmin (Minimum Cycle Time)"] = "tCKAVGmin (最小周期)",
+        ["tCKAVGmax (Maximum Cycle Time)"] = "tCKAVGmax (最大周期)",
+        ["tAA (CAS Latency Time)"] = "tAA (列选通延迟)",
+        ["tRCD (RAS to CAS Delay Time)"] = "tRCD (行选通至列选通延迟)",
+        ["tRP (Row Precharge Delay Time)"] = "tRP (行预充电延迟)",
+        ["tRAS (Active to Precharge Delay Time)"] = "tRAS (激活至预充电延迟)",
+        ["tRC (Active to Active/Refresh Delay Time)"] = "tRC (激活至激活/刷新延迟)",
+        ["tRFC1 (Refresh Recovery Delay Time)"] = "tRFC1 (刷新恢复延迟)",
+        ["tRFC2 (Refresh Recovery Delay Time)"] = "tRFC2 (刷新恢复延迟)",
+        ["tRFC4 (Refresh Recovery Delay Time)"] = "tRFC4 (刷新恢复延迟)",
+        ["tFAW (Four Activate Window Time)"] = "tFAW (四组激活窗口)",
+        ["tRRD_S (Activate to Activate Delay Time)"] = "tRRD_S (行激活间隔)",
+        ["tRRD_L (Activate to Activate Delay Time)"] = "tRRD_L (行激活间隔)",
+        ["tCCD_L (CAS to CAS Delay Time)"] = "tCCD_L (列选通间隔)",
+        ["tWR (Write Recovery Time)"] = "tWR (写入恢复)",
+        ["tWTR_S (Write to Read Time)"] = "tWTR_S (写转读间隔)",
+        ["tWTR_L (Write to Read Time)"] = "tWTR_L (写转读间隔)",
+        ["tRFC1 (Normal Refresh Recovery Time)"] = "tRFC1 (常规刷新恢复)",
+        ["tRFC2 (Fine Granularity Refresh Recovery Time)"] = "tRFC2 (细粒度刷新恢复)",
+        ["tRFCsb (Same Bank Refresh Recovery Time)"] = "tRFCsb (同组刷新恢复)",
+        ["tRFC1_dlr (Normal Refresh Recovery Time 3DS)"] = "tRFC1_dlr (常规刷新恢复 3DS)",
+        ["tRFC2_dlr (Fine Granularity Refresh Recovery Time 3DS)"] = "tRFC2_dlr (细粒度刷新恢复 3DS)",
+        ["tRFCsb_dlr (Same Bank Refresh Recovery Time 3DS)"] = "tRFCsb_dlr (同组刷新恢复 3DS)",
+
+        // ---- Storage (SMART) ----------------------------------------------
+        ["Temperature"] = "温度",
+        ["Warning Temperature"] = "警告温度",
+        ["Critical Temperature"] = "临界温度",
+        ["Life"] = "剩余寿命",
+        ["Remaining Life"] = "剩余寿命",
+        ["Data Read"] = "累计读取",
+        ["Data Written"] = "累计写入",
+        ["Power On Count"] = "通电次数",
+        ["Power On Hours"] = "通电时长",
+        ["Available Spare"] = "可用备用空间",
+        ["Available Spare Threshold"] = "可用备用空间阈值",
+        ["Percentage Used"] = "已用百分比",
+        ["Used Space"] = "已用空间",
+        ["Free Space"] = "可用空间",
+        ["Total Space"] = "总空间",
+        ["Read Activity"] = "读取占用",
+        ["Write Activity"] = "写入占用",
+        ["Total Activity"] = "总占用",
+        ["Read Rate"] = "读取速率",
+        ["Write Rate"] = "写入速率",
+
+        // ---- Network ------------------------------------------------------
+        ["Data Uploaded"] = "累计上传",
+        ["Data Downloaded"] = "累计下载",
+        ["Upload Speed"] = "上传速度",
+        ["Download Speed"] = "下载速度",
+        ["Network Utilization"] = "网络使用率",
+
+        // ---- Battery ------------------------------------------------------
+        // The library renames these sensors while running depending on whether the
+        // AC adapter is connected, so all the state names need to be covered.
+        ["Designed Capacity"] = "设计容量",
+        ["Fully-Charged Capacity"] = "满充容量",
+        ["Degradation Level"] = "电池健康度",
+        ["Charge Level"] = "电池电量",
+        ["Voltage"] = "电压",
+        ["Remaining Capacity"] = "剩余容量",
+        ["Charge/Discharge Current"] = "充放电电流",
+        ["Charge Current"] = "充电电流",
+        ["Discharge Current"] = "放电电流",
+        ["Charge/Discharge Rate"] = "充放电功率",
+        ["Charge Rate"] = "充电功率",
+        ["Discharge Rate"] = "放电功率",
+        ["Remaining Time (Estimated)"] = "剩余时间（估算）",
+        ["Battery Temperature"] = "电池温度"
+    };
+
+    // D3D engine friendly-name phrases. Names are made of these phrases plus vendor
+    // specific leftovers and indices, e.g. "D3D Optical Flow Accelerator 0" or
+    // "D3D High Priority 3D". Anything not listed stays untranslated on purpose.
+    private static readonly KeyValuePair<string, string>[] D3DPhrases =
+    {
+        new("High Priority Compute", "高优先级计算"),
+        new("Low Priority Compute", "低优先级计算"),
+        new("High Priority 3D", "高优先级三维"),
+        new("Low Priority 3D", "低优先级三维"),
+        new("Optical Flow Accelerator", "光流加速器"),
+        new("JPEG Decode", "JPEG 解码"),
+        new("Video Decode", "视频解码"),
+        new("Video Encode", "视频编码"),
+        new("Video Processing", "视频处理"),
+        new("Scene Assembly", "场景装配"),
+        new("Video", "视频"),
+        new("Audio", "音频"),
+        new("Compute", "计算"),
+        new("3D", "三维"),
+        new("Copy", "复制"),
+        new("Overlay", "覆盖"),
+        new("Crypto", "加密"),
+        new("Security", "安全"),
+        new("VR", "虚拟现实"),
+        new("True Audio", "高保真音频"),
+        new("Unknown", "未知"),
+        new("Other", "其他")
+    };
+
+    // Tree list column headings. The TreeColumn.Header itself always keeps the canonical
+    // English value (it is used as the persistence key for column widths), so the localized
+    // copy is applied only when the header text is drawn.
+    private static readonly Dictionary<string, string> ColumnHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Sensor"] = "传感器",
+        ["Value"] = "数值",
+        ["Min"] = "最小",
+        ["Max"] = "最大"
+    };
+
+    public static string ColumnHeader(string english)
+    {
+        if (!IsSupported)
+            return english;
+        return ColumnHeaders.TryGetValue(english, out string translated) ? translated : english;
+    }
+
+    // Sensor names that follow the pattern "EnglishBase #N" (e.g. "Temperature #1", "Fan #2").
+    // A few well-known suffixes are translated too; anything else falls back to English.
+    private static readonly KeyValuePair<string, string>[] NumberedBases =
+    {
+        new("P-Core", "性能核心"),
+        new("E-Core", "能效核心"),
+        new("CPU Core", "CPU 核心"),
+        new("GPU Hot Spot", "GPU 热点"),
+        new("GPU Fan", "GPU 风扇"),
+        new("Core", "核心"),
+        new("Temperature", "温度"),
+        new("Voltage", "电压"),
+        new("Fan", "风扇"),
+        new("Clock", "时钟"),
+        new("Load", "负载"),
+        new("Power", "功率")
+    };
+
+    // Numeric names that are not written with a hash: "CPU Package C3", "12VHPWR Pin 4".
+    private static readonly KeyValuePair<string, string>[] NoHashNumberedBases =
+    {
+        new("CPU Package C", "CPU 封装 C"),
+        new("12VHPWR Pin ", "12VHPWR 针脚 ")
+    };
+
+    public static bool IsSupported => CultureInfo.CurrentUICulture.TwoLetterISOLanguageName.Equals("zh", StringComparison.OrdinalIgnoreCase);
+
+    public static string HardwareName(string canonicalName)
+    {
+        if (!IsSupported)
+            return canonicalName;
+
+        if (HardwareNames.TryGetValue(canonicalName, out string translated))
+            return translated;
+
+        const string dimmPrefix = "DIMM #";
+        if (canonicalName.StartsWith(dimmPrefix, StringComparison.OrdinalIgnoreCase) && IsDigits(canonicalName.Substring(dimmPrefix.Length)))
+            return "内存条 #" + canonicalName.Substring(dimmPrefix.Length);
+
+        return canonicalName;
+    }
+
+    public static string SensorName(string canonicalName)
+    {
+        if (!IsSupported)
+            return canonicalName;
+
+        if (ExactNames.TryGetValue(canonicalName, out string exact))
+            return exact;
+
+        // D3D engine nodes are vendor specific combinations of known phrases,
+        // indices and rare extra words, so they get their own translator.
+        if (canonicalName.StartsWith("D3D ", StringComparison.OrdinalIgnoreCase))
+        {
+            string translated = "D3D " + TranslateD3D(canonicalName.Substring(4).Trim());
+            return translated;
+        }
+
+        foreach (KeyValuePair<string, string> baseTranslation in NumberedBases)
+        {
+            string prefix = baseTranslation.Key + " #";
+            if (!canonicalName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            string rest = canonicalName.Substring(prefix.Length);
+            int digitCount = 0;
+            while (digitCount < rest.Length && IsDigits(rest[digitCount]))
+                digitCount++;
+            if (digitCount == 0)
+                continue;
+
+            string number = rest.Substring(0, digitCount);
+            string tail = rest.Substring(digitCount);
+            string suffix = tail switch
+            {
+                "" => " #" + number,
+                " (Effective)" => " #" + number + " (有效)",
+                " (SMU)" => " #" + number + " (SMU)",
+                " VID" => " #" + number + " VID",
+                _ => null
+            };
+
+            if (tail.StartsWith(" Thread #", StringComparison.OrdinalIgnoreCase))
+            {
+                string threadRest = tail.Substring(" Thread #".Length);
+                if (IsDigits(threadRest))
+                    suffix = " #" + number + " 线程 #" + threadRest;
+            }
+
+            if (suffix != null)
+                return baseTranslation.Value + suffix;
+        }
+
+        foreach (KeyValuePair<string, string> baseTranslation in NoHashNumberedBases)
+        {
+            if (!canonicalName.StartsWith(baseTranslation.Key, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            string rest = canonicalName.Substring(baseTranslation.Key.Length);
+            if (IsDigits(rest))
+                return baseTranslation.Value + rest;
+        }
+
+        return canonicalName;
+    }
+
+    /// <summary>
+    /// Translates the readable part of a D3D engine node name. Known phrases are
+    /// matched longest-first; unknown words and numeric indices stay as reported.
+    /// </summary>
+    private static string TranslateD3D(string text)
+    {
+        List<string> parts = [text];
+        List<string> translated = new();
+        while (parts.Count > 0)
+        {
+            string current = parts[0];
+            parts.RemoveAt(0);
+
+            string trimmed = current.Trim();
+            if (trimmed.Length == 0)
+                continue;
+
+            string[] words = trimmed.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            int consumed = 0;
+            bool hit = false;
+            for (int count = words.Length; count > 0; count--)
+            {
+                string candidate = string.Join(" ", words, 0, count);
+                foreach (KeyValuePair<string, string> phrase in D3DPhrases)
+                {
+                    if (phrase.Key.Equals(candidate, StringComparison.OrdinalIgnoreCase))
+                    {
+                        translated.Add(phrase.Value);
+                        consumed = count;
+                        hit = true;
+                        break;
+                    }
+                }
+                if (hit)
+                    break;
+            }
+
+            if (!hit)
+            {
+                // Keep unknown words and indices verbatim.
+                if (words[0].Length == 0 || IsDigits(words[0]) || char.IsLetterOrDigit(words[0][0]))
+                    translated.Add(words[0]);
+                consumed = 1;
+            }
+
+            if (consumed < words.Length)
+                parts.Insert(0, string.Join(" ", words, consumed, words.Length - consumed));
+        }
+
+        return string.Join(" ", translated.ToArray());
+    }
+
+    private static bool IsDigits(string text)
+    {
+        if (text.Length == 0)
+            return false;
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (!IsDigits(text[i]))
+                return false;
+        }
+        return true;
+    }
+
+    private static bool IsDigits(char c) => c >= '0' && c <= '9';
+}

--- a/LibreHardwareMonitor.Windows.Forms/Localization/Strings.resx
+++ b/LibreHardwareMonitor.Windows.Forms/Localization/Strings.resx
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Menu.aboutMenuItem" xml:space="preserve"><value>About</value></data>
+  <data name="Menu.authWebServerMenuItem" xml:space="preserve"><value>Authentication</value></data>
+  <data name="Menu.batteryMenuItem" xml:space="preserve"><value>Batteries</value></data>
+  <data name="Menu.celsiusMenuItem" xml:space="preserve"><value>Celsius</value></data>
+  <data name="Menu.collpaseAllNodesMenuItem" xml:space="preserve"><value>Collapse All Nodes</value></data>
+  <data name="Menu.columnsMenuItem" xml:space="preserve"><value>Columns</value></data>
+  <data name="Menu.cpuMenuItem" xml:space="preserve"><value>CPU</value></data>
+  <data name="Menu.dailyFileRotationMenuItem" xml:space="preserve"><value>Daily</value></data>
+  <data name="Menu.exitMenuItem" xml:space="preserve"><value>Exit</value></data>
+  <data name="Menu.expandAllNodesMenuItem" xml:space="preserve"><value>Expand All Nodes</value></data>
+  <data name="Menu.fahrenheitMenuItem" xml:space="preserve"><value>Fahrenheit</value></data>
+  <data name="Menu.fanControllerMenuItem" xml:space="preserve"><value>Fan Controllers</value></data>
+  <data name="Menu.fileMenuItem" xml:space="preserve"><value>File</value></data>
+  <data name="Menu.fileRotationMethod" xml:space="preserve"><value>File Rotation Method</value></data>
+  <data name="Menu.forceDriveWakeupItem" xml:space="preserve"><value>Force Drive Wakeup</value></data>
+  <data name="Menu.gadgetMenuItem" xml:space="preserve"><value>Show Gadget</value></data>
+  <data name="Menu.gpuMenuItem" xml:space="preserve"><value>GPU</value></data>
+  <data name="Menu.hddMenuItem" xml:space="preserve"><value>Storage Devices</value></data>
+  <data name="Menu.helpMenuItem" xml:space="preserve"><value>Help</value></data>
+  <data name="Menu.hiddenMenuItem" xml:space="preserve"><value>Show Hidden Sensors</value></data>
+  <data name="Menu.languageMenuItem" xml:space="preserve"><value>Language</value></data>
+  <data name="Menu.logSensorsMenuItem" xml:space="preserve"><value>Log Sensors</value></data>
+  <data name="Menu.loggingIntervalMenuItem" xml:space="preserve"><value>Logging Interval</value></data>
+  <data name="Menu.mainboardMenuItem" xml:space="preserve"><value>Motherboard</value></data>
+  <data name="Menu.maxMenuItem" xml:space="preserve"><value>Max</value></data>
+  <data name="Menu.menuItemFileHardware" xml:space="preserve"><value>Hardware</value></data>
+  <data name="Menu.minCloseMenuItem" xml:space="preserve"><value>Minimize On Close</value></data>
+  <data name="Menu.minMenuItem" xml:space="preserve"><value>Min</value></data>
+  <data name="Menu.minTrayMenuItem" xml:space="preserve"><value>Minimize To Tray</value></data>
+  <data name="Menu.nicMenuItem" xml:space="preserve"><value>Network</value></data>
+  <data name="Menu.optionsMenuItem" xml:space="preserve"><value>Options</value></data>
+  <data name="Menu.perSessionFileRotationMenuItem" xml:space="preserve"><value>Per Session</value></data>
+  <data name="Menu.plotBottomMenuItem" xml:space="preserve"><value>Bottom</value></data>
+  <data name="Menu.plotLocationMenuItem" xml:space="preserve"><value>Plot Location</value></data>
+  <data name="Menu.plotMenuItem" xml:space="preserve"><value>Show Plot</value></data>
+  <data name="Menu.plotRightMenuItem" xml:space="preserve"><value>Right</value></data>
+  <data name="Menu.plotWindowMenuItem" xml:space="preserve"><value>Window</value></data>
+  <data name="Menu.powerMonitorMenuItem" xml:space="preserve"><value>Power Monitors</value></data>
+  <data name="Menu.psuMenuItem" xml:space="preserve"><value>Power supplies</value></data>
+  <data name="Menu.ramMenuItem" xml:space="preserve"><value>RAM</value></data>
+  <data name="Menu.resetMenuItem" xml:space="preserve"><value>Reset</value></data>
+  <data name="Menu.resetMinMaxMenuItem" xml:space="preserve"><value>Reset Min/Max</value></data>
+  <data name="Menu.resetPlotMenuItem" xml:space="preserve"><value>Reset Plot</value></data>
+  <data name="Menu.runWebServerMenuItem" xml:space="preserve"><value>Run</value></data>
+  <data name="Menu.saveReportMenuItem" xml:space="preserve"><value>Save Report...</value></data>
+  <data name="Menu.sensorValuesTimeWindowMenuItem" xml:space="preserve"><value>Sensor Values Time Window</value></data>
+  <data name="Menu.serverInterfacePortMenuItem" xml:space="preserve"><value>Interface / Port</value></data>
+  <data name="Menu.smartUpdate10CyclesMenuItem" xml:space="preserve"><value>Every 10 Cycles</value></data>
+  <data name="Menu.smartUpdate100CyclesMenuItem" xml:space="preserve"><value>Every 100 Cycles</value></data>
+  <data name="Menu.smartUpdate25CyclesMenuItem" xml:space="preserve"><value>Every 25 Cycles</value></data>
+  <data name="Menu.smartUpdate50CyclesMenuItem" xml:space="preserve"><value>Every 50 Cycles</value></data>
+  <data name="Menu.smartUpdateFollowUpdateIntervalMenuItem" xml:space="preserve"><value>Follow Update Interval</value></data>
+  <data name="Menu.splitPanelFixedPlotScalingMenuItem" xml:space="preserve"><value>Fixed Size Plot Panel</value></data>
+  <data name="Menu.splitPanelFixedSensorScalingMenuItem" xml:space="preserve"><value>Fixed Size Sensor Panel</value></data>
+  <data name="Menu.splitPanelPercentageScalingMenuItem" xml:space="preserve"><value>Percentage Scaling</value></data>
+  <data name="Menu.splitPlotPanelScalingMenuItem" xml:space="preserve"><value>Split Panel Scaling Mode</value></data>
+  <data name="Menu.startMinMenuItem" xml:space="preserve"><value>Start Minimized</value></data>
+  <data name="Menu.startupMenuItem" xml:space="preserve"><value>Run On Windows Startup</value></data>
+  <data name="Menu.strokeThicknessMenuItem" xml:space="preserve"><value>Stroke Thickness</value></data>
+  <data name="Menu.temperatureUnitsMenuItem" xml:space="preserve"><value>Temperature Unit</value></data>
+  <data name="Menu.themeMenuItem" xml:space="preserve"><value>Theme</value></data>
+  <data name="Menu.throttleSmartUpdateMenuItem" xml:space="preserve"><value>Throttle Disk S.M.A.R.T. Updates</value></data>
+  <data name="Menu.updateIntervalMenuItem" xml:space="preserve"><value>Update Interval</value></data>
+  <data name="Menu.valueMenuItem" xml:space="preserve"><value>Value</value></data>
+  <data name="Menu.viewMenuItem" xml:space="preserve"><value>View</value></data>
+  <data name="Menu.webMenuItem" xml:space="preserve"><value>Remote Web Server</value></data>
+  <data name="SensorGroup.Voltage" xml:space="preserve"><value>Voltages</value></data>
+  <data name="SensorGroup.Current" xml:space="preserve"><value>Currents</value></data>
+  <data name="SensorGroup.Energy" xml:space="preserve"><value>Capacities</value></data>
+  <data name="SensorGroup.Clock" xml:space="preserve"><value>Clocks</value></data>
+  <data name="SensorGroup.Load" xml:space="preserve"><value>Load</value></data>
+  <data name="SensorGroup.Temperature" xml:space="preserve"><value>Temperatures</value></data>
+  <data name="SensorGroup.Fan" xml:space="preserve"><value>Fans</value></data>
+  <data name="SensorGroup.Flow" xml:space="preserve"><value>Flows</value></data>
+  <data name="SensorGroup.Control" xml:space="preserve"><value>Controls</value></data>
+  <data name="SensorGroup.Level" xml:space="preserve"><value>Levels</value></data>
+  <data name="SensorGroup.Power" xml:space="preserve"><value>Powers</value></data>
+  <data name="SensorGroup.Data" xml:space="preserve"><value>Data</value></data>
+  <data name="SensorGroup.SmallData" xml:space="preserve"><value>Data</value></data>
+  <data name="SensorGroup.Factor" xml:space="preserve"><value>Factors</value></data>
+  <data name="SensorGroup.Frequency" xml:space="preserve"><value>Frequencies</value></data>
+  <data name="SensorGroup.Throughput" xml:space="preserve"><value>Throughput</value></data>
+  <data name="SensorGroup.TimeSpan" xml:space="preserve"><value>Times</value></data>
+  <data name="SensorGroup.Timing" xml:space="preserve"><value>Timings</value></data>
+  <data name="SensorGroup.Noise" xml:space="preserve"><value>Noise Levels</value></data>
+  <data name="SensorGroup.Conductivity" xml:space="preserve"><value>Conductivities</value></data>
+  <data name="SensorGroup.Humidity" xml:space="preserve"><value>Humidity Levels</value></data>
+  <data name="Message.RestartRequired" xml:space="preserve"><value>Language setting saved. Please restart the application for the change to take effect.</value></data>
+</root>

--- a/LibreHardwareMonitor.Windows.Forms/Localization/Strings.resx
+++ b/LibreHardwareMonitor.Windows.Forms/Localization/Strings.resx
@@ -12,6 +12,17 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ContextMenu.Control" xml:space="preserve"><value>Control</value></data>
+  <data name="ContextMenu.Default" xml:space="preserve"><value>Default</value></data>
+  <data name="ContextMenu.Hide" xml:space="preserve"><value>Hide</value></data>
+  <data name="ContextMenu.Manual" xml:space="preserve"><value>Manual</value></data>
+  <data name="ContextMenu.Parameters" xml:space="preserve"><value>Parameters...</value></data>
+  <data name="ContextMenu.PenColor" xml:space="preserve"><value>Pen Color...</value></data>
+  <data name="ContextMenu.Rename" xml:space="preserve"><value>Rename</value></data>
+  <data name="ContextMenu.ResetPenColor" xml:space="preserve"><value>Reset Pen Color</value></data>
+  <data name="ContextMenu.ShowInGadget" xml:space="preserve"><value>Show in Gadget</value></data>
+  <data name="ContextMenu.ShowInTray" xml:space="preserve"><value>Show in Tray</value></data>
+  <data name="ContextMenu.Unhide" xml:space="preserve"><value>Unhide</value></data>
   <data name="Menu.aboutMenuItem" xml:space="preserve"><value>About</value></data>
   <data name="Menu.authWebServerMenuItem" xml:space="preserve"><value>Authentication</value></data>
   <data name="Menu.batteryMenuItem" xml:space="preserve"><value>Batteries</value></data>
@@ -100,4 +111,17 @@
   <data name="SensorGroup.Conductivity" xml:space="preserve"><value>Conductivities</value></data>
   <data name="SensorGroup.Humidity" xml:space="preserve"><value>Humidity Levels</value></data>
   <data name="Message.RestartRequired" xml:space="preserve"><value>Language setting saved. Please restart the application for the change to take effect.</value></data>
+  <data name="Tray.HideShow" xml:space="preserve"><value>Hide/Show</value></data>
+  <data name="Tray.Exit" xml:space="preserve"><value>Exit</value></data>
+  <data name="Tray.RemoveSensor" xml:space="preserve"><value>Remove Sensor</value></data>
+  <data name="Tray.ChangeColor" xml:space="preserve"><value>Change Color...</value></data>
+  <data name="Menu.Theme.auto" xml:space="preserve"><value>Auto</value></data>
+  <data name="Menu.Theme.light" xml:space="preserve"><value>Light</value></data>
+  <data name="Menu.Theme.dark" xml:space="preserve"><value>Dark</value></data>
+  <data name="Menu.Theme.black" xml:space="preserve"><value>Black</value></data>
+  <data name="About.title" xml:space="preserve"><value>About</value></data>
+  <data name="About.ok" xml:space="preserve"><value>OK</value></data>
+  <data name="About.versionPrefix" xml:space="preserve"><value>Version </value></data>
+  <data name="About.projectWebsite" xml:space="preserve"><value>Project Website</value></data>
+  <data name="About.licensing" xml:space="preserve"><value>Licensing Information</value></data>
 </root>

--- a/LibreHardwareMonitor.Windows.Forms/Localization/Strings.zh-CN.resx
+++ b/LibreHardwareMonitor.Windows.Forms/Localization/Strings.zh-CN.resx
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Menu.aboutMenuItem" xml:space="preserve"><value>关于</value></data>
+  <data name="Menu.authWebServerMenuItem" xml:space="preserve"><value>身份验证</value></data>
+  <data name="Menu.batteryMenuItem" xml:space="preserve"><value>电池</value></data>
+  <data name="Menu.celsiusMenuItem" xml:space="preserve"><value>摄氏度</value></data>
+  <data name="Menu.collpaseAllNodesMenuItem" xml:space="preserve"><value>折叠全部节点</value></data>
+  <data name="Menu.columnsMenuItem" xml:space="preserve"><value>列</value></data>
+  <data name="Menu.cpuMenuItem" xml:space="preserve"><value>CPU</value></data>
+  <data name="Menu.dailyFileRotationMenuItem" xml:space="preserve"><value>按天</value></data>
+  <data name="Menu.exitMenuItem" xml:space="preserve"><value>退出</value></data>
+  <data name="Menu.expandAllNodesMenuItem" xml:space="preserve"><value>展开全部节点</value></data>
+  <data name="Menu.fahrenheitMenuItem" xml:space="preserve"><value>华氏度</value></data>
+  <data name="Menu.fanControllerMenuItem" xml:space="preserve"><value>风扇控制器</value></data>
+  <data name="Menu.fileMenuItem" xml:space="preserve"><value>文件</value></data>
+  <data name="Menu.fileRotationMethod" xml:space="preserve"><value>日志文件轮换方式</value></data>
+  <data name="Menu.forceDriveWakeupItem" xml:space="preserve"><value>强制唤醒硬盘</value></data>
+  <data name="Menu.gadgetMenuItem" xml:space="preserve"><value>显示悬浮窗</value></data>
+  <data name="Menu.gpuMenuItem" xml:space="preserve"><value>显卡</value></data>
+  <data name="Menu.hddMenuItem" xml:space="preserve"><value>存储设备</value></data>
+  <data name="Menu.helpMenuItem" xml:space="preserve"><value>帮助</value></data>
+  <data name="Menu.hiddenMenuItem" xml:space="preserve"><value>显示隐藏传感器</value></data>
+  <data name="Menu.languageMenuItem" xml:space="preserve"><value>语言</value></data>
+  <data name="Menu.logSensorsMenuItem" xml:space="preserve"><value>记录传感器日志</value></data>
+  <data name="Menu.loggingIntervalMenuItem" xml:space="preserve"><value>日志记录间隔</value></data>
+  <data name="Menu.mainboardMenuItem" xml:space="preserve"><value>主板</value></data>
+  <data name="Menu.maxMenuItem" xml:space="preserve"><value>最大</value></data>
+  <data name="Menu.menuItemFileHardware" xml:space="preserve"><value>硬件</value></data>
+  <data name="Menu.minCloseMenuItem" xml:space="preserve"><value>关闭时最小化到托盘</value></data>
+  <data name="Menu.minMenuItem" xml:space="preserve"><value>最小</value></data>
+  <data name="Menu.minTrayMenuItem" xml:space="preserve"><value>最小化到托盘</value></data>
+  <data name="Menu.nicMenuItem" xml:space="preserve"><value>网络</value></data>
+  <data name="Menu.optionsMenuItem" xml:space="preserve"><value>选项</value></data>
+  <data name="Menu.perSessionFileRotationMenuItem" xml:space="preserve"><value>按会话</value></data>
+  <data name="Menu.plotBottomMenuItem" xml:space="preserve"><value>底部</value></data>
+  <data name="Menu.plotLocationMenuItem" xml:space="preserve"><value>图表位置</value></data>
+  <data name="Menu.plotMenuItem" xml:space="preserve"><value>显示图表</value></data>
+  <data name="Menu.plotRightMenuItem" xml:space="preserve"><value>右侧</value></data>
+  <data name="Menu.plotWindowMenuItem" xml:space="preserve"><value>窗口</value></data>
+  <data name="Menu.powerMonitorMenuItem" xml:space="preserve"><value>电源监控</value></data>
+  <data name="Menu.psuMenuItem" xml:space="preserve"><value>电源</value></data>
+  <data name="Menu.ramMenuItem" xml:space="preserve"><value>内存</value></data>
+  <data name="Menu.resetMenuItem" xml:space="preserve"><value>重置</value></data>
+  <data name="Menu.resetMinMaxMenuItem" xml:space="preserve"><value>重置最小/最大值</value></data>
+  <data name="Menu.resetPlotMenuItem" xml:space="preserve"><value>重置图表</value></data>
+  <data name="Menu.runWebServerMenuItem" xml:space="preserve"><value>运行</value></data>
+  <data name="Menu.saveReportMenuItem" xml:space="preserve"><value>保存报告…</value></data>
+  <data name="Menu.sensorValuesTimeWindowMenuItem" xml:space="preserve"><value>传感器数值统计窗口</value></data>
+  <data name="Menu.serverInterfacePortMenuItem" xml:space="preserve"><value>接口 / 端口</value></data>
+  <data name="Menu.smartUpdate10CyclesMenuItem" xml:space="preserve"><value>每 10 个周期</value></data>
+  <data name="Menu.smartUpdate100CyclesMenuItem" xml:space="preserve"><value>每 100 个周期</value></data>
+  <data name="Menu.smartUpdate25CyclesMenuItem" xml:space="preserve"><value>每 25 个周期</value></data>
+  <data name="Menu.smartUpdate50CyclesMenuItem" xml:space="preserve"><value>每 50 个周期</value></data>
+  <data name="Menu.smartUpdateFollowUpdateIntervalMenuItem" xml:space="preserve"><value>跟随刷新间隔</value></data>
+  <data name="Menu.splitPanelFixedPlotScalingMenuItem" xml:space="preserve"><value>固定图表面板</value></data>
+  <data name="Menu.splitPanelFixedSensorScalingMenuItem" xml:space="preserve"><value>固定传感器面板</value></data>
+  <data name="Menu.splitPanelPercentageScalingMenuItem" xml:space="preserve"><value>百分比缩放</value></data>
+  <data name="Menu.splitPlotPanelScalingMenuItem" xml:space="preserve"><value>分栏缩放模式</value></data>
+  <data name="Menu.startMinMenuItem" xml:space="preserve"><value>最小化启动</value></data>
+  <data name="Menu.startupMenuItem" xml:space="preserve"><value>随 Windows 启动</value></data>
+  <data name="Menu.strokeThicknessMenuItem" xml:space="preserve"><value>线条粗细</value></data>
+  <data name="Menu.temperatureUnitsMenuItem" xml:space="preserve"><value>温度单位</value></data>
+  <data name="Menu.themeMenuItem" xml:space="preserve"><value>主题</value></data>
+  <data name="Menu.throttleSmartUpdateMenuItem" xml:space="preserve"><value>限制磁盘 S.M.A.R.T. 更新</value></data>
+  <data name="Menu.updateIntervalMenuItem" xml:space="preserve"><value>刷新间隔</value></data>
+  <data name="Menu.valueMenuItem" xml:space="preserve"><value>数值</value></data>
+  <data name="Menu.viewMenuItem" xml:space="preserve"><value>视图</value></data>
+  <data name="Menu.webMenuItem" xml:space="preserve"><value>远程 Web 服务器</value></data>
+  <data name="SensorGroup.Voltage" xml:space="preserve"><value>电压</value></data>
+  <data name="SensorGroup.Current" xml:space="preserve"><value>电流</value></data>
+  <data name="SensorGroup.Energy" xml:space="preserve"><value>容量</value></data>
+  <data name="SensorGroup.Clock" xml:space="preserve"><value>时钟</value></data>
+  <data name="SensorGroup.Load" xml:space="preserve"><value>负载</value></data>
+  <data name="SensorGroup.Temperature" xml:space="preserve"><value>温度</value></data>
+  <data name="SensorGroup.Fan" xml:space="preserve"><value>风扇</value></data>
+  <data name="SensorGroup.Flow" xml:space="preserve"><value>流速</value></data>
+  <data name="SensorGroup.Control" xml:space="preserve"><value>控制</value></data>
+  <data name="SensorGroup.Level" xml:space="preserve"><value>健康等级</value></data>
+  <data name="SensorGroup.Power" xml:space="preserve"><value>功率</value></data>
+  <data name="SensorGroup.Data" xml:space="preserve"><value>数据</value></data>
+  <data name="SensorGroup.SmallData" xml:space="preserve"><value>数据</value></data>
+  <data name="SensorGroup.Factor" xml:space="preserve"><value>系数</value></data>
+  <data name="SensorGroup.Frequency" xml:space="preserve"><value>频率</value></data>
+  <data name="SensorGroup.Throughput" xml:space="preserve"><value>吞吐量</value></data>
+  <data name="SensorGroup.TimeSpan" xml:space="preserve"><value>时长</value></data>
+  <data name="SensorGroup.Timing" xml:space="preserve"><value>时序</value></data>
+  <data name="SensorGroup.Noise" xml:space="preserve"><value>噪音等级</value></data>
+  <data name="SensorGroup.Conductivity" xml:space="preserve"><value>电导率</value></data>
+  <data name="SensorGroup.Humidity" xml:space="preserve"><value>湿度等级</value></data>
+  <data name="Message.RestartRequired" xml:space="preserve"><value>语言设置已保存，重启程序后生效。</value></data>
+</root>

--- a/LibreHardwareMonitor.Windows.Forms/Localization/Strings.zh-CN.resx
+++ b/LibreHardwareMonitor.Windows.Forms/Localization/Strings.zh-CN.resx
@@ -12,6 +12,17 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ContextMenu.Control" xml:space="preserve"><value>控制</value></data>
+  <data name="ContextMenu.Default" xml:space="preserve"><value>默认</value></data>
+  <data name="ContextMenu.Hide" xml:space="preserve"><value>隐藏</value></data>
+  <data name="ContextMenu.Manual" xml:space="preserve"><value>手动</value></data>
+  <data name="ContextMenu.Parameters" xml:space="preserve"><value>参数…</value></data>
+  <data name="ContextMenu.PenColor" xml:space="preserve"><value>画笔颜色…</value></data>
+  <data name="ContextMenu.Rename" xml:space="preserve"><value>重命名</value></data>
+  <data name="ContextMenu.ResetPenColor" xml:space="preserve"><value>重置画笔颜色</value></data>
+  <data name="ContextMenu.ShowInGadget" xml:space="preserve"><value>在悬浮窗中显示</value></data>
+  <data name="ContextMenu.ShowInTray" xml:space="preserve"><value>在托盘中显示</value></data>
+  <data name="ContextMenu.Unhide" xml:space="preserve"><value>取消隐藏</value></data>
   <data name="Menu.aboutMenuItem" xml:space="preserve"><value>关于</value></data>
   <data name="Menu.authWebServerMenuItem" xml:space="preserve"><value>身份验证</value></data>
   <data name="Menu.batteryMenuItem" xml:space="preserve"><value>电池</value></data>
@@ -91,7 +102,7 @@
   <data name="SensorGroup.Power" xml:space="preserve"><value>功率</value></data>
   <data name="SensorGroup.Data" xml:space="preserve"><value>数据</value></data>
   <data name="SensorGroup.SmallData" xml:space="preserve"><value>数据</value></data>
-  <data name="SensorGroup.Factor" xml:space="preserve"><value>系数</value></data>
+  <data name="SensorGroup.Factor" xml:space="preserve"><value>因子</value></data>
   <data name="SensorGroup.Frequency" xml:space="preserve"><value>频率</value></data>
   <data name="SensorGroup.Throughput" xml:space="preserve"><value>吞吐量</value></data>
   <data name="SensorGroup.TimeSpan" xml:space="preserve"><value>时长</value></data>
@@ -100,4 +111,77 @@
   <data name="SensorGroup.Conductivity" xml:space="preserve"><value>电导率</value></data>
   <data name="SensorGroup.Humidity" xml:space="preserve"><value>湿度等级</value></data>
   <data name="Message.RestartRequired" xml:space="preserve"><value>语言设置已保存，重启程序后生效。</value></data>
+  <data name="Plot.StackedAxes" xml:space="preserve"><value>堆叠坐标轴</value></data>
+  <data name="Plot.ShowAxesLabels" xml:space="preserve"><value>显示坐标轴标签</value></data>
+  <data name="Plot.TimeAxis" xml:space="preserve"><value>时间轴</value></data>
+  <data name="Plot.EnableZoom" xml:space="preserve"><value>启用缩放</value></data>
+  <data name="Plot.Auto" xml:space="preserve"><value>自动</value></data>
+  <data name="Plot.Zoom5min" xml:space="preserve"><value>5 分钟</value></data>
+  <data name="Plot.Zoom10min" xml:space="preserve"><value>10 分钟</value></data>
+  <data name="Plot.Zoom20min" xml:space="preserve"><value>20 分钟</value></data>
+  <data name="Plot.Zoom30min" xml:space="preserve"><value>30 分钟</value></data>
+  <data name="Plot.Zoom45min" xml:space="preserve"><value>45 分钟</value></data>
+  <data name="Plot.Zoom1h" xml:space="preserve"><value>1 小时</value></data>
+  <data name="Plot.Zoom1_5h" xml:space="preserve"><value>1.5 小时</value></data>
+  <data name="Plot.Zoom2h" xml:space="preserve"><value>2 小时</value></data>
+  <data name="Plot.Zoom3h" xml:space="preserve"><value>3 小时</value></data>
+  <data name="Plot.Zoom6h" xml:space="preserve"><value>6 小时</value></data>
+  <data name="Plot.Zoom12h" xml:space="preserve"><value>12 小时</value></data>
+  <data name="Plot.Zoom24h" xml:space="preserve"><value>24 小时</value></data>
+  <data name="Plot.ValueAxes" xml:space="preserve"><value>数值轴</value></data>
+  <data name="Plot.AutoscaleAll" xml:space="preserve"><value>自动缩放全部轴</value></data>
+  <data name="PlotAxis.Voltage" xml:space="preserve"><value>电压</value></data>
+  <data name="PlotAxis.Current" xml:space="preserve"><value>电流</value></data>
+  <data name="PlotAxis.Energy" xml:space="preserve"><value>能量</value></data>
+  <data name="PlotAxis.Clock" xml:space="preserve"><value>时钟</value></data>
+  <data name="PlotAxis.Load" xml:space="preserve"><value>负载</value></data>
+  <data name="PlotAxis.Temperature" xml:space="preserve"><value>温度</value></data>
+  <data name="PlotAxis.Fan" xml:space="preserve"><value>风扇</value></data>
+  <data name="PlotAxis.Flow" xml:space="preserve"><value>流速</value></data>
+  <data name="PlotAxis.Control" xml:space="preserve"><value>控制</value></data>
+  <data name="PlotAxis.Level" xml:space="preserve"><value>健康等级</value></data>
+  <data name="PlotAxis.Power" xml:space="preserve"><value>功率</value></data>
+  <data name="PlotAxis.Data" xml:space="preserve"><value>数据</value></data>
+  <data name="PlotAxis.SmallData" xml:space="preserve"><value>数据</value></data>
+  <data name="PlotAxis.Factor" xml:space="preserve"><value>系数</value></data>
+  <data name="PlotAxis.Frequency" xml:space="preserve"><value>频率</value></data>
+  <data name="PlotAxis.Throughput" xml:space="preserve"><value>吞吐量</value></data>
+  <data name="PlotAxis.TimeSpan" xml:space="preserve"><value>时长</value></data>
+  <data name="PlotAxis.Timing" xml:space="preserve"><value>时序</value></data>
+  <data name="PlotAxis.Noise" xml:space="preserve"><value>噪音等级</value></data>
+  <data name="PlotAxis.Conductivity" xml:space="preserve"><value>电导率</value></data>
+  <data name="PlotAxis.Humidity" xml:space="preserve"><value>湿度等级</value></data>
+  <data name="Gadget.HardwareNames" xml:space="preserve"><value>显示硬件名称</value></data>
+  <data name="Gadget.FontSize" xml:space="preserve"><value>字体大小</value></data>
+  <data name="Gadget.FontSizeSmall" xml:space="preserve"><value>小</value></data>
+  <data name="Gadget.FontSizeMedium" xml:space="preserve"><value>中</value></data>
+  <data name="Gadget.FontSizeLarge" xml:space="preserve"><value>大</value></data>
+  <data name="Gadget.FontSizeVeryLarge" xml:space="preserve"><value>特大</value></data>
+  <data name="Gadget.FontSizeExtremelyLarge" xml:space="preserve"><value>极大</value></data>
+  <data name="Gadget.FontColor" xml:space="preserve"><value>字体颜色</value></data>
+  <data name="Gadget.Choose" xml:space="preserve"><value>选择…</value></data>
+  <data name="Gadget.Default" xml:space="preserve"><value>默认</value></data>
+  <data name="Gadget.BackgroundColor" xml:space="preserve"><value>背景颜色</value></data>
+  <data name="Gadget.LockPositionAndSize" xml:space="preserve"><value>锁定位置和大小</value></data>
+  <data name="Gadget.AlwaysOnTop" xml:space="preserve"><value>总在最前</value></data>
+  <data name="Gadget.Opacity" xml:space="preserve"><value>不透明度</value></data>
+  <data name="Gadget.HideShowMainWindow" xml:space="preserve"><value>隐藏/显示主窗口</value></data>
+  <data name="Gadget.SelectColor" xml:space="preserve"><value>选择颜色</value></data>
+  <data name="Gadget.Hex" xml:space="preserve"><value>十六进制:</value></data>
+  <data name="Gadget.Ok" xml:space="preserve"><value>确定</value></data>
+  <data name="Gadget.Cancel" xml:space="preserve"><value>取消</value></data>
+  <data name="Gadget.EmptyHint" xml:space="preserve"><value>在主窗口中右键单击某个传感器，然后选择“在悬浮窗中显示”即可在此显示。</value></data>
+  <data name="Tray.HideShow" xml:space="preserve"><value>显示/隐藏</value></data>
+  <data name="Tray.Exit" xml:space="preserve"><value>退出</value></data>
+  <data name="Tray.RemoveSensor" xml:space="preserve"><value>移除传感器</value></data>
+  <data name="Tray.ChangeColor" xml:space="preserve"><value>更改颜色...</value></data>
+  <data name="Menu.Theme.auto" xml:space="preserve"><value>自动</value></data>
+  <data name="Menu.Theme.light" xml:space="preserve"><value>浅色</value></data>
+  <data name="Menu.Theme.dark" xml:space="preserve"><value>深色</value></data>
+  <data name="Menu.Theme.black" xml:space="preserve"><value>黑色</value></data>
+  <data name="About.title" xml:space="preserve"><value>关于</value></data>
+  <data name="About.ok" xml:space="preserve"><value>确定</value></data>
+  <data name="About.versionPrefix" xml:space="preserve"><value>版本 </value></data>
+  <data name="About.projectWebsite" xml:space="preserve"><value>项目网站</value></data>
+  <data name="About.licensing" xml:space="preserve"><value>许可信息</value></data>
 </root>

--- a/LibreHardwareMonitor.Windows.Forms/Localization/Strings.zh-CN.resx
+++ b/LibreHardwareMonitor.Windows.Forms/Localization/Strings.zh-CN.resx
@@ -54,7 +54,7 @@
   <data name="Menu.minTrayMenuItem" xml:space="preserve"><value>最小化到托盘</value></data>
   <data name="Menu.nicMenuItem" xml:space="preserve"><value>网络</value></data>
   <data name="Menu.optionsMenuItem" xml:space="preserve"><value>选项</value></data>
-  <data name="Menu.perSessionFileRotationMenuItem" xml:space="preserve"><value>按会话</value></data>
+  <data name="Menu.perSessionFileRotationMenuItem" xml:space="preserve"><value>每次运行一个文件</value></data>
   <data name="Menu.plotBottomMenuItem" xml:space="preserve"><value>底部</value></data>
   <data name="Menu.plotLocationMenuItem" xml:space="preserve"><value>图表位置</value></data>
   <data name="Menu.plotMenuItem" xml:space="preserve"><value>显示图表</value></data>

--- a/LibreHardwareMonitor.Windows.Forms/UI/AboutBox.cs
+++ b/LibreHardwareMonitor.Windows.Forms/UI/AboutBox.cs
@@ -1,4 +1,4 @@
-﻿// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 // Copyright (C) LibreHardwareMonitor and Contributors.
 // Partial Copyright (C) Michael Möller <mmoeller@openhardwaremonitor.org> and Contributors.
@@ -17,7 +17,11 @@ public sealed partial class AboutBox : Form
     {
         InitializeComponent();
         Font = SystemFonts.MessageBoxFont;
-        label3.Text = "Version " + Application.ProductVersion;
+        Text = LibreHardwareMonitor.Windows.Forms.Localization.LocalizationManager.Get("About.title") ?? "About";
+        okButton.Text = LibreHardwareMonitor.Windows.Forms.Localization.LocalizationManager.Get("About.ok") ?? "OK";
+        label3.Text = (LibreHardwareMonitor.Windows.Forms.Localization.LocalizationManager.Get("About.versionPrefix") ?? "Version ") + Application.ProductVersion;
+        projectLinkLabel.Text = LibreHardwareMonitor.Windows.Forms.Localization.LocalizationManager.Get("About.projectWebsite") ?? "Project Website";
+        licenseLinkLabel.Text = LibreHardwareMonitor.Windows.Forms.Localization.LocalizationManager.Get("About.licensing") ?? "Licensing Information";
         projectLinkLabel.Links.Remove(projectLinkLabel.Links[0]);
         projectLinkLabel.Links.Add(0, projectLinkLabel.Text.Length, "https://github.com/LibreHardwareMonitor/LibreHardwareMonitor");
         licenseLinkLabel.Links.Remove(licenseLinkLabel.Links[0]);

--- a/LibreHardwareMonitor.Windows.Forms/UI/HardwareNode.cs
+++ b/LibreHardwareMonitor.Windows.Forms/UI/HardwareNode.cs
@@ -1,10 +1,11 @@
-﻿// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 // Copyright (C) LibreHardwareMonitor and Contributors.
 // Partial Copyright (C) Michael Möller <mmoeller@openhardwaremonitor.org> and Contributors.
 // All Rights Reserved.
 
 using LibreHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Windows.Forms.Localization;
 using LibreHardwareMonitor.Windows.Forms.Utilities;
 using System;
 using System.Collections.Generic;
@@ -45,7 +46,7 @@ public class HardwareNode : Node, IExpandPersistNode
 
     public override string Text
     {
-        get { return Hardware.Name; }
+        get { return LocalizedNames.HardwareName(Hardware.Name); }
         set { Hardware.Name = value; }
     }
 

--- a/LibreHardwareMonitor.Windows.Forms/UI/MainForm.cs
+++ b/LibreHardwareMonitor.Windows.Forms/UI/MainForm.cs
@@ -599,10 +599,28 @@ public sealed partial class MainForm : Form
         chineseMenuItem.Checked = language != "en";
         _settings.SetValue("ui.language", language);
 
-        // Show the confirmation in the language the user just selected.
-        string title = LocalizationManager.GetFor("Menu.languageMenuItem", language) ?? "Language";
-        string message = LocalizationManager.GetFor("Message.RestartRequired", language) ?? "Language setting saved. Please restart the application for the change to take effect.";
-        MessageBox.Show(message, title, MessageBoxButtons.OK, MessageBoxIcon.Information);
+        // Apply immediately (hot switch): menus and the dynamically generated
+        // sensor/group names are re-evaluated on the next repaint.
+        LocalizationManager.SetLanguage(language);
+        LocalizationManager.ApplyToMenu(mainMenu.Items);
+        LocalizeThemeMenuItems();
+
+        treeView.Invalidate();
+        _systemTray.Redraw();
+        _gadget?.Redraw();
+    }
+
+    private void LocalizeThemeMenuItems()
+    {
+        foreach (ToolStripItem item in themeMenuItem.DropDownItems)
+        {
+            if (item.Tag is string key)
+            {
+                string text = LocalizationManager.Get(key);
+                if (!string.IsNullOrEmpty(text))
+                    item.Text = text;
+            }
+        }
     }
 
     private void StopFileHardwareMenuFromClosing(object sender, ToolStripDropDownClosingEventArgs e)
@@ -666,7 +684,8 @@ public sealed partial class MainForm : Form
         if (Theme.SupportsAutoThemeSwitching())
         {
             _autoThemeMenuItem = new ToolStripMenuItem();
-            _autoThemeMenuItem.Text = "Auto";
+            _autoThemeMenuItem.Text = LocalizationManager.Get("Menu.Theme.auto") ?? "Auto";
+            _autoThemeMenuItem.Tag = "Menu.Theme.auto";
             _autoThemeMenuItem.Click += (o, e) =>
             {
                 ClearThemeMenu();
@@ -681,7 +700,8 @@ public sealed partial class MainForm : Form
         foreach (Theme theme in Theme.All)
         {
             ToolStripMenuItem item = new ToolStripMenuItem();
-            item.Text = theme.DisplayName;
+            item.Text = LocalizationManager.Get("Menu.Theme." + theme.Id) ?? theme.DisplayName;
+            item.Tag = "Menu.Theme." + theme.Id;
             item.Click += (o, e) =>
             {
                 ClearThemeMenu();
@@ -1139,34 +1159,34 @@ public sealed partial class MainForm : Form
                 treeContextMenu.Items.Clear();
                 if (node.Sensor.Parameters.Count > 0)
                 {
-                    ToolStripItem item = new ToolStripMenuItem("Parameters...");
+                    ToolStripItem item = new ToolStripMenuItem(LocalizationManager.Get("ContextMenu.Parameters") ?? "Parameters...");
                     item.Click += delegate { ShowParameterForm(node.Sensor); };
                     treeContextMenu.Items.Add(item);
                 }
 
                 if (nodeTextBoxText.EditEnabled)
                 {
-                    ToolStripItem item = new ToolStripMenuItem("Rename");
+                    ToolStripItem item = new ToolStripMenuItem(LocalizationManager.Get("ContextMenu.Rename") ?? "Rename");
                     item.Click += delegate { nodeTextBoxText.BeginEdit(); };
                     treeContextMenu.Items.Add(item);
                 }
 
                 if (node.IsVisible)
                 {
-                    ToolStripItem item = new ToolStripMenuItem("Hide");
+                    ToolStripItem item = new ToolStripMenuItem(LocalizationManager.Get("ContextMenu.Hide") ?? "Hide");
                     item.Click += delegate { node.IsVisible = false; };
                     treeContextMenu.Items.Add(item);
                 }
                 else
                 {
-                    ToolStripItem item = new ToolStripMenuItem("Unhide");
+                    ToolStripItem item = new ToolStripMenuItem(LocalizationManager.Get("ContextMenu.Unhide") ?? "Unhide");
                     item.Click += delegate { node.IsVisible = true; };
                     treeContextMenu.Items.Add(item);
                 }
 
                 treeContextMenu.Items.Add(new ToolStripSeparator());
                 {
-                    ToolStripItem item = new ToolStripMenuItem("Pen Color...");
+                    ToolStripItem item = new ToolStripMenuItem(LocalizationManager.Get("ContextMenu.PenColor") ?? "Pen Color...");
                     item.Click += delegate
                     {
                         ColorDialog dialog = new() { Color = node.PenColor.GetValueOrDefault() };
@@ -1178,14 +1198,14 @@ public sealed partial class MainForm : Form
                 }
 
                 {
-                    ToolStripItem item = new ToolStripMenuItem("Reset Pen Color");
+                    ToolStripItem item = new ToolStripMenuItem(LocalizationManager.Get("ContextMenu.ResetPenColor") ?? "Reset Pen Color");
                     item.Click += delegate { node.PenColor = null; };
                     treeContextMenu.Items.Add(item);
                 }
 
                 treeContextMenu.Items.Add(new ToolStripSeparator());
                 {
-                    ToolStripMenuItem item = new("Show in Tray") { Checked = _systemTray.Contains(node.Sensor) };
+                    ToolStripMenuItem item = new(LocalizationManager.Get("ContextMenu.ShowInTray") ?? "Show in Tray") { Checked = _systemTray.Contains(node.Sensor) };
                     item.Click += delegate
                     {
                         if (item.Checked)
@@ -1199,7 +1219,7 @@ public sealed partial class MainForm : Form
 
                 if (_gadget != null)
                 {
-                    ToolStripMenuItem item = new("Show in Gadget") { Checked = _gadget.Contains(node.Sensor) };
+                    ToolStripMenuItem item = new(LocalizationManager.Get("ContextMenu.ShowInGadget") ?? "Show in Gadget") { Checked = _gadget.Contains(node.Sensor) };
                     item.Click += delegate
                     {
                         if (item.Checked)
@@ -1219,11 +1239,11 @@ public sealed partial class MainForm : Form
                 {
                     treeContextMenu.Items.Add(new ToolStripSeparator());
                     IControl control = node.Sensor.Control;
-                    ToolStripMenuItem controlItem = new("Control");
-                    ToolStripItem defaultItem = new ToolStripMenuItem("Default") { Checked = control.ControlMode == ControlMode.Default };
+                    ToolStripMenuItem controlItem = new(LocalizationManager.Get("ContextMenu.Control") ?? "Control");
+                    ToolStripItem defaultItem = new ToolStripMenuItem(LocalizationManager.Get("ContextMenu.Default") ?? "Default") { Checked = control.ControlMode == ControlMode.Default };
                     controlItem.DropDownItems.Add(defaultItem);
                     defaultItem.Click += delegate { control.SetDefault(); };
-                    ToolStripMenuItem manualItem = new("Manual");
+                    ToolStripMenuItem manualItem = new(LocalizationManager.Get("ContextMenu.Manual") ?? "Manual");
                     controlItem.DropDownItems.Add(manualItem);
                     manualItem.Checked = control.ControlMode == ControlMode.Software;
                     for (int i = 0; i <= 100; i += 5)
@@ -1251,7 +1271,7 @@ public sealed partial class MainForm : Form
 
                 if (nodeTextBoxText.EditEnabled)
                 {
-                    ToolStripItem item = new ToolStripMenuItem("Rename");
+                    ToolStripItem item = new ToolStripMenuItem(LocalizationManager.Get("ContextMenu.Rename") ?? "Rename");
                     item.Click += delegate { nodeTextBoxText.BeginEdit(); };
                     treeContextMenu.Items.Add(item);
                 }

--- a/LibreHardwareMonitor.Windows.Forms/UI/MainForm.cs
+++ b/LibreHardwareMonitor.Windows.Forms/UI/MainForm.cs
@@ -17,6 +17,7 @@ using Aga.Controls.Tree;
 using Aga.Controls.Tree.NodeControls;
 using LibreHardwareMonitor.Hardware;
 using LibreHardwareMonitor.Hardware.Storage;
+using LibreHardwareMonitor.Windows.Forms.Localization;
 using LibreHardwareMonitor.Windows.Forms.UI.Themes;
 using LibreHardwareMonitor.Windows.Forms.Utilities;
 
@@ -73,6 +74,10 @@ public sealed partial class MainForm : Form
 
         _settings = new PersistentSettings();
         _settings.Load(Path.ChangeExtension(Application.ExecutablePath, ".config"));
+
+        // Apply the saved UI language before any text is resolved so that satellite resources
+        // and the display-layer localization below use the right culture from the start.
+        LocalizationManager.SetLanguage(_settings.GetValue("ui.language", "en"));
 
         _unitManager = new UnitManager(_settings);
 
@@ -534,6 +539,11 @@ public sealed partial class MainForm : Form
         InitializePlotForm();
         InitializeSplitter();
 
+        // The language selector is a display-layer control: it must be added before the menu
+        // texts are localized, but everything else in the UI is left untouched in English.
+        InitializeLanguageMenu();
+        LocalizationManager.ApplyToMenu(mainMenu.Items);
+
         startupMenuItem.Visible = _startupManager.IsAvailable;
 
         if (startMinMenuItem.Checked)
@@ -561,6 +571,38 @@ public sealed partial class MainForm : Form
         };
 
         Microsoft.Win32.SystemEvents.PowerModeChanged += PowerModeChanged;
+    }
+
+    private void InitializeLanguageMenu()
+    {
+        ToolStripMenuItem languageMenuItem = new() { Name = "languageMenuItem", Text = "Language" };
+        ToolStripMenuItem englishMenuItem = new() { Name = "englishMenuItem", Text = "English" };
+        ToolStripMenuItem chineseMenuItem = new() { Name = "chineseMenuItem", Text = "中文" };
+
+        string current = _settings.GetValue("ui.language", "en");
+        englishMenuItem.Checked = current == "en";
+        chineseMenuItem.Checked = current != "en";
+
+        englishMenuItem.Click += (sender, e) => SelectLanguage("en", englishMenuItem, chineseMenuItem);
+        chineseMenuItem.Click += (sender, e) => SelectLanguage("zh-CN", englishMenuItem, chineseMenuItem);
+
+        languageMenuItem.DropDownItems.Add(englishMenuItem);
+        languageMenuItem.DropDownItems.Add(chineseMenuItem);
+
+        optionsMenuItem.DropDownItems.Insert(5, languageMenuItem);
+        optionsMenuItem.DropDownItems.Insert(6, new ToolStripSeparator());
+    }
+
+    private void SelectLanguage(string language, ToolStripMenuItem englishMenuItem, ToolStripMenuItem chineseMenuItem)
+    {
+        englishMenuItem.Checked = language == "en";
+        chineseMenuItem.Checked = language != "en";
+        _settings.SetValue("ui.language", language);
+
+        // Show the confirmation in the language the user just selected.
+        string title = LocalizationManager.GetFor("Menu.languageMenuItem", language) ?? "Language";
+        string message = LocalizationManager.GetFor("Message.RestartRequired", language) ?? "Language setting saved. Please restart the application for the change to take effect.";
+        MessageBox.Show(message, title, MessageBoxButtons.OK, MessageBoxIcon.Information);
     }
 
     private void StopFileHardwareMenuFromClosing(object sender, ToolStripDropDownClosingEventArgs e)

--- a/LibreHardwareMonitor.Windows.Forms/UI/PlotPanel.cs
+++ b/LibreHardwareMonitor.Windows.Forms/UI/PlotPanel.cs
@@ -1,4 +1,4 @@
-﻿// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 // Copyright (C) LibreHardwareMonitor and Contributors.
 // Partial Copyright (C) Michael Möller <mmoeller@openhardwaremonitor.org> and Contributors.
@@ -16,6 +16,7 @@ using OxyPlot.Annotations;
 using OxyPlot.Axes;
 using OxyPlot.WindowsForms;
 using OxyPlot.Series;
+using LibreHardwareMonitor.Windows.Forms.Localization;
 using LibreHardwareMonitor.Windows.Forms.UI.Themes;
 
 namespace LibreHardwareMonitor.Windows.Forms.UI;
@@ -127,7 +128,9 @@ public class PlotPanel : UserControl
             }
         };
 
-        ToolStripMenuItem stackedAxesMenuItem = new ToolStripMenuItem("Stacked Axes");
+        string L(string key, string fallback) => LocalizationManager.Get("Plot." + key) ?? fallback;
+
+        ToolStripMenuItem stackedAxesMenuItem = new ToolStripMenuItem(L("StackedAxes", "Stacked Axes"));
         _stackedAxes = new UserOption("stackedAxes", true, stackedAxesMenuItem, _settings);
         _stackedAxes.Changed += (sender, e) =>
         {
@@ -136,7 +139,7 @@ public class PlotPanel : UserControl
         };
         menu.Items.Add(stackedAxesMenuItem);
 
-        ToolStripMenuItem showAxesLabelsMenuItem = new ToolStripMenuItem("Show Axes Labels");
+        ToolStripMenuItem showAxesLabelsMenuItem = new ToolStripMenuItem(L("ShowAxesLabels", "Show Axes Labels"));
         _showAxesLabels = new UserOption("showAxesLabels", true, showAxesLabelsMenuItem, _settings);
         _showAxesLabels.Changed += (sender, e) =>
         {
@@ -147,22 +150,22 @@ public class PlotPanel : UserControl
         };
         menu.Items.Add(showAxesLabelsMenuItem);
 
-        ToolStripMenuItem timeAxisMenuItem = new ToolStripMenuItem("Time Axis");
+        ToolStripMenuItem timeAxisMenuItem = new ToolStripMenuItem(L("TimeAxis", "Time Axis"));
         ToolStripMenuItem[] timeAxisMenuItems =
-        { new ToolStripMenuItem("Enable Zoom"),
-            new ToolStripMenuItem("Auto", null, (s, e) => { TimeAxisZoom(0, double.NaN); }),
-            new ToolStripMenuItem("5 min", null, (s, e) => { TimeAxisZoom(0, 5 * 60); }),
-            new ToolStripMenuItem("10 min", null, (s, e) => { TimeAxisZoom(0, 10 * 60); }),
-            new ToolStripMenuItem("20 min", null, (s, e) => { TimeAxisZoom(0, 20 * 60); }),
-            new ToolStripMenuItem("30 min", null, (s, e) => { TimeAxisZoom(0, 30 * 60); }),
-            new ToolStripMenuItem("45 min", null, (s, e) => { TimeAxisZoom(0, 45 * 60); }),
-            new ToolStripMenuItem("1 h", null, (s, e) => { TimeAxisZoom(0, 60 * 60); }),
-            new ToolStripMenuItem("1.5 h", null, (s, e) => { TimeAxisZoom(0, 1.5 * 60 * 60); }),
-            new ToolStripMenuItem("2 h", null, (s, e) => { TimeAxisZoom(0, 2 * 60 * 60); }),
-            new ToolStripMenuItem("3 h", null, (s, e) => { TimeAxisZoom(0, 3 * 60 * 60); }),
-            new ToolStripMenuItem("6 h", null, (s, e) => { TimeAxisZoom(0, 6 * 60 * 60); }),
-            new ToolStripMenuItem("12 h", null, (s, e) => { TimeAxisZoom(0, 12 * 60 * 60); }),
-            new ToolStripMenuItem("24 h", null, (s, e) => { TimeAxisZoom(0, 24 * 60 * 60); }) };
+        { new ToolStripMenuItem(L("EnableZoom", "Enable Zoom")),
+            new ToolStripMenuItem(L("Auto", "Auto"), null, (s, e) => { TimeAxisZoom(0, double.NaN); }),
+            new ToolStripMenuItem(L("Zoom5min", "5 min"), null, (s, e) => { TimeAxisZoom(0, 5 * 60); }),
+            new ToolStripMenuItem(L("Zoom10min", "10 min"), null, (s, e) => { TimeAxisZoom(0, 10 * 60); }),
+            new ToolStripMenuItem(L("Zoom20min", "20 min"), null, (s, e) => { TimeAxisZoom(0, 20 * 60); }),
+            new ToolStripMenuItem(L("Zoom30min", "30 min"), null, (s, e) => { TimeAxisZoom(0, 30 * 60); }),
+            new ToolStripMenuItem(L("Zoom45min", "45 min"), null, (s, e) => { TimeAxisZoom(0, 45 * 60); }),
+            new ToolStripMenuItem(L("Zoom1h", "1 h"), null, (s, e) => { TimeAxisZoom(0, 60 * 60); }),
+            new ToolStripMenuItem(L("Zoom1_5h", "1.5 h"), null, (s, e) => { TimeAxisZoom(0, 1.5 * 60 * 60); }),
+            new ToolStripMenuItem(L("Zoom2h", "2 h"), null, (s, e) => { TimeAxisZoom(0, 2 * 60 * 60); }),
+            new ToolStripMenuItem(L("Zoom3h", "3 h"), null, (s, e) => { TimeAxisZoom(0, 3 * 60 * 60); }),
+            new ToolStripMenuItem(L("Zoom6h", "6 h"), null, (s, e) => { TimeAxisZoom(0, 6 * 60 * 60); }),
+            new ToolStripMenuItem(L("Zoom12h", "12 h"), null, (s, e) => { TimeAxisZoom(0, 12 * 60 * 60); }),
+            new ToolStripMenuItem(L("Zoom24h", "24 h"), null, (s, e) => { TimeAxisZoom(0, 24 * 60 * 60); }) };
 
         foreach (ToolStripItem mi in timeAxisMenuItems)
             timeAxisMenuItem.DropDownItems.Add(mi);
@@ -174,10 +177,10 @@ public class PlotPanel : UserControl
             _timeAxis.IsZoomEnabled = _timeAxisEnableZoom.Value;
         };
 
-        ToolStripMenuItem yAxesMenuItem = new ToolStripMenuItem("Value Axes");
+        ToolStripMenuItem yAxesMenuItem = new ToolStripMenuItem(L("ValueAxes", "Value Axes"));
         ToolStripMenuItem[] yAxesMenuItems =
-        { new ToolStripMenuItem("Enable Zoom"),
-            new ToolStripMenuItem("Autoscale All", null, (s, e) => { AutoscaleAllYAxes(); }) };
+        { new ToolStripMenuItem(L("EnableZoom", "Enable Zoom")),
+            new ToolStripMenuItem(L("AutoscaleAll", "Autoscale All"), null, (s, e) => { AutoscaleAllYAxes(); }) };
 
         foreach (ToolStripItem mi in yAxesMenuItems)
             yAxesMenuItem.DropDownItems.Add(mi);
@@ -248,7 +251,7 @@ public class PlotPanel : UserControl
                 MinorGridlineThickness = 1,
                 MinorGridlineColor = _timeAxis.MinorGridlineColor,
                 AxislineStyle = LineStyle.Solid,
-                Title = typeName,
+                Title = LocalizationManager.Get("PlotAxis." + typeName) ?? typeName,
                 Key = typeName,
             };
 
@@ -341,7 +344,7 @@ public class PlotPanel : UserControl
                 Color = colors[sensor].ToOxyColor(),
                 StrokeThickness = strokeThickness,
                 YAxisKey = _axes[sensor.SensorType].Key,
-                Title = sensor.Hardware.Name + " " + sensor.Name
+                Title = sensor.Hardware.Name + " " + LocalizedNames.SensorName(sensor.Name)
             };
 
             _model.Series.Add(series);

--- a/LibreHardwareMonitor.Windows.Forms/UI/SensorGadget.cs
+++ b/LibreHardwareMonitor.Windows.Forms/UI/SensorGadget.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using LibreHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Windows.Forms.Localization;
 using LibreHardwareMonitor.Windows.Forms.UI.Themes;
 using LibreHardwareMonitor.Windows.Forms.Utilities;
 
@@ -143,21 +144,23 @@ public class SensorGadget : Gadget
         SetFontSize(settings.GetValue("sensorGadget.FontSize", 7.5f));
         Resize(settings.GetValue("sensorGadget.Width", Size.Width));
 
+        string L(string key, string fallback) => LocalizationManager.Get("Gadget." + key) ?? fallback;
+
         ContextMenuStrip contextMenuStrip = new ContextMenuStrip();
-        ToolStripMenuItem hardwareNamesItem = new ToolStripMenuItem("Hardware Names");
+        ToolStripMenuItem hardwareNamesItem = new ToolStripMenuItem(L("HardwareNames", "Hardware Names"));
         contextMenuStrip.Items.Add(hardwareNamesItem);
-        ToolStripMenuItem fontSizeMenu = new ToolStripMenuItem("Font Size");
+        ToolStripMenuItem fontSizeMenu = new ToolStripMenuItem(L("FontSize", "Font Size"));
         for (int i = 0; i < 5; i++)
         {
             float size;
             string name;
             switch (i)
             {
-                case 0: size = 6.5f; name = "Small"; break;
-                case 1: size = 7.5f; name = "Medium"; break;
-                case 2: size = 9f; name = "Large"; break;
-                case 3: size = 11f; name = "Very Large"; break;
-                case 4: size = 22f; name = "Extremely Large"; break;
+                case 0: size = 6.5f; name = L("FontSizeSmall", "Small"); break;
+                case 1: size = 7.5f; name = L("FontSizeMedium", "Medium"); break;
+                case 2: size = 9f; name = L("FontSizeLarge", "Large"); break;
+                case 3: size = 11f; name = L("FontSizeVeryLarge", "Very Large"); break;
+                case 4: size = 22f; name = L("FontSizeExtremelyLarge", "Extremely Large"); break;
                 default: throw new NotImplementedException();
             }
 
@@ -176,8 +179,8 @@ public class SensorGadget : Gadget
         Color fontColor = settings.GetValue("sensorGadget.FontColor", Color.White);
         SetFontColor(fontColor);
 
-        ToolStripMenuItem fontColorMenu = new ToolStripMenuItem("Font Color");
-        ToolStripItem chooseFontColorItem = new ToolStripMenuItem("Choose...");
+        ToolStripMenuItem fontColorMenu = new ToolStripMenuItem(L("FontColor", "Font Color"));
+        ToolStripItem chooseFontColorItem = new ToolStripMenuItem(L("Choose", "Choose..."));
         chooseFontColorItem.Click += delegate
         {
             if (TrySelectColor(fontColor, out Color selectedColor))
@@ -190,7 +193,7 @@ public class SensorGadget : Gadget
         };
         fontColorMenu.DropDownItems.Add(chooseFontColorItem);
 
-        ToolStripItem defaultFontColorItem = new ToolStripMenuItem("Default");
+        ToolStripItem defaultFontColorItem = new ToolStripMenuItem(L("Default", "Default"));
         defaultFontColorItem.Click += delegate
         {
             fontColor = Color.White;
@@ -204,8 +207,8 @@ public class SensorGadget : Gadget
         Color backgroundColor = settings.GetValue("sensorGadget.BackgroundColor", Color.FromArgb(0));
         SetBackgroundColor(backgroundColor);
 
-        ToolStripMenuItem backgroundColorMenu = new ToolStripMenuItem("Background Color");
-        ToolStripItem chooseBackgroundItem = new ToolStripMenuItem("Choose...");
+        ToolStripMenuItem backgroundColorMenu = new ToolStripMenuItem(L("BackgroundColor", "Background Color"));
+        ToolStripItem chooseBackgroundItem = new ToolStripMenuItem(L("Choose", "Choose..."));
         chooseBackgroundItem.Click += delegate
         {
             if (TrySelectColor(backgroundColor.A == 0 ? Color.White : backgroundColor, out Color selectedColor))
@@ -217,7 +220,7 @@ public class SensorGadget : Gadget
         };
         backgroundColorMenu.DropDownItems.Add(chooseBackgroundItem);
 
-        ToolStripItem defaultBackgroundItem = new ToolStripMenuItem("Default");
+        ToolStripItem defaultBackgroundItem = new ToolStripMenuItem(L("Default", "Default"));
         defaultBackgroundItem.Click += delegate
         {
             Color color = Color.FromArgb(0);
@@ -228,12 +231,12 @@ public class SensorGadget : Gadget
         backgroundColorMenu.DropDownItems.Add(defaultBackgroundItem);
         contextMenuStrip.Items.Add(backgroundColorMenu);
         contextMenuStrip.Items.Add(new ToolStripSeparator());
-        ToolStripMenuItem lockItem = new ToolStripMenuItem("Lock Position and Size");
+        ToolStripMenuItem lockItem = new ToolStripMenuItem(L("LockPositionAndSize", "Lock Position and Size"));
         contextMenuStrip.Items.Add(lockItem);
         contextMenuStrip.Items.Add(new ToolStripSeparator());
-        ToolStripMenuItem alwaysOnTopItem = new ToolStripMenuItem("Always on Top");
+        ToolStripMenuItem alwaysOnTopItem = new ToolStripMenuItem(L("AlwaysOnTop", "Always on Top"));
         contextMenuStrip.Items.Add(alwaysOnTopItem);
-        ToolStripMenuItem opacityMenu = new ToolStripMenuItem("Opacity");
+        ToolStripMenuItem opacityMenu = new ToolStripMenuItem(L("Opacity", "Opacity"));
         contextMenuStrip.Items.Add(opacityMenu);
         Opacity = (byte)settings.GetValue("sensorGadget.Opacity", 255);
 
@@ -253,7 +256,7 @@ public class SensorGadget : Gadget
         }
 
         contextMenuStrip.Items.Add(new ToolStripSeparator());
-        ToolStripMenuItem hideShowItem = new ToolStripMenuItem("Hide/Show Main Window");
+        ToolStripMenuItem hideShowItem = new ToolStripMenuItem(L("HideShowMainWindow", "Hide/Show Main Window"));
         contextMenuStrip.Items.Add(hideShowItem);
 
         ContextMenuStrip = contextMenuStrip;
@@ -693,7 +696,7 @@ public class SensorGadget : Gadget
     {
         using Form form = new Form
         {
-            Text = "Select Color",
+            Text = LocalizationManager.Get("Gadget.SelectColor") ?? "Select Color",
             FormBorderStyle = FormBorderStyle.Sizable,
             StartPosition = FormStartPosition.CenterScreen,
             MinimizeBox = false,
@@ -738,7 +741,7 @@ public class SensorGadget : Gadget
         {
             AutoSize = true,
             Location = new Point(0, 0),
-            Text = "Hex:"
+            Text = LocalizationManager.Get("Gadget.Hex") ?? "Hex:"
         };
         TextBox hexTextBox = new TextBox
         {
@@ -748,7 +751,7 @@ public class SensorGadget : Gadget
 
         Button okButton = new Button
         {
-            Text = "OK",
+            Text = LocalizationManager.Get("Gadget.Ok") ?? "OK",
             DialogResult = DialogResult.OK,
             AutoSize = true,
             AutoSizeMode = AutoSizeMode.GrowAndShrink,
@@ -757,7 +760,7 @@ public class SensorGadget : Gadget
         };
         Button cancelButton = new Button
         {
-            Text = "Cancel",
+            Text = LocalizationManager.Get("Gadget.Cancel") ?? "Cancel",
             DialogResult = DialogResult.Cancel,
             AutoSize = true,
             AutoSizeMode = AutoSizeMode.GrowAndShrink,
@@ -1138,7 +1141,8 @@ public class SensorGadget : Gadget
             if (_sensors.Count == 0)
             {
                 x = LeftBorder + 1;
-                g.DrawString("Right-click on a sensor in the main window and select " +
+                g.DrawString(LocalizationManager.Get("Gadget.EmptyHint") ??
+                             "Right-click on a sensor in the main window and select " +
                              "\"Show in Gadget\" to show the sensor here.",
                              _smallFont, _textBrush,
                              new Rectangle(x, y - 1, w - RightBorder - x, 0));
@@ -1296,7 +1300,7 @@ public class SensorGadget : Gadget
                     remainingWidth -= _leftMargin + 2;
                     if (remainingWidth > 0)
                     {
-                        g.DrawString(sensor.Name, _smallFont, _textBrush, new RectangleF(_leftMargin - 1, y - 1, remainingWidth, 0), _trimStringFormat);
+                        g.DrawString(LocalizedNames.SensorName(sensor.Name), _smallFont, _textBrush, new RectangleF(_leftMargin - 1, y - 1, remainingWidth, 0), _trimStringFormat);
                     }
                     y += _sensorLineHeight;
                 }

--- a/LibreHardwareMonitor.Windows.Forms/UI/SensorNode.cs
+++ b/LibreHardwareMonitor.Windows.Forms/UI/SensorNode.cs
@@ -1,4 +1,4 @@
-﻿// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 // Copyright (C) LibreHardwareMonitor and Contributors.
 // Partial Copyright (C) Michael Möller <mmoeller@openhardwaremonitor.org> and Contributors.
@@ -9,6 +9,7 @@ using System.Drawing;
 using System.Globalization;
 using System.Text;
 using LibreHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Windows.Forms.Localization;
 using LibreHardwareMonitor.Windows.Forms.Utilities;
 
 namespace LibreHardwareMonitor.Windows.Forms.UI;
@@ -158,7 +159,7 @@ public class SensorNode : Node
 
     public override string Text
     {
-        get { return Sensor.Name; }
+        get { return LocalizedNames.SensorName(Sensor.Name); }
         set { Sensor.Name = value; }
     }
 

--- a/LibreHardwareMonitor.Windows.Forms/UI/SensorNotifyIcon.cs
+++ b/LibreHardwareMonitor.Windows.Forms/UI/SensorNotifyIcon.cs
@@ -12,6 +12,7 @@ using System.Drawing.Text;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using LibreHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Windows.Forms.Localization;
 using LibreHardwareMonitor.Windows.Forms.Utilities;
 
 namespace LibreHardwareMonitor.Windows.Forms.UI;
@@ -29,6 +30,10 @@ public class SensorNotifyIcon : IDisposable
     private readonly Pen _pen;
     private readonly Font _font;
     private readonly Font _smallFont;
+    private readonly ToolStripItem _hideShowItem;
+    private readonly ToolStripItem _removeItem;
+    private readonly ToolStripItem _colorItem;
+    private readonly ToolStripItem _exitItem;
 
     public SensorNotifyIcon(SystemTray sensorSystemTray, ISensor sensor, PersistentSettings settings, UnitManager unitManager)
     {
@@ -44,21 +49,21 @@ public class SensorNotifyIcon : IDisposable
 
         _pen = new Pen(Color.FromArgb(96, Color.Black));
         ContextMenuStrip contextMenuStrip = new ContextMenuStrip();
-        ToolStripItem hideShowItem = new ToolStripMenuItem("Hide/Show");
-        hideShowItem.Click += delegate
+        _hideShowItem = new ToolStripMenuItem();
+        _hideShowItem.Click += delegate
         {
             sensorSystemTray.SendHideShowCommand();
         };
-        contextMenuStrip.Items.Add(hideShowItem);
+        contextMenuStrip.Items.Add(_hideShowItem);
         contextMenuStrip.Items.Add(new ToolStripSeparator());
-        ToolStripItem removeItem = new ToolStripMenuItem("Remove Sensor");
-        removeItem.Click += delegate
+        _removeItem = new ToolStripMenuItem();
+        _removeItem.Click += delegate
         {
             sensorSystemTray.Remove(Sensor);
         };
-        contextMenuStrip.Items.Add(removeItem);
-        ToolStripItem colorItem = new ToolStripMenuItem("Change Color...");
-        colorItem.Click += delegate
+        contextMenuStrip.Items.Add(_removeItem);
+        _colorItem = new ToolStripMenuItem();
+        _colorItem.Click += delegate
         {
             ColorDialog dialog = new ColorDialog { Color = Color };
             if (dialog.ShowDialog() == DialogResult.OK)
@@ -68,14 +73,25 @@ public class SensorNotifyIcon : IDisposable
                                                  "traycolor").ToString(), Color);
             }
         };
-        contextMenuStrip.Items.Add(colorItem);
+        contextMenuStrip.Items.Add(_colorItem);
         contextMenuStrip.Items.Add(new ToolStripSeparator());
-        ToolStripItem exitItem = new ToolStripMenuItem("Exit");
-        exitItem.Click += delegate
+        _exitItem = new ToolStripMenuItem();
+        _exitItem.Click += delegate
         {
             sensorSystemTray.SendExitCommand();
         };
-        contextMenuStrip.Items.Add(exitItem);
+        contextMenuStrip.Items.Add(_exitItem);
+
+        // Resolve the text every time the menu is opened, so that a run-time language
+        // switch is reflected here as well.
+        contextMenuStrip.Opening += delegate
+        {
+            _hideShowItem.Text = LocalizationManager.Get("Tray.HideShow") ?? "Hide/Show";
+            _removeItem.Text = LocalizationManager.Get("Tray.RemoveSensor") ?? "Remove Sensor";
+            _colorItem.Text = LocalizationManager.Get("Tray.ChangeColor") ?? "Change Color...";
+            _exitItem.Text = LocalizationManager.Get("Tray.Exit") ?? "Exit";
+        };
+
         _notifyIcon.ContextMenuStrip = contextMenuStrip;
         _notifyIcon.DoubleClick += delegate
         {
@@ -294,12 +310,12 @@ public class SensorNotifyIcon : IDisposable
             case SensorType.Timing: format = "\n{0}: {0:F3} ns"; break;
         }
 
-        string formattedValue = string.Format(format, Sensor.Name, Sensor.Value);
+        string formattedValue = string.Format(format, LocalizedNames.SensorName(Sensor.Name), Sensor.Value);
 
         if (Sensor.SensorType == SensorType.Temperature && _unitManager.TemperatureUnit == TemperatureUnit.Fahrenheit)
         {
             format = "\n{0}: {1:F1} °F";
-            formattedValue = string.Format(format, Sensor.Name, UnitManager.CelsiusToFahrenheit(Sensor.Value));
+            formattedValue = string.Format(format, LocalizedNames.SensorName(Sensor.Name), UnitManager.CelsiusToFahrenheit(Sensor.Value));
         }
 
         string hardwareName = Sensor.Hardware.Name;

--- a/LibreHardwareMonitor.Windows.Forms/UI/SystemTray.cs
+++ b/LibreHardwareMonitor.Windows.Forms/UI/SystemTray.cs
@@ -1,4 +1,4 @@
-﻿// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 // Copyright (C) LibreHardwareMonitor and Contributors.
 // Partial Copyright (C) Michael Möller <mmoeller@openhardwaremonitor.org> and Contributors.
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
 using LibreHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Windows.Forms.Localization;
 using LibreHardwareMonitor.Windows.Forms.Utilities;
 
 namespace LibreHardwareMonitor.Windows.Forms.UI;
@@ -20,6 +21,8 @@ public class SystemTray : IDisposable
     private readonly List<SensorNotifyIcon> _sensorList = new List<SensorNotifyIcon>();
     private bool _mainIconEnabled;
     private readonly NotifyIconAdv _mainIcon;
+    private readonly ToolStripItem _hideShowItem;
+    private readonly ToolStripItem _exitItem;
 
     public SystemTray(IComputer computer, PersistentSettings settings, UnitManager unitManager)
     {
@@ -32,19 +35,28 @@ public class SystemTray : IDisposable
         _mainIcon = new NotifyIconAdv();
 
         ContextMenuStrip contextMenuStrip = new ContextMenuStrip();
-        ToolStripItem hideShowItem = new ToolStripMenuItem("Hide/Show");
-        hideShowItem.Click += delegate
+        _hideShowItem = new ToolStripMenuItem();
+        _hideShowItem.Click += delegate
         {
             SendHideShowCommand();
         };
-        contextMenuStrip.Items.Add(hideShowItem);
+        contextMenuStrip.Items.Add(_hideShowItem);
         contextMenuStrip.Items.Add(new ToolStripSeparator());
-        ToolStripItem exitItem = new ToolStripMenuItem("Exit");
-        exitItem.Click += delegate
+        _exitItem = new ToolStripMenuItem();
+        _exitItem.Click += delegate
         {
             SendExitCommand();
         };
-        contextMenuStrip.Items.Add(exitItem);
+        contextMenuStrip.Items.Add(_exitItem);
+
+        // The menu is created before the language is known to be final (and the language can
+        // change at run time), so its text is resolved whenever the menu is opened.
+        contextMenuStrip.Opening += delegate
+        {
+            _hideShowItem.Text = LocalizationManager.Get("Tray.HideShow") ?? "Hide/Show";
+            _exitItem.Text = LocalizationManager.Get("Tray.Exit") ?? "Exit";
+        };
+
         _mainIcon.ContextMenuStrip = contextMenuStrip;
         _mainIcon.DoubleClick += delegate
         {

--- a/LibreHardwareMonitor.Windows.Forms/UI/Theme.cs
+++ b/LibreHardwareMonitor.Windows.Forms/UI/Theme.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using Aga.Controls.Tree;
+using LibreHardwareMonitor.Windows.Forms.Localization;
 using Microsoft.Win32;
 
 namespace LibreHardwareMonitor.Windows.Forms.UI.Themes
@@ -89,7 +90,7 @@ namespace LibreHardwareMonitor.Windows.Forms.UI.Themes
 
             TreeViewAdv.CustomColumnTextRenderFunc = (g, rect, font, text) =>
             {
-                TextRenderer.DrawText(g, text, font, rect, Current.TreeTextColor, TextFormatFlags.Left);
+                TextRenderer.DrawText(g, LocalizedNames.ColumnHeader(text), font, rect, Current.TreeTextColor, TextFormatFlags.Left);
             };
 
             TreeViewAdv.CustomHorizontalLinePen = new Pen(Current.TreeRowSepearatorColor);

--- a/LibreHardwareMonitor.Windows.Forms/UI/TypeNode.cs
+++ b/LibreHardwareMonitor.Windows.Forms/UI/TypeNode.cs
@@ -26,93 +26,114 @@ public sealed class TypeNode : Node, IExpandPersistNode
         {
             case SensorType.Voltage:
                 Image = Utilities.EmbeddedResources.GetImage("voltage.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Voltages");
                 break;
             case SensorType.Current:
                 Image = Utilities.EmbeddedResources.GetImage("voltage.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Currents");
                 break;
             case SensorType.Energy:
                 Image = Utilities.EmbeddedResources.GetImage("battery.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Capacities");
                 break;
             case SensorType.Clock:
                 Image = Utilities.EmbeddedResources.GetImage("clock.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Clocks");
                 break;
             case SensorType.Load:
                 Image = Utilities.EmbeddedResources.GetImage("load.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Load");
                 break;
             case SensorType.Temperature:
                 Image = Utilities.EmbeddedResources.GetImage("temperature.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Temperatures");
                 break;
             case SensorType.Fan:
                 Image = Utilities.EmbeddedResources.GetImage("fan.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Fans");
                 break;
             case SensorType.Flow:
                 Image = Utilities.EmbeddedResources.GetImage("flow.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Flows");
                 break;
             case SensorType.Control:
                 Image = Utilities.EmbeddedResources.GetImage("control.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Controls");
                 break;
             case SensorType.Level:
                 Image = Utilities.EmbeddedResources.GetImage("level.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Levels");
                 break;
             case SensorType.Power:
                 Image = Utilities.EmbeddedResources.GetImage("power.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Powers");
                 break;
             case SensorType.Data:
                 Image = Utilities.EmbeddedResources.GetImage("data.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Data");
                 break;
             case SensorType.SmallData:
                 Image = Utilities.EmbeddedResources.GetImage("data.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Data");
                 break;
             case SensorType.Factor:
                 Image = Utilities.EmbeddedResources.GetImage("factor.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Factors");
                 break;
             case SensorType.Frequency:
                 Image = Utilities.EmbeddedResources.GetImage("clock.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Frequencies");
                 break;
             case SensorType.Throughput:
                 Image = Utilities.EmbeddedResources.GetImage("throughput.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Throughput");
                 break;
             case SensorType.TimeSpan:
                 Image = Utilities.EmbeddedResources.GetImage("time.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Times");
                 break;
             case SensorType.Timing:
                 Image = Utilities.EmbeddedResources.GetImage("time.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Timings");
                 break;
             case SensorType.Noise:
                 Image = Utilities.EmbeddedResources.GetImage("loudspeaker.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Noise Levels");
                 break;
             case SensorType.Conductivity:
                 Image = Utilities.EmbeddedResources.GetImage("voltage.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Conductivities");
                 break;
             case SensorType.Humidity:
                 Image = Utilities.EmbeddedResources.GetImage("humidity.png");
-                Text = LocalizationManager.GetGroupText(sensorType, "Humidity Levels");
                 break;
         }
 
         NodeAdded += TypeNode_NodeAdded;
         NodeRemoved += TypeNode_NodeRemoved;
         _expanded = settings.GetValue(_expandedIdentifier, true);
+    }
+
+    /// <summary>
+    /// The group heading is derived from the current UI culture on every read, so a simple
+    /// repaint is enough to hot-switch the language. English is used as the fallback.
+    /// </summary>
+    public override string Text
+    {
+        get { return LocalizationManager.GetGroupText(SensorType, EnglishTitle); }
+        set { /* group headings always follow the current language */ }
+    }
+
+    private string EnglishTitle
+    {
+        get
+        {
+            switch (SensorType)
+            {
+                case SensorType.Voltage: return "Voltages";
+                case SensorType.Current: return "Currents";
+                case SensorType.Energy: return "Capacities";
+                case SensorType.Clock: return "Clocks";
+                case SensorType.Load: return "Load";
+                case SensorType.Temperature: return "Temperatures";
+                case SensorType.Fan: return "Fans";
+                case SensorType.Flow: return "Flows";
+                case SensorType.Control: return "Controls";
+                case SensorType.Level: return "Levels";
+                case SensorType.Power: return "Powers";
+                case SensorType.Data: return "Data";
+                case SensorType.SmallData: return "Data";
+                case SensorType.Factor: return "Factors";
+                case SensorType.Frequency: return "Frequencies";
+                case SensorType.Throughput: return "Throughput";
+                case SensorType.TimeSpan: return "Times";
+                case SensorType.Timing: return "Timings";
+                case SensorType.Noise: return "Noise Levels";
+                case SensorType.Conductivity: return "Conductivities";
+                case SensorType.Humidity: return "Humidity Levels";
+                default: return string.Empty;
+            }
+        }
     }
 
     private void TypeNode_NodeRemoved(Node node)

--- a/LibreHardwareMonitor.Windows.Forms/UI/TypeNode.cs
+++ b/LibreHardwareMonitor.Windows.Forms/UI/TypeNode.cs
@@ -1,10 +1,11 @@
-﻿// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 // If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 // Copyright (C) LibreHardwareMonitor and Contributors.
 // Partial Copyright (C) Michael Möller <mmoeller@openhardwaremonitor.org> and Contributors.
 // All Rights Reserved.
 
 using LibreHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Windows.Forms.Localization;
 using LibreHardwareMonitor.Windows.Forms.Utilities;
 
 namespace LibreHardwareMonitor.Windows.Forms.UI;
@@ -25,87 +26,87 @@ public sealed class TypeNode : Node, IExpandPersistNode
         {
             case SensorType.Voltage:
                 Image = Utilities.EmbeddedResources.GetImage("voltage.png");
-                Text = "Voltages";
+                Text = LocalizationManager.GetGroupText(sensorType, "Voltages");
                 break;
             case SensorType.Current:
                 Image = Utilities.EmbeddedResources.GetImage("voltage.png");
-                Text = "Currents";
+                Text = LocalizationManager.GetGroupText(sensorType, "Currents");
                 break;
             case SensorType.Energy:
                 Image = Utilities.EmbeddedResources.GetImage("battery.png");
-                Text = "Capacities";
+                Text = LocalizationManager.GetGroupText(sensorType, "Capacities");
                 break;
             case SensorType.Clock:
                 Image = Utilities.EmbeddedResources.GetImage("clock.png");
-                Text = "Clocks";
+                Text = LocalizationManager.GetGroupText(sensorType, "Clocks");
                 break;
             case SensorType.Load:
                 Image = Utilities.EmbeddedResources.GetImage("load.png");
-                Text = "Load";
+                Text = LocalizationManager.GetGroupText(sensorType, "Load");
                 break;
             case SensorType.Temperature:
                 Image = Utilities.EmbeddedResources.GetImage("temperature.png");
-                Text = "Temperatures";
+                Text = LocalizationManager.GetGroupText(sensorType, "Temperatures");
                 break;
             case SensorType.Fan:
                 Image = Utilities.EmbeddedResources.GetImage("fan.png");
-                Text = "Fans";
+                Text = LocalizationManager.GetGroupText(sensorType, "Fans");
                 break;
             case SensorType.Flow:
                 Image = Utilities.EmbeddedResources.GetImage("flow.png");
-                Text = "Flows";
+                Text = LocalizationManager.GetGroupText(sensorType, "Flows");
                 break;
             case SensorType.Control:
                 Image = Utilities.EmbeddedResources.GetImage("control.png");
-                Text = "Controls";
+                Text = LocalizationManager.GetGroupText(sensorType, "Controls");
                 break;
             case SensorType.Level:
                 Image = Utilities.EmbeddedResources.GetImage("level.png");
-                Text = "Levels";
+                Text = LocalizationManager.GetGroupText(sensorType, "Levels");
                 break;
             case SensorType.Power:
                 Image = Utilities.EmbeddedResources.GetImage("power.png");
-                Text = "Powers";
+                Text = LocalizationManager.GetGroupText(sensorType, "Powers");
                 break;
             case SensorType.Data:
                 Image = Utilities.EmbeddedResources.GetImage("data.png");
-                Text = "Data";
+                Text = LocalizationManager.GetGroupText(sensorType, "Data");
                 break;
             case SensorType.SmallData:
                 Image = Utilities.EmbeddedResources.GetImage("data.png");
-                Text = "Data";
+                Text = LocalizationManager.GetGroupText(sensorType, "Data");
                 break;
             case SensorType.Factor:
                 Image = Utilities.EmbeddedResources.GetImage("factor.png");
-                Text = "Factors";
+                Text = LocalizationManager.GetGroupText(sensorType, "Factors");
                 break;
             case SensorType.Frequency:
                 Image = Utilities.EmbeddedResources.GetImage("clock.png");
-                Text = "Frequencies";
+                Text = LocalizationManager.GetGroupText(sensorType, "Frequencies");
                 break;
             case SensorType.Throughput:
                 Image = Utilities.EmbeddedResources.GetImage("throughput.png");
-                Text = "Throughput";
+                Text = LocalizationManager.GetGroupText(sensorType, "Throughput");
                 break;
             case SensorType.TimeSpan:
                 Image = Utilities.EmbeddedResources.GetImage("time.png");
-                Text = "Times";
+                Text = LocalizationManager.GetGroupText(sensorType, "Times");
                 break;
             case SensorType.Timing:
                 Image = Utilities.EmbeddedResources.GetImage("time.png");
-                Text = "Timings";
+                Text = LocalizationManager.GetGroupText(sensorType, "Timings");
                 break;
             case SensorType.Noise:
                 Image = Utilities.EmbeddedResources.GetImage("loudspeaker.png");
-                Text = "Noise Levels";
+                Text = LocalizationManager.GetGroupText(sensorType, "Noise Levels");
                 break;
             case SensorType.Conductivity:
                 Image = Utilities.EmbeddedResources.GetImage("voltage.png");
-                Text = "Conductivities";
+                Text = LocalizationManager.GetGroupText(sensorType, "Conductivities");
                 break;
             case SensorType.Humidity:
                 Image = Utilities.EmbeddedResources.GetImage("humidity.png");
-                Text = "Humidity Levels";
+                Text = LocalizationManager.GetGroupText(sensorType, "Humidity Levels");
                 break;
         }
 

--- a/LibreHardwareMonitor.Windows.Forms/Utilities/HttpServer.cs
+++ b/LibreHardwareMonitor.Windows.Forms/Utilities/HttpServer.cs
@@ -637,7 +637,7 @@ public class HttpServer
 
                 foreach (SensorNode sensor in node.Nodes[i].Nodes)
                 {
-                    string valueSensorName = sensor.Text.Replace("#", String.Empty);
+                    string valueSensorName = sensor.Sensor.Name.Replace("#", String.Empty);
 
                     // Variables needed in dictionary lookup and error message
                     string tagSensorType = sensor.Sensor.SensorType.ToString();
@@ -803,6 +803,7 @@ public class HttpServer
         switch (n)
         {
             case SensorNode sensorNode:
+                jsonNode["Text"] = sensorNode.Sensor.Name;
                 jsonNode["SensorId"] = sensorNode.Sensor.Identifier.ToString();
                 jsonNode["Type"] = sensorNode.Sensor.SensorType.ToString();
 
@@ -819,6 +820,7 @@ public class HttpServer
                 jsonNode["ImageURL"] = "images/transparent.png";
                 break;
             case HardwareNode hardwareNode:
+                jsonNode["Text"] = hardwareNode.Hardware.Name;
                 jsonNode["HardwareId"] = hardwareNode.Hardware.Identifier.ToString();
                 jsonNode["ImageURL"] = "images_icon/" + GetHardwareImageFile(hardwareNode);
                 break;


### PR DESCRIPTION
Adds a lightweight, resource-driven localization framework to the WinForms UI, together with a Simplified Chinese (zh-CN) resource set.

- Default language stays English; no hardcoded strings.
- Canonical hardware/sensor names used by the web server, CSV logging and reports are left untouched - localized names apply only at the draw layer.
- New "Language" menu switches UI language at runtime; choice is persisted.
- Group headers, plot labels, tray menus, about box and sensor names are covered.

Related discussion: #2511 