### PR TITLE
Fix sensor definitions for Gigabyte X870 AORUS Elite WIFI7

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2396,7 +2396,7 @@ internal sealed class SuperIOHardware : Hardware
                         v.Add(new Voltage("+12V", 2, 5, 1));
                         v.Add(new Voltage("+5V", 3, 1.5F, 1));
                         v.Add(new Voltage("CPU NB/SoC", 4, 0, 1));
-                        v.Add(new Voltage("CPU MISC", 5, 0, 1));
+                        v.Add(new Voltage("CPU Misc", 5, 0, 1));
                         v.Add(new Voltage("CPU VDDIO", 6));
                         v.Add(new Voltage("DRAM VDD", 7));
                         v.Add(new Voltage("DRAM VDDQ", 8));

--- a/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/SuperIOHardware.cs
@@ -2391,6 +2391,16 @@ internal sealed class SuperIOHardware : Hardware
 
                     case Model.X870_AORUS_ELITE_WIFI7: // ITE IT8696E
                     case Model.X870_AORUS_ELITE_WIFI7_ICE: // ITE IT8696E
+                        v.Add(new Voltage("Vcore", 0));
+                        v.Add(new Voltage("+3.3V", 1, 6.49F, 10));
+                        v.Add(new Voltage("+12V", 2, 5, 1));
+                        v.Add(new Voltage("+5V", 3, 1.5F, 1));
+                        v.Add(new Voltage("CPU NB/SoC", 4, 0, 1));
+                        v.Add(new Voltage("CPU MISC", 5, 0, 1));
+                        v.Add(new Voltage("CPU VDDIO", 6));
+                        v.Add(new Voltage("DRAM VDD", 7));
+                        v.Add(new Voltage("DRAM VDDQ", 8));
+
                         t.Add(new Temperature("System #1", 0));
                         t.Add(new Temperature("PCH", 1));
                         t.Add(new Temperature("CPU", 2));
@@ -3028,12 +3038,12 @@ internal sealed class SuperIOHardware : Hardware
 
                     case Model.X870_AORUS_ELITE_WIFI7: // ITE IT87952E
                     case Model.X870_AORUS_ELITE_WIFI7_ICE: // ITE IT87952E
-                        v.Add(new Voltage("Vcore", 0));
-                        v.Add(new Voltage("DIMM I/O", 1));
-                        v.Add(new Voltage("Chipset +0.82V", 2));
+                        v.Add(new Voltage("Voltage #1", 0, true));
+                        v.Add(new Voltage("Voltage #2", 1, true));
+                        v.Add(new Voltage("Voltage #3", 2, true));
                         v.Add(new Voltage("Voltage #4", 3, true));
-                        v.Add(new Voltage("CPU System Agent", 4));
-                        v.Add(new Voltage("Chipset +1.8V", 5));
+                        v.Add(new Voltage("Voltage #5", 4, true));
+                        v.Add(new Voltage("Voltage #6", 5, true));
                         v.Add(new Voltage("Voltage #7", 6, true));
                         v.Add(new Voltage("+3V Standby", 7, 10, 10));
                         v.Add(new Voltage("CMOS Battery", 8, 10, 10));


### PR DESCRIPTION
Current implementation does not list any voltages for the ITE IT8696E and user reported the voltages from ITE IT87952E are all incorrect.

The support for these motherboards was added with this commit: https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/commit/fd3bfeb7c5f0e9a62e940970eba4c8fd7d0bd1eb which references [pull1510](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/pull/1510)

It seems the sensors were added under the wrong I/O chip. I'm not entirely sure about the sensors definitions, so I've disabled the wrong voltages that are currently listed under ITE IT87952E.

After the change, user shared this screen:

<img width="630" height="661" alt="image" src="https://github.com/user-attachments/assets/ac369927-986c-4e48-9d4f-00efd75e164b" />


Channels 5 and 6 were later labelled CPU NB/SoC and CPU MISC based on HwInfo:

<img width="2152" height="367" alt="image" src="https://github.com/user-attachments/assets/287b88f4-df6a-4a86-941c-fbd7794d6eaf" />

